### PR TITLE
Fix 3rd party component dependencies to be peerDependencies instead

### DIFF
--- a/.changeset/modern-maps-mate.md
+++ b/.changeset/modern-maps-mate.md
@@ -1,0 +1,28 @@
+---
+"@sl-design-system/inline-message": patch
+"@sl-design-system/message-dialog": patch
+"@sl-design-system/breadcrumbs": patch
+"@sl-design-system/radio-group": patch
+"@sl-design-system/button-bar": patch
+"@sl-design-system/text-field": patch
+"@sl-design-system/checkbox": patch
+"@sl-design-system/skeleton": patch
+"@sl-design-system/textarea": patch
+"@sl-design-system/spinner": patch
+"@sl-design-system/tooltip": patch
+"@sl-design-system/dialog": patch
+"@sl-design-system/drawer": patch
+"@sl-design-system/editor": patch
+"@sl-design-system/select": patch
+"@sl-design-system/shared": patch
+"@sl-design-system/switch": patch
+"@sl-design-system/badge": patch
+"@sl-design-system/card": patch
+"@sl-design-system/form": patch
+"@sl-design-system/grid": patch
+"@sl-design-system/icon": patch
+"@sl-design-system/menu": patch
+"@sl-design-system/tabs": patch
+---
+
+Fix 3rd party dependencies to be peerDependencies instead

--- a/packages/components/badge/package.json
+++ b/packages/components/badge/package.json
@@ -37,7 +37,10 @@
   "scripts": {
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "lit": "^3.1.2"
+  },
+  "peerDependencies": {
     "lit": "^3.1.2"
   }
 }

--- a/packages/components/breadcrumbs/package.json
+++ b/packages/components/breadcrumbs/package.json
@@ -38,11 +38,16 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit/localize": "^0.12.1",
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/icon": "0.0.7",
     "@sl-design-system/menu": "0.0.2",
-    "@sl-design-system/tooltip": "0.0.19",
-    "lit": "^3.1.2"
+    "@sl-design-system/tooltip": "0.0.19"
+  },
+  "devDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/button-bar/package.json
+++ b/packages/components/button-bar/package.json
@@ -37,7 +37,10 @@
   "scripts": {
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "lit": "^3.1.2"
+  },
+  "peerDependencies": {
     "lit": "^3.1.2"
   }
 }

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -37,7 +37,10 @@
   "scripts": {
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "lit": "^3.1.2"
+  },
+  "peerDependencies": {
     "lit": "^3.1.2"
   }
 }

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -38,8 +38,13 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit/localize": "^0.12.1",
     "@sl-design-system/form": "0.0.8",
     "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@lit/localize": "^0.12.1"
+  },
+  "peerDependencies": {
+    "@lit/localize": "^0.12.1"
   }
 }

--- a/packages/components/dialog/package.json
+++ b/packages/components/dialog/package.json
@@ -38,11 +38,17 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit/localize": "^0.12.1",
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/button": "0.0.21",
     "@sl-design-system/button-bar": "0.0.4",
     "@sl-design-system/icon": "0.0.7",
     "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/drawer/package.json
+++ b/packages/components/drawer/package.json
@@ -38,8 +38,13 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/button": "0.0.21",
     "@sl-design-system/button-bar": "0.0.4"
+  },
+  "devDependencies": {
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/editor/package.json
+++ b/packages/components/editor/package.json
@@ -39,7 +39,19 @@
   },
   "dependencies": {
     "@sl-design-system/form": "0.0.8",
-    "@sl-design-system/shared": "0.2.5",
+    "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "prosemirror-commands": "^1.5.2",
+    "prosemirror-history": "^1.3.2",
+    "prosemirror-inputrules": "^1.4.0",
+    "prosemirror-keymap": "^1.2.2",
+    "prosemirror-model": "^1.19.4",
+    "prosemirror-schema-list": "^1.3.0",
+    "prosemirror-state": "^1.4.3",
+    "prosemirror-view": "^1.33.1"
+  },
+  "peerDependencies": {
     "prosemirror-commands": "^1.5.2",
     "prosemirror-history": "^1.3.2",
     "prosemirror-inputrules": "^1.4.0",

--- a/packages/components/form/package.json
+++ b/packages/components/form/package.json
@@ -38,8 +38,14 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit/localize": "^0.12.1",
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/grid/package.json
+++ b/packages/components/grid/package.json
@@ -38,13 +38,20 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit-labs/virtualizer": "^2.0.12",
-    "@lit/localize": "^0.12.1",
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/checkbox": "0.0.22",
     "@sl-design-system/icon": "0.0.7",
     "@sl-design-system/popover": "0.1.5",
     "@sl-design-system/shared": "0.2.5",
     "@sl-design-system/text-field": "0.1.17"
+  },
+  "devDependencies": {
+    "@lit-labs/virtualizer": "^2.0.12",
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@lit-labs/virtualizer": "^2.0.12",
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -37,7 +37,10 @@
   "scripts": {
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "lit": "^3.1.2"
+  },
+  "peerDependencies": {
     "lit": "^3.1.2"
   }
 }

--- a/packages/components/inline-message/package.json
+++ b/packages/components/inline-message/package.json
@@ -38,10 +38,16 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit/localize": "^0.12.1",
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/button": "0.0.21",
     "@sl-design-system/icon": "0.0.7",
     "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -38,10 +38,16 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit/localize": "^0.12.1",
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/button": "0.0.21",
     "@sl-design-system/icon": "0.0.7",
     "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/message-dialog/package.json
+++ b/packages/components/message-dialog/package.json
@@ -38,9 +38,15 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit/localize": "^0.12.1",
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/button": "0.0.21",
     "@sl-design-system/dialog": "0.0.10"
+  },
+  "devDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/radio-group/package.json
+++ b/packages/components/radio-group/package.json
@@ -38,8 +38,13 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit/localize": "^0.12.1",
     "@sl-design-system/form": "0.0.8",
     "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@lit/localize": "^0.12.1"
+  },
+  "peerDependencies": {
+    "@lit/localize": "^0.12.1"
   }
 }

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -38,10 +38,16 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit/localize": "^0.12.1",
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/form": "0.0.8",
     "@sl-design-system/icon": "0.0.7",
     "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/shared/package.json
+++ b/packages/components/shared/package.json
@@ -27,7 +27,11 @@
   "scripts": {
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@floating-ui/dom": "^1.6.3",
+    "lit": "^3.1.2"
+  },
+  "peerDependencies": {
     "@floating-ui/dom": "^1.6.3",
     "lit": "^3.1.2"
   }

--- a/packages/components/skeleton/package.json
+++ b/packages/components/skeleton/package.json
@@ -37,7 +37,10 @@
   "scripts": {
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "lit": "^3.1.2"
+  },
+  "peerDependencies": {
     "lit": "^3.1.2"
   }
 }

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -37,7 +37,10 @@
   "scripts": {
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
-  "dependencies": {
+  "devDependencies": {
+    "lit": "^3.1.2"
+  },
+  "peerDependencies": {
     "lit": "^3.1.2"
   }
 }

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -40,7 +40,12 @@
   "dependencies": {
     "@sl-design-system/form": "0.0.8",
     "@sl-design-system/icon": "0.0.7",
-    "@sl-design-system/shared": "0.2.5",
-    "lit": "^3.1.2"
+    "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -38,11 +38,16 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@lit/localize": "^0.12.1",
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/button": "0.0.21",
     "@sl-design-system/icon": "0.0.7",
-    "@sl-design-system/shared": "0.2.5",
-    "lit": "^3.1.2"
+    "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@lit/localize": "^0.12.1",
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/text-field/package.json
+++ b/packages/components/text-field/package.json
@@ -38,9 +38,14 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/form": "0.0.8",
     "@sl-design-system/icon": "0.0.7",
     "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/textarea/package.json
+++ b/packages/components/textarea/package.json
@@ -38,9 +38,14 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@open-wc/scoped-elements": "^3.0.5",
     "@sl-design-system/form": "0.0.8",
     "@sl-design-system/icon": "0.0.7",
     "@sl-design-system/shared": "0.2.5"
+  },
+  "devDependencies": {
+    "@open-wc/scoped-elements": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@open-wc/scoped-elements": "^3.0.5"
   }
 }

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -38,8 +38,6 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@sl-design-system/popover": "0.1.5",
-    "@sl-design-system/shared": "0.2.5",
-    "lit": "^3.1.2"
+    "@sl-design-system/shared": "0.2.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5002,6 +5002,8 @@ __metadata:
   resolution: "@sl-design-system/badge@workspace:packages/components/badge"
   dependencies:
     lit: "npm:^3.1.2"
+  peerDependencies:
+    lit: ^3.1.2
   languageName: unknown
   linkType: soft
 
@@ -5038,7 +5040,9 @@ __metadata:
     "@sl-design-system/icon": "npm:0.0.7"
     "@sl-design-system/menu": "npm:0.0.2"
     "@sl-design-system/tooltip": "npm:0.0.19"
-    lit: "npm:^3.1.2"
+  peerDependencies:
+    "@lit/localize": ^0.12.1
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5047,6 +5051,8 @@ __metadata:
   resolution: "@sl-design-system/button-bar@workspace:packages/components/button-bar"
   dependencies:
     lit: "npm:^3.1.2"
+  peerDependencies:
+    lit: ^3.1.2
   languageName: unknown
   linkType: soft
 
@@ -5063,6 +5069,8 @@ __metadata:
   resolution: "@sl-design-system/card@workspace:packages/components/card"
   dependencies:
     lit: "npm:^3.1.2"
+  peerDependencies:
+    lit: ^3.1.2
   languageName: unknown
   linkType: soft
 
@@ -5073,6 +5081,8 @@ __metadata:
     "@lit/localize": "npm:^0.12.1"
     "@sl-design-system/form": "npm:0.0.8"
     "@sl-design-system/shared": "npm:0.2.5"
+  peerDependencies:
+    "@lit/localize": ^0.12.1
   languageName: unknown
   linkType: soft
 
@@ -5112,6 +5122,9 @@ __metadata:
     "@sl-design-system/button-bar": "npm:0.0.4"
     "@sl-design-system/icon": "npm:0.0.7"
     "@sl-design-system/shared": "npm:0.2.5"
+  peerDependencies:
+    "@lit/localize": ^0.12.1
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5122,6 +5135,8 @@ __metadata:
     "@open-wc/scoped-elements": "npm:^3.0.5"
     "@sl-design-system/button": "npm:0.0.21"
     "@sl-design-system/button-bar": "npm:0.0.4"
+  peerDependencies:
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5139,6 +5154,15 @@ __metadata:
     prosemirror-schema-list: "npm:^1.3.0"
     prosemirror-state: "npm:^1.4.3"
     prosemirror-view: "npm:^1.33.1"
+  peerDependencies:
+    prosemirror-commands: ^1.5.2
+    prosemirror-history: ^1.3.2
+    prosemirror-inputrules: ^1.4.0
+    prosemirror-keymap: ^1.2.2
+    prosemirror-model: ^1.19.4
+    prosemirror-schema-list: ^1.3.0
+    prosemirror-state: ^1.4.3
+    prosemirror-view: ^1.33.1
   languageName: unknown
   linkType: soft
 
@@ -5188,6 +5212,9 @@ __metadata:
     "@lit/localize": "npm:^0.12.1"
     "@open-wc/scoped-elements": "npm:^3.0.5"
     "@sl-design-system/shared": "npm:0.2.5"
+  peerDependencies:
+    "@lit/localize": ^0.12.1
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5203,6 +5230,10 @@ __metadata:
     "@sl-design-system/popover": "npm:0.1.5"
     "@sl-design-system/shared": "npm:0.2.5"
     "@sl-design-system/text-field": "npm:0.1.17"
+  peerDependencies:
+    "@lit-labs/virtualizer": ^2.0.12
+    "@lit/localize": ^0.12.1
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5211,6 +5242,8 @@ __metadata:
   resolution: "@sl-design-system/icon@workspace:packages/components/icon"
   dependencies:
     lit: "npm:^3.1.2"
+  peerDependencies:
+    lit: ^3.1.2
   languageName: unknown
   linkType: soft
 
@@ -5223,6 +5256,9 @@ __metadata:
     "@sl-design-system/button": "npm:0.0.21"
     "@sl-design-system/icon": "npm:0.0.7"
     "@sl-design-system/shared": "npm:0.2.5"
+  peerDependencies:
+    "@lit/localize": ^0.12.1
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5275,6 +5311,9 @@ __metadata:
     "@sl-design-system/button": "npm:0.0.21"
     "@sl-design-system/icon": "npm:0.0.7"
     "@sl-design-system/shared": "npm:0.2.5"
+  peerDependencies:
+    "@lit/localize": ^0.12.1
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5286,6 +5325,9 @@ __metadata:
     "@open-wc/scoped-elements": "npm:^3.0.5"
     "@sl-design-system/button": "npm:0.0.21"
     "@sl-design-system/dialog": "npm:0.0.10"
+  peerDependencies:
+    "@lit/localize": ^0.12.1
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5379,6 +5421,8 @@ __metadata:
     "@lit/localize": "npm:^0.12.1"
     "@sl-design-system/form": "npm:0.0.8"
     "@sl-design-system/shared": "npm:0.2.5"
+  peerDependencies:
+    "@lit/localize": ^0.12.1
   languageName: unknown
   linkType: soft
 
@@ -5425,6 +5469,9 @@ __metadata:
     "@sl-design-system/form": "npm:0.0.8"
     "@sl-design-system/icon": "npm:0.0.7"
     "@sl-design-system/shared": "npm:0.2.5"
+  peerDependencies:
+    "@lit/localize": ^0.12.1
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5434,6 +5481,9 @@ __metadata:
   dependencies:
     "@floating-ui/dom": "npm:^1.6.3"
     lit: "npm:^3.1.2"
+  peerDependencies:
+    "@floating-ui/dom": ^1.6.3
+    lit: ^3.1.2
   languageName: unknown
   linkType: soft
 
@@ -5442,6 +5492,8 @@ __metadata:
   resolution: "@sl-design-system/skeleton@workspace:packages/components/skeleton"
   dependencies:
     lit: "npm:^3.1.2"
+  peerDependencies:
+    lit: ^3.1.2
   languageName: unknown
   linkType: soft
 
@@ -5450,6 +5502,8 @@ __metadata:
   resolution: "@sl-design-system/spinner@workspace:packages/components/spinner"
   dependencies:
     lit: "npm:^3.1.2"
+  peerDependencies:
+    lit: ^3.1.2
   languageName: unknown
   linkType: soft
 
@@ -5457,10 +5511,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sl-design-system/switch@workspace:packages/components/switch"
   dependencies:
+    "@open-wc/scoped-elements": "npm:^3.0.5"
     "@sl-design-system/form": "npm:0.0.8"
     "@sl-design-system/icon": "npm:0.0.7"
     "@sl-design-system/shared": "npm:0.2.5"
-    lit: "npm:^3.1.2"
+  peerDependencies:
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5473,7 +5529,9 @@ __metadata:
     "@sl-design-system/button": "npm:0.0.21"
     "@sl-design-system/icon": "npm:0.0.7"
     "@sl-design-system/shared": "npm:0.2.5"
-    lit: "npm:^3.1.2"
+  peerDependencies:
+    "@lit/localize": ^0.12.1
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5493,6 +5551,8 @@ __metadata:
     "@sl-design-system/form": "npm:0.0.8"
     "@sl-design-system/icon": "npm:0.0.7"
     "@sl-design-system/shared": "npm:0.2.5"
+  peerDependencies:
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5504,6 +5564,8 @@ __metadata:
     "@sl-design-system/form": "npm:0.0.8"
     "@sl-design-system/icon": "npm:0.0.7"
     "@sl-design-system/shared": "npm:0.2.5"
+  peerDependencies:
+    "@open-wc/scoped-elements": ^3.0.5
   languageName: unknown
   linkType: soft
 
@@ -5517,9 +5579,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sl-design-system/tooltip@workspace:packages/components/tooltip"
   dependencies:
-    "@sl-design-system/popover": "npm:0.1.5"
     "@sl-design-system/shared": "npm:0.2.5"
-    lit: "npm:^3.1.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Previously we had 3rd party component dependencies as `dependencies` in their respective `package.json` files. This can cause issues when used in applications, because the components will not use the same dependencies from the application. For example, runtime translations are broken because components have their own version of `@lit/localize` which does not have the translations as configured by the application.

By making those 3rd party dependencies `peerDependencies`, this is fixed.