### PR TITLE
Fix missing `calc()` functions in theme parts.

### DIFF
--- a/.changeset/dry-jokes-sit.md
+++ b/.changeset/dry-jokes-sit.md
@@ -1,0 +1,20 @@
+---
+"@sl-design-system/bingel": patch
+"@sl-design-system/bingel-dc": patch
+"@sl-design-system/bingel-int": patch
+"@sl-design-system/clickedu": patch
+"@sl-design-system/editorial-suite": patch
+"@sl-design-system/itslearning": patch
+"@sl-design-system/kampus": patch
+"@sl-design-system/magister": patch
+"@sl-design-system/max": patch
+"@sl-design-system/my-digital-book": patch
+"@sl-design-system/myvanin": patch
+"@sl-design-system/neon": patch
+"@sl-design-system/nowa-era": patch
+"@sl-design-system/sanoma-learning": patch
+"@sl-design-system/sanoma-utbildning": patch
+"@sl-design-system/teas": patch
+---
+
+Fix missing `calc()` functions in theme parts.

--- a/scripts/build-themes.js
+++ b/scripts/build-themes.js
@@ -188,8 +188,8 @@ const build = async (production = false) => {
               'sl/size/css/lineHeight',
               'sl/size/css/paragraphSpacing',
               'sl/size/css/px',
-              production ? undefined : 'sl/color/transparentColorMix',
-              production ? undefined : 'sl/wrapMathInCalc'
+              'sl/color/transparentColorMix',
+              'sl/wrapMathInCalc'
             ].filter(Boolean),
             prefix: 'sl',
             files


### PR DESCRIPTION
Some transformations were not being applied to the files in `@sl-design-system/<theme>/css` and `@sl-design-system/<theme>/scss`, like the `wrapMathInCalc` transform. This resulted in styling errors when using these files. The light/dark files do not have this bug.