### PR TITLE
Fix tbody min-height not taking the border width into account

### DIFF
--- a/.changeset/great-socks-sing.md
+++ b/.changeset/great-socks-sing.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Fix tbody min-height not taking the border width into account

--- a/packages/components/grid/src/grid.scss
+++ b/packages/components/grid/src/grid.scss
@@ -1,5 +1,7 @@
 :host {
-  --_border: 1px solid #eee;
+  --_border: var(--_border-width) solid var(--_border-color);
+  --_border-color: #eee;
+  --_border-width: 1px;
   --_border-radius: 3px;
   --_cell-background: #fff;
   --_cell-border: 1px solid #eee;
@@ -60,6 +62,7 @@ tbody {
   border-start-end-radius: 0;
   border-start-start-radius: 0;
   max-width: var(--sl-grid-width);
+  min-height: calc(var(--sl-grid-tbody-min-height) + var(--_border-width));
   overflow-x: auto;
 }
 

--- a/packages/components/grid/src/stories/basics.stories.ts
+++ b/packages/components/grid/src/stories/basics.stories.ts
@@ -22,6 +22,19 @@ export const Simple: Story = {
   `
 };
 
+export const Few: Story = {
+  loaders: [async () => ({ people: (await getPeople({ count: 10 })).people })],
+  render: (_, { loaded: { people } }) => html`
+    <sl-grid .items=${people}>
+      <sl-grid-column path="firstName"></sl-grid-column>
+      <sl-grid-column path="lastName"></sl-grid-column>
+      <sl-grid-column path="email"></sl-grid-column>
+      <sl-grid-column path="address.phone"></sl-grid-column>
+      <sl-grid-column path="profession"></sl-grid-column>
+    </sl-grid>
+  `
+};
+
 export const Small: Story = {
   loaders: [async () => ({ people: (await getPeople()).people })],
   render: (_, { loaded: { people } }) => html`

--- a/tools/example-data/index.d.ts
+++ b/tools/example-data/index.d.ts
@@ -11,4 +11,10 @@ export interface People {
   people: Person[];
 }
 
-export declare function getPeople(): Promise<People>;
+export interface Options {
+  count?: number;
+  managerId?: string;
+  startIndex?: number;
+}
+
+export declare function getPeople(options?: Options): Promise<People>;


### PR DESCRIPTION
This works around an issue with `@lit-labs/virtualizer` where it does not take the border-width into account when calculating the `min-height`. This is also related to us using `box-sizing: border-box`, but due to styling, we cannot remove that.