### PR TITLE
Fix/grid selected count

### DIFF
--- a/.changeset/late-doors-care.md
+++ b/.changeset/late-doors-care.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Fix incorrect selection count after all rows have been selected

--- a/packages/components/grid/src/selection-column.ts
+++ b/packages/components/grid/src/selection-column.ts
@@ -55,9 +55,14 @@ export class GridSelectionColumn<T = any> extends GridColumn<T> {
   }
 
   renderSelectionHeader(): TemplateResult {
-    const count = this.grid?.selection.areAllSelected()
-      ? this.grid?.selection.size
-      : this.grid?.selection.selection.size;
+    let count = 0;
+    if (this.grid?.selection.areAllSelected()) {
+      count = this.grid?.selection.size;
+    } else if (this.grid?.selection.isSelectAllToggled()) {
+      count = this.grid?.selection.size - this.grid?.selection.selection.size;
+    } else {
+      count = this.grid?.selection.selection.size ?? 0;
+    }
 
     return html`
       <th part="header active-selection">

--- a/packages/components/shared/src/controllers/selection.ts
+++ b/packages/components/shared/src/controllers/selection.ts
@@ -100,4 +100,8 @@ export class SelectionController<T> {
       return this.#selection.has(item);
     }
   }
+
+  isSelectAllToggled(): boolean {
+    return this.#selectAll;
+  }
 }


### PR DESCRIPTION
This fixes the selection row count when:
- You first select all rows via the column header
- Then deselect some rows

It should then show a count of `all - selected`. Instead it showed just `selected`. This PR fixes that.