### PR TITLE
Fix error when querying form control state after disconnect

### DIFF
--- a/.changeset/thin-apricots-wonder.md
+++ b/.changeset/thin-apricots-wonder.md
@@ -1,0 +1,5 @@
+---
+"@sl-design-system/form": patch
+---
+
+Fix for form control element errors after disconnect in unit tests

--- a/packages/components/form/src/form-control-mixin.ts
+++ b/packages/components/form/src/form-control-mixin.ts
@@ -280,7 +280,6 @@ export function FormControlMixin<T extends Constructor<ReactiveElement>>(constru
       this.#unregister = undefined;
 
       this.#formControlElement?.removeEventListener('invalid', this.#onInvalid);
-      this.#formControlElement = undefined;
 
       super.disconnectedCallback();
     }

--- a/packages/components/text-field/src/text-field.spec.ts
+++ b/packages/components/text-field/src/text-field.spec.ts
@@ -257,6 +257,20 @@ describe('sl-text-field', () => {
 
       expect(onValidate).to.have.been.callCount(5);
     });
+
+    it('should not throw an error when querying state after the element has been disconnected', () => {
+      const onError = spy();
+
+      el.remove();
+
+      try {
+        el.updateValidity();
+      } catch (error) {
+        onError(error);
+      }
+
+      expect(onError).not.to.have.been.called;
+    });
   });
 
   describe('invalid', () => {


### PR DESCRIPTION
Do not set the `formControlElement` variable to `undefined` on disconnect. This prevents errors in unit tests from happening due to async code.