### PR TITLE
Move grid to a toplevel category in Storybook

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -36,7 +36,7 @@ export const Stable = styled(Status)(({ theme }) => ({
 
 const SYSTEM_TAGS = ['dev', 'autodocs', 'test'];
 
-const findComponentTags = (stories: LeafEntry[]) => {
+const findComponentTags = (stories: LeafEntry[] = []) => {
   const allTags = stories.flatMap((story) => story?.tags ?? []);
   const tagToCount = allTags.reduce(
     (acc, tag) => {
@@ -45,6 +45,7 @@ const findComponentTags = (stories: LeafEntry[]) => {
     },
     {} as Record<string, number>
   );
+
   return Object.entries(tagToCount)
     .filter(([tag, count]) => count === stories.length && !SYSTEM_TAGS.includes(tag))
     .map(([tag]) => tag);
@@ -55,9 +56,9 @@ addons.setConfig({
   theme: slTheme,
   sidebar: {
     renderLabel: (item: HashEntry, api: API) => {
-      if (item.type !== 'component') return item.name;
+      if (item.depth !== 1 || item.type === 'docs') return item.name;
 
-      const tags = findComponentTags(item.children.map((childId) => api.getData(childId)));
+      const tags = findComponentTags(item.children?.map(id => api.getData(id)).filter(({ type }) => type === 'story'));
       if (tags.length) {
         const tag = tags[0];
 
@@ -76,6 +77,6 @@ addons.setConfig({
       } else {
         return item.name;
       }
-    },
+    }
   }
 });

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -67,7 +67,7 @@ const preview: Preview = {
     options: {
       storySort: {
         method: 'alphabetical',
-        order: ['', 'Getting started', 'Components', 'Form', ['Examples'], 'Layout', 'Overlay']
+        order: ['', 'Getting started']
       }
     },
     viewport: {

--- a/packages/components/grid/src/stories/basics.stories.ts
+++ b/packages/components/grid/src/stories/basics.stories.ts
@@ -10,7 +10,8 @@ import { type GridColumnDataRenderer } from '../column.js';
 type Story = StoryObj;
 
 export default {
-  title: 'Layout/Grid/Basics',
+  title: 'Grid/Basics',
+  tags: ['draft'],
   parameters: {
     // Disables Chromatic's snapshotting on a story level
     chromatic: { disableSnapshot: true }

--- a/packages/components/grid/src/stories/drag-and-drop.stories.ts
+++ b/packages/components/grid/src/stories/drag-and-drop.stories.ts
@@ -8,7 +8,8 @@ import { type GridDropFilter, type SlDropEvent } from '../grid.js';
 type Story = StoryObj;
 
 export default {
-  title: 'Layout/Grid/Drag and drop',
+  title: 'Grid/Drag and drop',
+  tags: ['draft'],
   parameters: {
     // Disables Chromatic's snapshotting on a story level
     chromatic: { disableSnapshot: true }

--- a/packages/components/grid/src/stories/editing.stories.ts
+++ b/packages/components/grid/src/stories/editing.stories.ts
@@ -6,7 +6,8 @@ import '../../register.js';
 type Story = StoryObj;
 
 export default {
-  title: 'Layout/Grid/Editing',
+  title: 'Grid/Editing',
+  tags: ['draft'],
   loaders: [async () => ({ people: (await getPeople()).people })],
   parameters: {
     // Disables Chromatic's snapshotting on a story level

--- a/packages/components/grid/src/stories/filtering.stories.ts
+++ b/packages/components/grid/src/stories/filtering.stories.ts
@@ -9,7 +9,8 @@ import '../../register.js';
 type Story = StoryObj;
 
 export default {
-  title: 'Layout/Grid/Filtering',
+  title: 'Grid/Filtering',
+  tags: ['draft'],
   loaders: [async () => ({ people: (await getPeople()).people })],
   parameters: {
     // Disables Chromatic's snapshotting on a story level

--- a/packages/components/grid/src/stories/grouping.stories.ts
+++ b/packages/components/grid/src/stories/grouping.stories.ts
@@ -11,7 +11,8 @@ import { type GridViewModelGroup } from '../view-model.js';
 type Story = StoryObj;
 
 export default {
-  title: 'Layout/Grid/Grouping',
+  title: 'Grid/Grouping',
+  tags: ['draft'],
   parameters: {
     // Disables Chromatic's snapshotting on a story level
     chromatic: { disableSnapshot: true }

--- a/packages/components/grid/src/stories/scrolling.stories.ts
+++ b/packages/components/grid/src/stories/scrolling.stories.ts
@@ -7,7 +7,8 @@ import '../../register.js';
 type Story = StoryObj;
 
 export default {
-  title: 'Layout/Grid/Scrolling',
+  title: 'Grid/Scrolling',
+  tags: ['draft'],
   parameters: {
     // Disables Chromatic's snapshotting on a story level
     chromatic: { disableSnapshot: true }

--- a/packages/components/grid/src/stories/selection.stories.ts
+++ b/packages/components/grid/src/stories/selection.stories.ts
@@ -10,7 +10,8 @@ import { type SlActiveItemChangeEvent } from '../grid.js';
 type Story = StoryObj;
 
 export default {
-  title: 'Layout/Grid/Selection',
+  title: 'Grid/Selection',
+  tags: ['draft'],
   parameters: {
     // Disables Chromatic's snapshotting on a story level
     chromatic: { disableSnapshot: true }

--- a/packages/components/grid/src/stories/sorting.stories.ts
+++ b/packages/components/grid/src/stories/sorting.stories.ts
@@ -8,7 +8,8 @@ import '../../register.js';
 type Story = StoryObj;
 
 export default {
-  title: 'Layout/Grid/Sorting',
+  title: 'Grid/Sorting',
+  tags: ['draft'],
   loaders: [async () => ({ people: (await getPeople()).people })],
   parameters: {
     // Disables Chromatic's snapshotting on a story level

--- a/packages/components/grid/src/stories/styling.stories.ts
+++ b/packages/components/grid/src/stories/styling.stories.ts
@@ -12,7 +12,8 @@ export interface PersonWithRating extends Person {
 }
 
 export default {
-  title: 'Layout/Grid/Styling',
+  title: 'Grid/Styling',
+  tags: ['draft'],
   parameters: {
     // Disables Chromatic's snapshotting on a story level
     chromatic: { disableSnapshot: true }


### PR DESCRIPTION
Also makes it possible to mark different parts of grid draft/preview/stable.