### PR TITLE
Fix dialog overflow to be visible instead of the default hidden

### DIFF
--- a/.changeset/early-waves-smell.md
+++ b/.changeset/early-waves-smell.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/dialog': patch
+---
+
+Set dialog overflow from hidden (default) to visible

--- a/packages/components/dialog/src/dialog.scss
+++ b/packages/components/dialog/src/dialog.scss
@@ -41,6 +41,7 @@ dialog {
   );
   max-inline-size: var(--_max-inline-size);
   opacity: 0;
+  overflow: visible;
   padding-block: var(--_padding-block);
   padding-inline: var(--_padding-inline);
 }


### PR DESCRIPTION
![CleanShot 2024-02-17 at 09 39 41@2x](https://github.com/sl-design-system/components/assets/3968/8a75160e-b3aa-4bdb-8a7a-24885a704d42)

Without this fix, content in the dialog cannot overflow the boundaries of the dialog, like in the screenshot.