### PR TITLE
Change Magister non-button components to have as 1px border instead of 2px

### DIFF
--- a/.changeset/ten-jars-relax.md
+++ b/.changeset/ten-jars-relax.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/magister': patch
+---
+
+Change non-button components to have as 1px border instead of 2px

--- a/packages/components/grid/src/grid.scss
+++ b/packages/components/grid/src/grid.scss
@@ -66,7 +66,7 @@ tr {
 th,
 td {
   align-items: center;
-  box-sizing: content-box;
+  box-sizing: border-box;
   display: inline-flex;
   flex-shrink: 0;
   overflow: hidden;

--- a/packages/themes/magister/all.css
+++ b/packages/themes/magister/all.css
@@ -293,7 +293,7 @@
   --sl-space-button-default-inline-lg: calc(var(--sl-space-xl) - var(--sl-border-width-button-default));
   --sl-space-button-default-inline-sm: calc(var(--sl-space-lg) - var(--sl-border-width-button-default));
   --sl-space-button-default-inline-md: calc(var(--sl-space-lg) - var(--sl-border-width-button-default));
-  --sl-border-width-input-border: var(--sl-border-width-sm);
+  --sl-border-width-input-border: var(--sl-border-width-xs);
   --sl-border-width-input-none: var(--sl-border-width-none);
   --sl-border-width-button-link: var(--sl-border-width-sm);
   --sl-border-width-button-outline: var(--sl-border-width-sm);

--- a/packages/themes/magister/base.css
+++ b/packages/themes/magister/base.css
@@ -285,7 +285,7 @@
   --sl-space-button-default-inline-lg: calc(var(--sl-space-xl) - var(--sl-border-width-button-default));
   --sl-space-button-default-inline-sm: calc(var(--sl-space-lg) - var(--sl-border-width-button-default));
   --sl-space-button-default-inline-md: calc(var(--sl-space-lg) - var(--sl-border-width-button-default));
-  --sl-border-width-input-border: var(--sl-border-width-sm);
+  --sl-border-width-input-border: var(--sl-border-width-xs);
   --sl-border-width-input-none: var(--sl-border-width-none);
   --sl-border-width-button-link: var(--sl-border-width-sm);
   --sl-border-width-button-outline: var(--sl-border-width-sm);

--- a/packages/themes/magister/base.json
+++ b/packages/themes/magister/base.json
@@ -1155,7 +1155,7 @@
           "description": "border.width.button.default"
         },
         "border": {
-          "value": "{border.width.sm}",
+          "value": "{border.width.xs}",
           "type": "borderWidth",
           "description": "border.width.button.outline"
         }

--- a/packages/themes/magister/base.scss
+++ b/packages/themes/magister/base.scss
@@ -286,7 +286,7 @@
   --sl-space-button-default-inline-lg: calc(var(--sl-space-xl) - var(--sl-border-width-button-default));
   --sl-space-button-default-inline-sm: calc(var(--sl-space-lg) - var(--sl-border-width-button-default));
   --sl-space-button-default-inline-md: calc(var(--sl-space-lg) - var(--sl-border-width-button-default));
-  --sl-border-width-input-border: var(--sl-border-width-sm);
+  --sl-border-width-input-border: var(--sl-border-width-xs);
   --sl-border-width-input-none: var(--sl-border-width-none);
   --sl-border-width-button-link: var(--sl-border-width-sm);
   --sl-border-width-button-outline: var(--sl-border-width-sm);

--- a/packages/tokens/src/magister/base.json
+++ b/packages/tokens/src/magister/base.json
@@ -906,7 +906,7 @@
           "description": "border.width.button.default"
         },
         "border": {
-          "value": "{border.width.sm}",
+          "value": "{border.width.xs}",
           "type": "borderWidth",
           "description": "border.width.button.outline"
         }


### PR DESCRIPTION
Also fixes a minor regression in the grid selection column styling.