### PR TITLE
fixed checkbox checked value

### DIFF
--- a/.changeset/mighty-dryers-exist.md
+++ b/.changeset/mighty-dryers-exist.md
@@ -2,4 +2,7 @@
 "@sl-design-system/grid": patch
 ---
 
-fixed checkbox checked value
+Fixed checkbox checked value;
+When a grid includes both a selection column and a filter column, a potential issue may arise. If you select a filter and then proceed to check a checkbox in the selection column, subsequently deselecting it, the checked status of the filtered item might not be visible. However, the filtering functionality remains intact.
+
+Fixed it by changing ?checked to .checked since it should have the same effect, as both the property and attribute control whether the checkbox is checked or not.

--- a/.changeset/mighty-dryers-exist.md
+++ b/.changeset/mighty-dryers-exist.md
@@ -1,0 +1,5 @@
+---
+"@sl-design-system/grid": patch
+---
+
+fixed checkbox checked value

--- a/packages/components/grid/src/filter.ts
+++ b/packages/components/grid/src/filter.ts
@@ -116,7 +116,7 @@ export class GridFilter<T> extends ScopedElementsMixin(LitElement) {
                   option => html`
                     <sl-checkbox
                       @sl-change=${(event: CustomEvent<boolean>) => this.#onChange(option, event.detail)}
-                      ?checked=${this.value?.includes(option.value?.toString() ?? '')}
+                      .checked=${this.value?.includes(option.value?.toString() ?? '')}
                       .value=${option.value}
                     >
                       ${option.label}

--- a/packages/components/grid/src/stories/filtering.stories.ts
+++ b/packages/components/grid/src/stories/filtering.stories.ts
@@ -56,6 +56,18 @@ export const EmptyValues: Story = {
   }
 };
 
+export const FilteringWithSelection: Story = {
+  render: (_, { loaded: { people } }) => html`
+    <sl-grid .items=${people}>
+      <sl-grid-selection-column></sl-grid-selection-column>
+      <sl-grid-column path="firstName"></sl-grid-column>
+      <sl-grid-column path="lastName"></sl-grid-column>
+      <sl-grid-filter-column path="status"></sl-grid-filter-column>
+      <sl-grid-filter-column path="membership"></sl-grid-filter-column>
+    </sl-grid>
+  `
+};
+
 export const OutsideGrid: Story = {
   render: (_, { loaded: { people } }) => {
     const dataSource = new ArrayDataSource(people as Person[]);


### PR DESCRIPTION
When a grid includes both a selection column and a filter column, a potential issue may arise. If you select a filter and then proceed to check a checkbox in the selection column, subsequently deselecting it, the checked status of the filtered item might not be visible. However, the filtering functionality remains intact.

Fixed it by changing ?checked to .checked since it should have the same effect, as both the property and attribute control whether the checkbox is checked or not.