### PR TITLE
Fix checkbox being too big when there is no label

### DIFF
--- a/.changeset/moody-parents-grin.md
+++ b/.changeset/moody-parents-grin.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/checkbox': patch
+---
+
+Fix checkbox being too big when there is no label

--- a/packages/components/checkbox/src/checkbox.scss
+++ b/packages/components/checkbox/src/checkbox.scss
@@ -8,7 +8,6 @@ $sizes: md, lg;
   --_border-radius: var(--sl-border-radius-checkbox);
   --_border-size: var(--sl-border-width-input-border);
   --_border: var(--_border-size) solid var(--_border-color);
-  --_line-height: var(--sl-text-typeset-line-height-md);
   --_path-length: 23;
   --_stroke-dashoffset: var(--_path-length);
   --_stroke-linecap: round;
@@ -23,7 +22,16 @@ $sizes: md, lg;
   gap: var(--_gap);
   line-height: var(--_line-height);
   outline: none;
-  padding: var(--_padding);
+}
+
+:host([no-label]) {
+  .outer {
+    padding-inline-start: var(--_padding-inline);
+  }
+
+  .label {
+    display: none;
+  }
 }
 
 :host(:where(:disabled, [internals-disabled])) {
@@ -41,21 +49,27 @@ $sizes: md, lg;
   outline: none;
 }
 
-.box {
+.outer {
+  display: inline-flex;
+  padding-block: var(--_padding-block);
+  padding-inline-end: var(--_padding-inline);
+}
+
+.inner {
   background: var(--_background);
   border: var(--_border);
   border-radius: var(--_border-radius);
   box-shadow: var(--_box-shadow);
   display: inline-flex;
   flex-shrink: 0;
-
   padding: calc((var(--_size) - var(--_icon-size)) / 2 - var(--_border-size));
   transition: var(--_transition);
   transition-property: background, border-color, box-shadow, color, filter;
 }
 
 .label {
-  margin-block-start: calc((var(--_size) - var(--_line-height)) / 2);
+  line-height: var(--_line-height);
+  margin-block-start: calc((var(--_size) + var(--_padding-block) * 2 - var(--_line-height)) / 2);
 }
 
 sl-icon,
@@ -90,11 +104,9 @@ path {
 @each $size in $sizes {
   :host([size='#{$size}']) {
     --_line-height: var(--sl-text-typeset-line-height-#{$size});
-    --_padding: var(--sl-space-input-block-#{$size})
-      var(--sl-space-input-inline-#{$size})
-      var(--sl-space-input-block-#{$size})
-      0;
-    --_gap: var(--sl-space-input-gap-#{$size});
+    --_padding-block: var(--sl-space-input-block-#{$size});
+    --_padding-inline: var(--sl-space-input-inline-#{$size});
+    --_gap: calc(var(--sl-space-input-gap-#{$size}) - var(--_padding-inline));
     --_size: var(--sl-size-input-#{$size});
   }
 }

--- a/packages/components/checkbox/src/checkbox.stories.ts
+++ b/packages/components/checkbox/src/checkbox.stories.ts
@@ -221,7 +221,25 @@ export const Indeterminate: StoryObj = {
 };
 
 export const NoText: StoryObj = {
-  render: () => html`<sl-checkbox aria-label="Hello world"></sl-checkbox>`
+  render: () => html`
+    <style>
+      div {
+        align-items: start;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+      sl-checkbox {
+        background: hotpink;
+      }
+    </style>
+    <div>
+      <sl-checkbox aria-label="Hello world"> </sl-checkbox>
+      <sl-checkbox>Hello world</sl-checkbox>
+      <sl-checkbox aria-label="Hello world" size="lg"></sl-checkbox>
+      <sl-checkbox size="lg">Hello world</sl-checkbox>
+    </div>
+  `
 };
 
 export const Overflow: StoryObj = {

--- a/packages/components/checkbox/src/checkbox.ts
+++ b/packages/components/checkbox/src/checkbox.ts
@@ -48,7 +48,7 @@ export class Checkbox extends FormControlMixin(HintMixin(LitElement)) {
   /** Whether the checkbox has the indeterminate state. */
   @property({ type: Boolean }) indeterminate = false;
 
-  /** Button size. */
+  /** Checkbox size. */
   @property({ reflect: true }) size: CheckboxSize = 'md';
 
   /** The value for the checkbox. */
@@ -62,6 +62,8 @@ export class Checkbox extends FormControlMixin(HintMixin(LitElement)) {
     this.setFormControlElement(this);
 
     this.#validation.validate(this.checked ? this.value : undefined);
+
+    this.#updateNoLabel();
 
     if (!this.hasAttribute('tabindex')) {
       this.tabIndex = 0;
@@ -105,14 +107,18 @@ export class Checkbox extends FormControlMixin(HintMixin(LitElement)) {
   override render(): TemplateResult {
     return html`
       <div @click=${this.#onToggle} class="wrapper">
-        <span class="box">
-          <svg version="1.1" aria-hidden="true" focusable="false" part="svg" viewBox="0 0 24 24">
-            ${this.indeterminate
-              ? svg`<path d="M4.1,12 9,12 20.3,12"></path>`
-              : svg`<path d="M4.1,12.7 9,17.6 20.3,6.3"></path>`}
-          </svg>
+        <div class="outer">
+          <div class="inner">
+            <svg version="1.1" aria-hidden="true" focusable="false" part="svg" viewBox="0 0 24 24">
+              ${this.indeterminate
+                ? svg`<path d="M4.1,12 9,12 20.3,12"></path>`
+                : svg`<path d="M4.1,12.7 9,17.6 20.3,6.3"></path>`}
+            </svg>
+          </div>
+        </div>
+        <span class="label">
+          <slot @slotchange=${() => this.#updateNoLabel()}></slot>
         </span>
-        <span class="label"><slot></slot></span>
       </div>
       ${this.renderHint()} ${this.#validation.render()}
     `;
@@ -148,5 +154,20 @@ export class Checkbox extends FormControlMixin(HintMixin(LitElement)) {
     this.checked = !this.checked;
     this.#validation.validate(this.checked ? this.value : undefined);
     this.change.emit(this.checked);
+  }
+
+  /**
+   * Updates the `no-label` attribute based on the presence of a label.
+   */
+  #updateNoLabel(): void {
+    const empty = Array.from(this.childNodes)
+      .filter(
+        node =>
+          (node.nodeType === Node.ELEMENT_NODE && !(node as Element).hasAttribute('slot')) ||
+          node.nodeType === Node.TEXT_NODE
+      )
+      .every(node => node.nodeType !== Node.ELEMENT_NODE && node.textContent?.trim() === '');
+
+    this.toggleAttribute('no-label', empty);
   }
 }


### PR DESCRIPTION
- Check if there is a label present and add a `no-label` attribute if there isn't
- Hide `.label` when `no-label` attribute it present
- Add left padding when there is no label present
- Split padding into `block` and `inline`
- Adjust gap to take inline padding into account
- Move padding from the outer element to the actual click target
- Fix vertical alignment of label bug

Fixes #390 