### PR TITLE
Fix popover positioning in FF & Safari

### DIFF
--- a/.changeset/three-lamps-dream.md
+++ b/.changeset/three-lamps-dream.md
@@ -1,0 +1,5 @@
+---
+"@sl-design-system/popover": patch
+---
+
+Fix popover positioning in FF and Safari

--- a/packages/components/popover/src/popover.scss
+++ b/packages/components/popover/src/popover.scss
@@ -18,6 +18,7 @@
   box-shadow: var(--_box-shadow);
   color: var(--_color);
   font: var(--_font);
+  margin: 0;
   max-inline-size: var(--_max-width);
   opacity: 0;
   overflow: visible;


### PR DESCRIPTION
The `margin: 0;` reset was missing from sl-popover.