### PR TITLE
Fix various grid issues

### DIFF
--- a/.changeset/perfect-feet-raise.md
+++ b/.changeset/perfect-feet-raise.md
@@ -1,0 +1,11 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Fix various grid issues:
+
+- Fix unexported filter types
+- Add `GridColumnAlignment` type
+- Add `itemsChanged()` callback for when the items in the grid have changed
+- Fix name of sorter direction change event to match other events
+- Fix initial checked state in selection column header

--- a/packages/components/grid/register.ts
+++ b/packages/components/grid/register.ts
@@ -19,6 +19,7 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     'sl-active-item-change': GridActiveItemChangeEvent<any>;
     'sl-filter-change': GridFilterValueChangeEvent;
+    'sl-grid-items-change': Event;
   }
 
   interface HTMLElementTagNameMap {

--- a/packages/components/grid/src/column.ts
+++ b/packages/components/grid/src/column.ts
@@ -1,9 +1,12 @@
-import type { CSSResult, TemplateResult } from 'lit';
+import type { CSSResult, PropertyValues, TemplateResult } from 'lit';
 import type { Grid } from './grid.js';
 import type { EventEmitter } from '@sl-design-system/shared';
-import { dasherize, event, getNameByPath, getValueByPath } from '@sl-design-system/shared';
+import { EventsController, dasherize, event, getNameByPath, getValueByPath } from '@sl-design-system/shared';
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
+
+/** Custom for aligning the content in the cells. */
+export type GridColumnAlignment = 'start' | 'center' | 'end';
 
 /** Custom renderer type for column headers. */
 export type GridColumnHeaderRenderer = () => string | undefined | TemplateResult;
@@ -15,10 +18,13 @@ export type GridColumnDataRenderer<T> = (model: T) => string | undefined | Templ
 export type GridColumnParts<T> = (model: T) => string | undefined;
 
 export class GridColumn<T extends Record<string, unknown> = Record<string, unknown>> extends LitElement {
+  #events = new EventsController(this);
+
+  /** Actual width of the column. */
   #width?: number;
 
   /** The alignment of the content within the column. */
-  @property() align: 'start' | 'center' | 'end' = 'start';
+  @property() align: GridColumnAlignment = 'start';
 
   /**
    * Automatically sets the width of the column based on the column contents when this is set to `true`.
@@ -90,6 +96,15 @@ export class GridColumn<T extends Record<string, unknown> = Record<string, unkno
       this.autoWidth = true;
     }
   }
+
+  override willUpdate(changes: PropertyValues<this>): void {
+    if (changes.has('grid') && this.grid) {
+      this.#events.listen(this.grid, 'sl-grid-items-change', this.itemsChanged);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  itemsChanged(): void {}
 
   renderHeader(): TemplateResult {
     const parts = ['header', ...this.#getParts()];

--- a/packages/components/grid/src/filter-column.ts
+++ b/packages/components/grid/src/filter-column.ts
@@ -44,7 +44,15 @@ export class GridFilterColumn extends GridColumn {
   override willUpdate(changes: PropertyValues<this>): void {
     super.willUpdate(changes);
 
-    if (changes.has('grid') && this.mode !== 'text' && typeof this.options === 'undefined') {
+    if (changes.has('grid')) {
+      this.itemsChanged();
+    }
+  }
+
+  override itemsChanged(): void {
+    super.itemsChanged();
+
+    if (this.mode !== 'text' && typeof this.options === 'undefined') {
       // No options were provided, so we'll create a list of options based on the column's values
       this.internalOptions = this.grid?.items
         ?.reduce((acc, item) => {

--- a/packages/components/grid/src/filter-column.ts
+++ b/packages/components/grid/src/filter-column.ts
@@ -1,10 +1,16 @@
 import type { PropertyValues, TemplateResult } from 'lit';
-import type { GridFilterMode, GridFilterOption } from './filter.js';
 import { getNameByPath, getValueByPath } from '@sl-design-system/shared';
 import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { GridColumn } from './column.js';
 import { GridFilter } from './filter.js';
+
+export type GridFilterMode = 'select' | 'text';
+
+export interface GridFilterOption {
+  label: string;
+  value?: unknown;
+}
 
 export class GridFilterColumn extends GridColumn {
   /** The internal options if none are provided. */

--- a/packages/components/grid/src/filter.ts
+++ b/packages/components/grid/src/filter.ts
@@ -1,5 +1,6 @@
 import type { CSSResultGroup, TemplateResult } from 'lit';
 import type { GridColumn } from './column.js';
+import type { GridFilterMode, GridFilterOption } from './filter-column.js';
 import type { ScopedElementsMap } from '@open-wc/scoped-elements';
 import type { EventEmitter } from '@sl-design-system/shared';
 import { faFilter, faFilterList, faXmark } from '@fortawesome/pro-regular-svg-icons';
@@ -16,13 +17,6 @@ import { property } from 'lit/decorators.js';
 import styles from './filter.scss.js';
 
 export type GridFilterChange = 'added' | 'removed';
-
-export type GridFilterMode = 'select' | 'text';
-
-export interface GridFilterOption {
-  label: string;
-  value?: unknown;
-}
 
 Icon.registerIcon(faFilter, faFilterList, faXmark);
 

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -276,7 +276,7 @@ export class Grid<T extends Record<string, unknown> = Record<string, unknown>> e
       });
 
     // Since we set an explicit width for the `<thead>` and `<tbody>`, we also need
-    // to set an explicit with for all the `<tr>` elements. Otherwise, the sticky columns
+    // to set an explicit width for all the `<tr>` elements. Otherwise, the sticky columns
     // will not be sticky when you scroll horizontally.
     const rowWidth = this.columns.reduce((acc, cur) => acc + Number(cur?.width ?? 0), 0);
     this.style.setProperty('--sl-grid-row-width', `${rowWidth}px`);

--- a/packages/components/grid/src/selection-column.ts
+++ b/packages/components/grid/src/selection-column.ts
@@ -23,8 +23,8 @@ export class GridSelectionColumn<T extends Record<string, unknown> = Record<stri
     this.scopedElements = { 'sl-checkbox': Checkbox };
   }
 
-  override updated(changes: PropertyValues<this>): void {
-    super.updated(changes);
+  override willUpdate(changes: PropertyValues<this>): void {
+    super.willUpdate(changes);
 
     if (changes.has('grid') && this.grid) {
       this.#events.listen(this.grid, 'sl-active-item-change', this.#onActiveItemChange);

--- a/packages/components/grid/src/selection-column.ts
+++ b/packages/components/grid/src/selection-column.ts
@@ -38,7 +38,7 @@ export class GridSelectionColumn<T extends Record<string, unknown> = Record<stri
   }
 
   override renderHeader(): TemplateResult {
-    const checked = this.grid?.selection.areAllSelected(),
+    const checked = !!this.grid?.selection.size && this.grid?.selection.areAllSelected(),
       indeterminate = this.grid?.selection.areSomeSelected();
 
     return html`

--- a/packages/components/grid/src/sorter.ts
+++ b/packages/components/grid/src/sorter.ts
@@ -31,9 +31,9 @@ export class GridSorter extends ScopedElementsMixin(LitElement) {
   /** The direction in which to sort the items. */
   @property({ reflect: true }) direction?: DataSourceSortDirection;
 
-  @event() directionChange!: EventEmitter<DataSourceSortDirection | undefined>;
-
   @event() sorterChange!: EventEmitter<GridSorterChange>;
+
+  @event() sorterDirectionChange!: EventEmitter<DataSourceSortDirection | undefined>;
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -88,7 +88,7 @@ export class GridSorter extends ScopedElementsMixin(LitElement) {
 
   #onClick(): void {
     this.#toggleDirection();
-    this.directionChange.emit(this.direction);
+    this.sorterDirectionChange.emit(this.direction);
   }
 
   #onKeydown(event: KeyboardEvent): void {
@@ -96,7 +96,7 @@ export class GridSorter extends ScopedElementsMixin(LitElement) {
       event.preventDefault();
 
       this.#toggleDirection();
-      this.directionChange.emit(this.direction);
+      this.sorterDirectionChange.emit(this.direction);
     }
   }
 


### PR DESCRIPTION
- Fix unexported filter types
- Add `GridColumnAlignment` type
- Add `itemsChanged()` callback for when the items in the grid have changed
- Fix name of sorter direction change event to match other events
- Fix initial checked state in selection column header