### PR TITLE
Various grid fixes

### DIFF
--- a/.changeset/sharp-grapes-shout.md
+++ b/.changeset/sharp-grapes-shout.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Add `position="bottom"` to filter popover so it does not appear below a sticky header above it in browsers that do not support popover yet

--- a/.changeset/smart-trainers-shout.md
+++ b/.changeset/smart-trainers-shout.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Use explicit grid events instead of `CustomEvent`. Allows us to add a `column` property for column related events.

--- a/packages/components/grid/register.ts
+++ b/packages/components/grid/register.ts
@@ -17,7 +17,8 @@ customElements.define('sl-grid-sort-column', GridSortColumn);
 
 declare global {
   interface GlobalEventHandlersEventMap {
-    'sl-active-item-change': GridActiveItemChangeEvent;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    'sl-active-item-change': GridActiveItemChangeEvent<any>;
     'sl-filter-value-change': GridFilterValueChangeEvent;
     'sl-grid-items-change': GridEvent;
     'sl-sort-direction-change': GridSortDirectionChangeEvent;

--- a/packages/components/grid/register.ts
+++ b/packages/components/grid/register.ts
@@ -1,5 +1,6 @@
-import type { GridFilterValueChangeEvent } from './src/filter.js';
-import type { GridActiveItemChangeEvent } from './src/grid.js';
+import type { GridFilterValueChangeEvent } from './src/filter-column.js';
+import type { GridActiveItemChangeEvent, GridEvent } from './src/grid.js';
+import type { GridSortDirectionChangeEvent } from './src/sort-column.js';
 import { Grid } from './src/grid.js';
 import { GridColumn } from './src/column.js';
 import { GridColumnGroup } from './src/column-group.js';
@@ -16,10 +17,10 @@ customElements.define('sl-grid-sort-column', GridSortColumn);
 
 declare global {
   interface GlobalEventHandlersEventMap {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    'sl-active-item-change': GridActiveItemChangeEvent<any>;
-    'sl-filter-change': GridFilterValueChangeEvent;
-    'sl-grid-items-change': Event;
+    'sl-active-item-change': GridActiveItemChangeEvent;
+    'sl-filter-value-change': GridFilterValueChangeEvent;
+    'sl-grid-items-change': GridEvent;
+    'sl-sort-direction-change': GridSortDirectionChangeEvent;
   }
 
   interface HTMLElementTagNameMap {

--- a/packages/components/grid/src/column-group.ts
+++ b/packages/components/grid/src/column-group.ts
@@ -2,7 +2,7 @@ import type { PropertyValues, TemplateResult } from 'lit';
 import { getNameByPath } from '@sl-design-system/shared';
 import { html } from 'lit';
 import { state } from 'lit/decorators.js';
-import { GridColumn } from './column.js';
+import { GridColumn, GridColumnEvent } from './column.js';
 
 export class GridColumnGroup<T extends Record<string, unknown> = Record<string, unknown>> extends GridColumn<T> {
   #width?: number;
@@ -45,6 +45,6 @@ export class GridColumnGroup<T extends Record<string, unknown> = Record<string, 
     }, {});
 
     // Notify the grid that the column definition has changed
-    this.columnUpdate.emit();
+    this.columnUpdate.emit(new GridColumnEvent('sl-column-update', this));
   }
 }

--- a/packages/components/grid/src/column.ts
+++ b/packages/components/grid/src/column.ts
@@ -17,6 +17,15 @@ export type GridColumnDataRenderer<T> = (model: T) => string | undefined | Templ
 /** Custom type for providing parts to a cell. */
 export type GridColumnParts<T> = (model: T) => string | undefined;
 
+export class GridColumnEvent<T extends Record<string, unknown> = Record<string, unknown>> extends Event {
+  column: GridColumn<T>;
+
+  constructor(type: string, column: GridColumn<T>) {
+    super(type, { bubbles: true, composed: true });
+    this.column = column;
+  }
+}
+
 export class GridColumn<T extends Record<string, unknown> = Record<string, unknown>> extends LitElement {
   #events = new EventsController(this);
 
@@ -44,7 +53,7 @@ export class GridColumn<T extends Record<string, unknown> = Record<string, unkno
   @property({ type: Boolean, attribute: 'auto-width' }) autoWidth?: boolean;
 
   /** Emits when the column definition has changed. */
-  @event() columnUpdate!: EventEmitter<void>;
+  @event() columnUpdate!: EventEmitter<GridColumnEvent<T>>;
 
   /** The parent grid instance. */
   @property({ attribute: false }) grid?: Grid<T>;
@@ -83,7 +92,7 @@ export class GridColumn<T extends Record<string, unknown> = Record<string, unkno
   }
 
   /** Width of the cells for this column in pixels. */
-  @property()
+  @property({ type: Number })
   get width(): number | undefined {
     return this.#width;
   }

--- a/packages/components/grid/src/filter-column.ts
+++ b/packages/components/grid/src/filter-column.ts
@@ -3,7 +3,7 @@ import { getNameByPath, getValueByPath } from '@sl-design-system/shared';
 import { localized, msg } from '@lit/localize';
 import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { GridColumn } from './column.js';
+import { GridColumn, GridColumnEvent } from './column.js';
 import { GridFilter } from './filter.js';
 
 export type GridFilterMode = 'select' | 'text';
@@ -11,6 +11,12 @@ export type GridFilterMode = 'select' | 'text';
 export interface GridFilterOption {
   label: string;
   value?: unknown;
+}
+
+export class GridFilterValueChangeEvent extends GridColumnEvent {
+  constructor(column: GridColumn, public readonly value: string | string[] | undefined) {
+    super('sl-filter-value-change', column);
+  }
 }
 
 @localized()

--- a/packages/components/grid/src/filter.ts
+++ b/packages/components/grid/src/filter.ts
@@ -1,6 +1,5 @@
 import type { CSSResultGroup, TemplateResult } from 'lit';
 import type { GridColumn } from './column.js';
-import type { GridFilterMode, GridFilterOption } from './filter-column.js';
 import type { ScopedElementsMap } from '@open-wc/scoped-elements';
 import type { EventEmitter } from '@sl-design-system/shared';
 import { faFilter, faXmark } from '@fortawesome/pro-regular-svg-icons';
@@ -15,17 +14,12 @@ import { Popover } from '@sl-design-system/popover';
 import { event, getNameByPath } from '@sl-design-system/shared';
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
+import { type GridFilterMode, type GridFilterOption, GridFilterValueChangeEvent } from './filter-column.js';
 import styles from './filter.scss.js';
 
 export type GridFilterChange = 'added' | 'removed';
 
 Icon.registerIcon(faFilter, faFilterSolid, faXmark);
-
-export class GridFilterValueChangeEvent extends Event {
-  constructor(public readonly column: GridColumn, public readonly value: string | string[] | undefined) {
-    super('sl-filter-value-change', { bubbles: true, composed: true });
-  }
-}
 
 @localized()
 export class GridFilter extends ScopedElementsMixin(LitElement) {

--- a/packages/components/grid/src/filter.ts
+++ b/packages/components/grid/src/filter.ts
@@ -92,7 +92,7 @@ export class GridFilter extends ScopedElementsMixin(LitElement) {
         <slot></slot>
         <sl-icon .name=${this.active ? 'fas-filter' : 'far-filter'}></sl-icon>
       </sl-button>
-      <sl-popover anchor="anchor">
+      <sl-popover anchor="anchor" position="bottom">
         <header>
           <h1 id="title">
             ${msg(`Filter by`)} <span>${this.column.header?.toString() || getNameByPath(this.column.path)}</span>

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -73,7 +73,7 @@ export class Grid<T extends Record<string, unknown> = Record<string, unknown>> e
   @property({ attribute: false }) dataSource?: DataSource<T>;
 
   /** Emits when the items in the grid have changed. */
-  @event() gridItemsChange!: EventEmitter<void>;
+  @event() gridItemsChange!: EventEmitter<GridEvent<T>>;
 
   /** An array of items to be displayed in the grid. */
   @property({ type: Array }) items?: T[];
@@ -145,7 +145,7 @@ export class Grid<T extends Record<string, unknown> = Record<string, unknown>> e
       }
 
       // Notify any listeners (columns) that the items have changed
-      this.gridItemsChange.emit();
+      this.gridItemsChange.emit(new GridEvent('sl-grid-items-change', this));
     }
   }
 

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -2,12 +2,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import type { GridSorter, GridSorterChange } from './sorter.js';
 import type { GridFilter, GridFilterChange } from './filter.js';
 import type { ScopedElementsMap } from '@open-wc/scoped-elements';
-import type {
-  DataSource,
-  DataSourceFilterValue,
-  DataSourceSortDirection,
-  EventEmitter
-} from '@sl-design-system/shared';
+import type { DataSource, DataSourceFilterValue, EventEmitter } from '@sl-design-system/shared';
 import { localized } from '@lit/localize';
 import { virtualize } from '@lit-labs/virtualizer/virtualize.js';
 import { ScopedElementsMixin } from '@open-wc/scoped-elements';
@@ -20,8 +15,17 @@ import { GridColumnGroup } from './column-group.js';
 import styles from './grid.scss.js';
 import { GridSelectionColumn } from './selection-column.js';
 
-export class GridActiveItemChangeEvent<T> extends Event {
-  constructor(public readonly item: T, public readonly relatedEvent: Event | null) {
+export class GridEvent<T extends Record<string, unknown> = Record<string, unknown>> extends Event {
+  grid: Grid<T>;
+
+  constructor(type: string, grid: Grid<T>) {
+    super(type, { bubbles: true, composed: true });
+    this.grid = grid;
+  }
+}
+
+export class GridActiveItemChangeEvent<T extends Record<string, unknown> = Record<string, unknown>> extends Event {
+  constructor(public readonly grid: Grid<T>, public readonly item: T, public readonly relatedEvent: Event | null) {
     super('sl-active-item-change', { bubbles: true, composed: true });
   }
 }
@@ -170,8 +174,8 @@ export class Grid<T extends Record<string, unknown> = Record<string, unknown>> e
         <thead
           @sl-filter-change=${this.#onFilterChange}
           @sl-filter-value-change=${this.#onFilterValueChange}
+          @sl-sort-direction-change=${this.#onSortDirectionChange}
           @sl-sorter-change=${this.#onSorterChange}
-          @sl-sorter-direction-change=${this.#onSorterDirectionChange}
           part="thead"
         >
           ${this.renderHeader()}
@@ -309,7 +313,7 @@ export class Grid<T extends Record<string, unknown> = Record<string, unknown>> e
 
   #onClickRow(event: Event, item: T): void {
     this.activeItem = item;
-    this.activeItemChange.emit(new GridActiveItemChangeEvent(this.activeItem, event));
+    this.activeItemChange.emit(new GridActiveItemChangeEvent(this, this.activeItem, event));
   }
 
   #onColumnUpdate(event: Event & { target: GridColumn<T> }): void {
@@ -345,6 +349,12 @@ export class Grid<T extends Record<string, unknown> = Record<string, unknown>> e
     this.columns = columns;
   }
 
+  #onSortDirectionChange({ target }: Event & { target: GridSorter<T> }): void {
+    this.#sorters.filter(sorter => sorter !== target).forEach(sorter => sorter.reset());
+
+    this.#applySorters();
+  }
+
   #onSorterChange({ detail, target }: CustomEvent<GridSorterChange> & { target: GridSorter<T> }): void {
     if (detail === 'added') {
       this.#sorters = [...this.#sorters, target];
@@ -356,14 +366,6 @@ export class Grid<T extends Record<string, unknown> = Record<string, unknown>> e
     if (this.#sorters.some(sorter => sorter.direction !== undefined)) {
       this.#applySorters();
     }
-  }
-
-  #onSorterDirectionChange({
-    target
-  }: CustomEvent<DataSourceSortDirection | undefined> & { target: GridSorter<T> }): void {
-    this.#sorters.filter(sorter => sorter !== target).forEach(sorter => sorter.reset());
-
-    this.#applySorters();
   }
 
   #onVisibilityChanged(): void {

--- a/packages/components/grid/src/sort-column.ts
+++ b/packages/components/grid/src/sort-column.ts
@@ -3,8 +3,14 @@ import type { DataSourceSortDirection, DataSourceSortFunction } from '@sl-design
 import { getNameByPath } from '@sl-design-system/shared';
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
-import { GridColumn } from './column.js';
+import { GridColumn, GridColumnEvent } from './column.js';
 import { GridSorter } from './sorter.js';
+
+export class GridSortDirectionChangeEvent extends GridColumnEvent {
+  constructor(column: GridColumn, public readonly direction: DataSourceSortDirection | undefined) {
+    super('sl-sort-direction-change', column);
+  }
+}
 
 export class GridSortColumn extends GridColumn {
   /** The direction this columns should be sorted in. */

--- a/packages/components/grid/src/sorter.ts
+++ b/packages/components/grid/src/sorter.ts
@@ -8,6 +8,7 @@ import { EventsController, event } from '@sl-design-system/shared';
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
+import { GridSortDirectionChangeEvent } from './sort-column.js';
 import styles from './sorter.scss.js';
 
 export type GridSorterChange = 'added' | 'removed';
@@ -36,7 +37,7 @@ export class GridSorter<T> extends ScopedElementsMixin(LitElement) {
 
   @event() sorterChange!: EventEmitter<GridSorterChange>;
 
-  @event() sorterDirectionChange!: EventEmitter<DataSourceSortDirection | undefined>;
+  @event() sortDirectionChange!: EventEmitter<GridSortDirectionChangeEvent>;
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -91,7 +92,7 @@ export class GridSorter<T> extends ScopedElementsMixin(LitElement) {
 
   #onClick(): void {
     this.#toggleDirection();
-    this.sorterDirectionChange.emit(this.direction);
+    this.sortDirectionChange.emit(new GridSortDirectionChangeEvent(this.column, this.direction));
   }
 
   #onKeydown(event: KeyboardEvent): void {
@@ -99,7 +100,7 @@ export class GridSorter<T> extends ScopedElementsMixin(LitElement) {
       event.preventDefault();
 
       this.#toggleDirection();
-      this.sorterDirectionChange.emit(this.direction);
+      this.sortDirectionChange.emit(new GridSortDirectionChangeEvent(this.column, this.direction));
     }
   }
 


### PR DESCRIPTION
- Add `position="bottom"` to filter popover so it does not appear below a sticky header above it in browsers that do not support popover yet
- Use explicit grid events instead of `CustomEvent`. Allows us to add a `column` property for column related events.