### PR TITLE
Minor dialog fixes

### DIFF
--- a/.changeset/old-berries-lay.md
+++ b/.changeset/old-berries-lay.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/dialog': patch
+---
+
+Remove any margin on the slotted (sub)title
+
+This fixes the use of a heading element (`<h1>` for example) as the dialog (sub)title: heading elements by default have block margins.

--- a/packages/components/dialog/src/dialog.scss
+++ b/packages/components/dialog/src/dialog.scss
@@ -82,11 +82,13 @@ dialog[open]:not([closing]) {
 
 slot[name='title']::slotted(*) {
   font: var(--_title-font);
+  margin: 0;
   text-wrap: balance;
 }
 
 slot[name='subtitle']::slotted(*) {
   font: var(--_subtitle-font);
+  margin: 0;
 }
 
 slot[name='header-actions'] sl-button-bar {

--- a/packages/components/dialog/src/dialog.stories.ts
+++ b/packages/components/dialog/src/dialog.stories.ts
@@ -54,8 +54,8 @@ export default {
       </style>
       <sl-button fill="outline" size="md" @click=${onClick}>Show Dialog</sl-button>
       <sl-dialog ?close-button=${closeButton} ?disable-cancel=${disableCancel}>
-        <span slot="title">${title}</span>
-        ${subtitle ? html`<span slot="subtitle">${subtitle}</span>` : nothing} ${body}
+        <h1 slot="title">${title}</h1>
+        ${subtitle ? html`<h2 slot="subtitle">${subtitle}</h2>` : nothing} ${body}
         ${headerButtons ? headerButtons(args) : nothing}
         ${footerButtons
           ? footerButtons(args)

--- a/packages/tokens/src/core.json
+++ b/packages/tokens/src/core.json
@@ -1058,32 +1058,34 @@
           "paddingTop": {
             "value": "{space.xl}",
             "type": "spacing",
-            "description": "space.button.solid.block.md"
+            "description": "space.dialog.desktop.container.paddingTop"
           },
           "inline": {
             "value": "{space.xl}",
             "type": "spacing",
-            "description": "space.button.solid.block.md"
+            "description": "space.dialog.desktop.container.inline"
           },
           "paddingBottom": {
             "value": "{space.xl}",
             "type": "spacing",
-            "description": "space.button.solid.block.md"
+            "description": "space.dialog.desktop.container.paddingBottom"
           }
         },
         "body": {
           "block": {
-            "value": "{space.2xl}",
+            "value": "{space.xl}",
             "type": "spacing",
-            "description": "space.button.solid.block.md"
+            "description": "space.dialog.desktop.body.block"
           },
           "inline": {
-            "value": "{space.2xl}",
-            "type": "spacing"
+            "value": "{space.xl}",
+            "type": "spacing",
+            "description": "space.dialog.desktop.body.inline"
           },
           "gap": {
-            "value": "{space.2xl}",
-            "type": "spacing"
+            "value": "{space.xl}",
+            "type": "spacing",
+            "description": "space.dialog.desktop.body.gap"
           }
         }
       },
@@ -1107,17 +1109,17 @@
         },
         "body": {
           "block": {
-            "value": "{space.xl}",
+            "value": "{space.lg}",
             "type": "spacing",
             "description": "space.button.solid.block.md"
           },
           "inline": {
-            "value": "{space.xl}",
+            "value": "{space.lg}",
             "type": "spacing",
             "description": "space.button.solid.block.md"
           },
           "gap": {
-            "value": "{space.xl}",
+            "value": "{space.lg}",
             "type": "spacing",
             "description": "space.button.solid.block.md"
           }


### PR DESCRIPTION
- Reset the `margin` on elements in the (sub)title slots
- Use `<h1>` and `<h2>` in the storybook dialog examples
- Reduce the padding in dialogs from 30px to 24px for desktop and from 24px to 16px on mobile