### PR TITLE
Improve getting started, polyfills section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ When you finish the branch and want to get your changes merged into `main`, plea
 
 When you create a PR, please make sure the PR is associated with the issue. You can do this by either typing "Fixes #123" in the body of the PR, or by manually associating an issue with a PR.
 
-Please run `yarn changeset` locally to create an entry for `CHANGELOG.md`.
+Please run `yarn changeset` locally to create an entry for `CHANGELOG.md` (note that this is not needed when you make changes to the website only).
 
 ## Linting
 

--- a/website/src/categories/getting-started/developers.md
+++ b/website/src/categories/getting-started/developers.md
@@ -154,16 +154,19 @@ Make sure you include the polyfills before you include the SLDS components. This
 The following web standards require polyfills at this time:
 - [Popover](https://caniuse.com/mdn-api_htmlelement_popover)
 - [Scoped Custom Element Registry](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Scoped-Custom-Element-Registries.md)
+- [Element Internals](https://caniuse.com/mdn-api_elementinternals)
 
 To use these polyfills, you need to install the following packages:
 - `@oddbird/popover-polyfill`
 - `@webcomponents/scoped-custom-element-registry`
+- `element-internals-polyfill`
 
 Once installed you need to import the polyfills in your application. You can do this by importing the polyfills in your main JS file:
 
 ```js
 import '@oddbird/popover-polyfill';
 import '@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min.js';
+import 'element-internals-polyfill';
 ```
 
 Another option is to include them in your HTML:
@@ -171,6 +174,7 @@ Another option is to include them in your HTML:
 ```html
 <script src="./node_modules/@oddbird/popover-polyfill/dist/popover.min.js"></script>
 <script src="./node_modules/@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min.js"></script>
+<script src="./node_modules/element-internals-polyfill"></script>
 ```
 
 </section>


### PR DESCRIPTION
When implementing the `sl-button` in `max-online`, we encountered lots of errors stating `this.attachInternals is not a function`. 
Polyfill [element-internals-polyfill](https://www.npmjs.com/package/element-internals-polyfill) is needed to solve this for older browsers. See also https://caniuse.com/mdn-api_elementinternals
