### PR TITLE
Add a generic type to TextField so we can use that for inheritance

### DIFF
--- a/.changeset/angry-mails-pretend.md
+++ b/.changeset/angry-mails-pretend.md
@@ -1,0 +1,5 @@
+---
+"@sl-design-system/text-field": minor
+---
+
+Support other types than just string for inheritance

--- a/.changeset/angry-mails-pretend.md
+++ b/.changeset/angry-mails-pretend.md
@@ -2,4 +2,7 @@
 "@sl-design-system/text-field": minor
 ---
 
-Support other types than just string for inheritance
+Support other types than just string for inheritance:
+- Use `T extends { toString(): string } = string` type for `TextField`
+- Add `parseValue` method that converts the raw value to the given type (or throw an `Error` if it cannot be parsed)
+- Add `formatValue` method to format a value for display in the input

--- a/.changeset/clever-bees-shop.md
+++ b/.changeset/clever-bees-shop.md
@@ -1,4 +1,5 @@
 ---
+"@sl-design-system/angular": patch
 "@sl-design-system/search-field": patch
 ---
 

--- a/.changeset/clever-bees-shop.md
+++ b/.changeset/clever-bees-shop.md
@@ -1,0 +1,5 @@
+---
+"@sl-design-system/search-field": patch
+---
+
+Update to use the new TextField generic type

--- a/packages/angular/src/forms/text-field.directive.ts
+++ b/packages/angular/src/forms/text-field.directive.ts
@@ -30,9 +30,13 @@ export class TextFieldDirective extends FormControlElementDirective<TextField> {
     } else if (this.element.validity.patternMismatch) {
       return { pattern: { requiredPattern: this.element.pattern, actualValue: this.element.value } };
     } else if (this.element.validity.tooLong) {
-      return { maxlength: { requiredLength: this.element.maxLength, actualLength: this.element.value.length } };
+      return {
+        maxlength: { requiredLength: this.element.maxLength, actualLength: this.element.value?.toString().length ?? 0 }
+      };
     } else if (this.element.validity.tooShort) {
-      return { minlength: { requiredLength: this.element.minLength, actualLength: this.element.value.length } };
+      return {
+        minlength: { requiredLength: this.element.minLength, actualLength: this.element.value?.toString().length ?? 0 }
+      };
     } else if (this.element.validity.valueMissing) {
       return { required: true };
     }

--- a/packages/components/search-field/src/search-field.ts
+++ b/packages/components/search-field/src/search-field.ts
@@ -79,7 +79,7 @@ export class SearchField extends ScopedElementsMixin(TextField) {
     if (event.key === 'Enter') {
       event.preventDefault();
 
-      this.searchEvent.emit(this.value);
+      this.searchEvent.emit(this.value?.toString() ?? '');
     } else if (event.key === 'Escape') {
       event.preventDefault();
 

--- a/packages/components/text-field/src/text-field.spec.ts
+++ b/packages/components/text-field/src/text-field.spec.ts
@@ -2,9 +2,10 @@ import { expect, fixture } from '@open-wc/testing';
 import { type SlFormControlEvent } from '@sl-design-system/form';
 import { sendKeys } from '@web/test-runner-commands';
 import { LitElement, type TemplateResult, html } from 'lit';
+import { property } from 'lit/decorators.js';
 import { spy } from 'sinon';
 import '../register.js';
-import { type TextField } from './text-field.js';
+import { TextField } from './text-field.js';
 
 describe('sl-text-field', () => {
   let el: TextField, input: HTMLInputElement;
@@ -429,6 +430,97 @@ describe('sl-text-field', () => {
 
     it('should emit an sl-form-control event after first render', () => {
       expect(el.onFormControl).to.have.been.calledOnce;
+    });
+  });
+
+  describe('inheritance', () => {
+    let el: DateField;
+
+    class DateField extends TextField<Date> {
+      #value?: Date;
+
+      override get value(): Date | undefined {
+        return this.#value;
+      }
+
+      @property()
+      override set value(value: number | string | Date | undefined) {
+        if (value instanceof Date) {
+          this.#value = value;
+        } else if (typeof value === 'number') {
+          this.#value = new Date(value);
+        } else if (typeof value === 'string') {
+          this.#value = new Date(value);
+        } else {
+          this.#value = undefined;
+        }
+      }
+
+      /** Parse the string value as a date using a regex, or throw an error if the value is invalid. */
+      override parseValue(value: string): Date | undefined {
+        const match = value.match(/^(\d{2})-(\d{2})-(\d{4})$/);
+
+        if (!match) {
+          throw new Error('Invalid date format');
+        } else {
+          const [, day, month, year] = match,
+            date = new Date(`${year}-${month}-${day}`);
+
+          if (isNaN(date.getTime())) {
+            throw new Error('Invalid date');
+          }
+
+          return date;
+        }
+      }
+
+      /** Format the date as DD-MM-YYYY. */
+      override formatValue(value?: Date): string {
+        return value?.toLocaleDateString() ?? '';
+      }
+    }
+
+    beforeEach(async () => {
+      try {
+        customElements.define('test-date-field', DateField);
+      } catch {
+        /* empty */
+      }
+
+      el = await fixture(html`<test-date-field></test-date-field>`);
+    });
+
+    it('should format the value correctly', async () => {
+      const date = new Date(2024, 0, 1);
+
+      el.value = date;
+      await el.updateComplete;
+
+      expect(el.querySelector('input')?.value).to.equal(date.toLocaleDateString());
+    });
+
+    it('should parse the value correctly', async () => {
+      el.focus();
+      await sendKeys({ type: '01-01-2024' });
+
+      expect(el.value).to.be.an.instanceof(Date);
+      expect(el.value!.getFullYear()).to.equal(2024);
+      expect(el.value!.getMonth()).to.equal(0);
+      expect(el.value!.getDate()).to.equal(1);
+    });
+
+    it('should support setting a date in milliseconds', async () => {
+      el.value = new Date(2025, 0, 1).getTime();
+      await el.updateComplete;
+
+      expect(el.querySelector('input')?.value).to.equal('1/1/2025');
+    });
+
+    it('should support setting a date as text', async () => {
+      el.value = '01-01-2025';
+      await el.updateComplete;
+
+      expect(el.querySelector('input')?.value).to.equal('1/1/2025');
     });
   });
 });

--- a/packages/components/text-field/src/text-field.stories.ts
+++ b/packages/components/text-field/src/text-field.stories.ts
@@ -5,7 +5,7 @@ import '@sl-design-system/icon/register.js';
 import { type Meta, type StoryObj } from '@storybook/web-components';
 import { type TemplateResult, html } from 'lit';
 import '../register.js';
-import { type TextField, type TextFieldSize } from './text-field.js';
+import { TextField, type TextFieldSize } from './text-field.js';
 
 type Props = Pick<
   TextField,
@@ -172,7 +172,7 @@ export const CustomValidity: Story = {
     hint: 'This story has both builtin validation (required) and custom validation. You need to enter "SLDS" to make the field valid. The custom validation is done by listening to the sl-validate event and setting the custom validity on the input element.',
     slot: () => {
       const onValidate = (event: Event & { target: TextField }): void => {
-        const value = event.target.value;
+        const value = event.target.value?.toString() ?? '';
 
         let message = '';
         if (value.length > 0 && value !== 'SLDS') {
@@ -202,6 +202,45 @@ export const CustomAsyncValidity: Story = {
       };
 
       return html`<sl-text-field @sl-validate=${onValidate} required></sl-text-field>`;
+    }
+  }
+};
+
+export const CustomComponent: Story = {
+  args: {
+    slot: () => {
+      class CustomTextField extends TextField<Date> {
+        /** Parse the string value as a date using a regex, or throw an error if the value is invalid. */
+        override parseValue(value: string): Date | undefined {
+          const match = value.match(/^(\d{2})-(\d{2})-(\d{4})$/);
+
+          if (!match) {
+            throw new Error('Invalid date format');
+          } else {
+            const [, day, month, year] = match,
+              date = new Date(`${year}-${month}-${day}`);
+
+            if (isNaN(date.getTime())) {
+              throw new Error('Invalid date');
+            }
+
+            return date;
+          }
+        }
+
+        /** Format the date as DD-MM-YYYY. */
+        override formatValue(value?: Date): string {
+          return value?.toLocaleDateString() ?? '';
+        }
+      }
+
+      try {
+        customElements.define('custom-text-field', CustomTextField);
+      } catch {
+        /* empty */
+      }
+
+      return html`<custom-text-field placeholder="Enter a DD-MM-YYYY value"></custom-text-field>`;
     }
   }
 };

--- a/packages/components/text-field/src/text-field.stories.ts
+++ b/packages/components/text-field/src/text-field.stories.ts
@@ -4,6 +4,7 @@ import '@sl-design-system/form/register.js';
 import '@sl-design-system/icon/register.js';
 import { type Meta, type StoryObj } from '@storybook/web-components';
 import { type TemplateResult, html } from 'lit';
+import { property } from 'lit/decorators.js';
 import '../register.js';
 import { TextField, type TextFieldSize } from './text-field.js';
 
@@ -208,8 +209,20 @@ export const CustomAsyncValidity: Story = {
 
 export const CustomComponent: Story = {
   args: {
+    hint: 'This story uses a custom component that inherits from the text field component. It parses and formats the value as a date in the format "DD-MM-YYYY". The field is invalid if the year is before 2024.',
     slot: () => {
       class CustomTextField extends TextField<Date> {
+        #value?: Date;
+
+        override get value(): Date | undefined {
+          return this.#value;
+        }
+
+        @property()
+        override set value(value: Date | undefined) {
+          this.#value = value;
+        }
+
         /** Parse the string value as a date using a regex, or throw an error if the value is invalid. */
         override parseValue(value: string): Date | undefined {
           const match = value.match(/^(\d{2})-(\d{2})-(\d{4})$/);
@@ -240,7 +253,23 @@ export const CustomComponent: Story = {
         /* empty */
       }
 
-      return html`<custom-text-field placeholder="Enter a DD-MM-YYYY value"></custom-text-field>`;
+      const onValidate = (event: Event & { target: CustomTextField }): void => {
+        const year = event.target.value?.getFullYear();
+
+        if (typeof year === 'number') {
+          event.target.setCustomValidity(year < 2024 ? 'Enter a date after 2023' : '');
+        } else {
+          event.target.setCustomValidity('');
+        }
+      };
+
+      return html`
+        <custom-text-field
+          @sl-validate=${onValidate}
+          placeholder="Enter a DD-MM-YYYY value"
+          required
+        ></custom-text-field>
+      `;
     }
   }
 };

--- a/packages/components/text-field/src/text-field.ts
+++ b/packages/components/text-field/src/text-field.ts
@@ -5,7 +5,7 @@ import { Icon } from '@sl-design-system/icon';
 import { type EventEmitter, event } from '@sl-design-system/shared';
 import { type SlBlurEvent, type SlChangeEvent, type SlFocusEvent } from '@sl-design-system/shared/events.js';
 import { type CSSResultGroup, LitElement, type PropertyValues, type TemplateResult, html, nothing } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import styles from './text-field.scss.js';
 
 declare global {
@@ -43,11 +43,20 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
   /** @internal */
   static override styles: CSSResultGroup = styles;
 
+  /** The value of the text field. */
+  #value: T | undefined = '' as unknown as T;
+
+  /** Specifies which type of data the browser can use to pre-fill the input. */
+  @property() autocomplete?: typeof HTMLInputElement.prototype.autocomplete;
+
   /** @internal Emits when the focus leaves the component. */
   @event({ name: 'sl-blur' }) blurEvent!: EventEmitter<SlBlurEvent>;
 
   /** @internal Emits when the value changes. */
   @event({ name: 'sl-change' }) changeEvent!: EventEmitter<SlChangeEvent<T | undefined>>;
+
+  /** Whether the text field is disabled; when set no interaction is possible. */
+  @property({ type: Boolean, reflect: true }) override disabled?: boolean;
 
   /** @internal Emits when the component gains focus. */
   @event({ name: 'sl-focus' }) focusEvent!: EventEmitter<SlFocusEvent>;
@@ -56,15 +65,10 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
   input!: HTMLInputElement;
 
   /**
-   * Specifies which type of data the browser can use to pre-fill the input.
-   *
-   * NOTE: Declare the type this way so it is backwards compatible with 4.9.5,
-   * which we still use in `@sl-design-system/angular`.
+   * The size attribute of the input element.
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size
    */
-  @property() autocomplete?: typeof HTMLInputElement.prototype.autocomplete;
-
-  /** Whether the text field is disabled; when set no interaction is possible. */
-  @property({ type: Boolean, reflect: true }) override disabled?: boolean;
+  @property({ type: Number, attribute: 'input-size', reflect: true }) inputSize?: number;
 
   /** Maximum length (number of characters). */
   @property({ type: Number, attribute: 'maxlength' }) maxLength?: number;
@@ -72,17 +76,14 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
   /** Minimum length (number of characters). */
   @property({ type: Number, attribute: 'minlength' }) minLength?: number;
 
-  /**
-   * The size attribute of the input element.
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size
-   */
-  @property({ type: Number, attribute: 'input-size', reflect: true }) inputSize?: number;
-
   /** This will validate the value of the input using the given pattern. */
   @property() pattern?: string;
 
   /** Placeholder text in the input. */
   @property() placeholder?: string;
+
+  /** The raw (string) value of the input. */
+  @state() rawValue = '';
 
   /** Whether you can interact with the input or if it is just a static, readonly display. */
   @property({ type: Boolean, reflect: true }) readonly?: boolean;
@@ -102,8 +103,15 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
    */
   @property() type: 'email' | 'number' | 'tel' | 'text' | 'url' | 'password' = 'text';
 
-  /** The value for the input, to be used in forms. */
-  @property() override value?: T;
+  override get value(): T | undefined {
+    return this.#value;
+  }
+
+  /** The value of the text field. */
+  @property()
+  override set value(value: T | undefined) {
+    this.#value = value;
+  }
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -146,8 +154,12 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
       setTimeout(() => this.updateValidity());
     }
 
-    if (changes.has('value') && this.value?.toString() !== this.input.value) {
-      this.setInputValue(this.value);
+    if (changes.has('value')) {
+      const formattedValue = this.formatValue(this.value);
+
+      if (this.input.value !== formattedValue) {
+        this.input.value = this.formatValue(this.value);
+      }
     }
   }
 
@@ -193,16 +205,16 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
    * Method that converts the string value in the input to the specified type T. Override this method
    * if you want to convert the value in a different way.
    */
-  getInputValue(): T | undefined {
-    return this.input.value as unknown as T;
+  parseValue(value: string): T | undefined {
+    return value as unknown as T;
   }
 
   /**
    * Method that formats the value and set's it on the native input element. Override this method
    * if you want to format the value in a different way.
    */
-  setInputValue(value?: T): void {
-    this.input.value = value?.toString() || '';
+  formatValue(value?: T): string {
+    return value?.toString() || '';
   }
 
   override focus(): void {
@@ -214,9 +226,17 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
     this.updateState({ touched: true });
   }
 
-  #onInput(): void {
-    this.value = this.getInputValue();
-    this.changeEvent.emit(this.value);
+  #onInput({ target }: Event & { target: HTMLInputElement }): void {
+    this.rawValue = target.value;
+
+    try {
+      // Try to parse the value, but do nothing if it fails
+      this.value = this.parseValue(this.rawValue);
+      this.changeEvent.emit(this.value);
+    } catch {
+      /* empty */
+    }
+
     this.updateState({ dirty: true });
     this.updateValidity();
   }

--- a/packages/components/text-field/src/text-field.ts
+++ b/packages/components/text-field/src/text-field.ts
@@ -203,7 +203,7 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
 
   /**
    * Method that converts the string value in the input to the specified type T. Override this method
-   * if you want to convert the value in a different way.
+   * if you want to convert the value in a different way. Throw an error if the value is invalid.
    */
   parseValue(value: string): T | undefined {
     return value as unknown as T;


### PR DESCRIPTION
- Use `T extends { toString(): string } = string` type for `TextField`
- Add `parseValue` method that converts the raw value to the given type (or throw an Error if it cannot be parsed)
- Add `formatValue` method to format a value for display in the input