### PR TITLE
Add proper tooltip cleanup

### DIFF
--- a/.changeset/lovely-cars-teach.md
+++ b/.changeset/lovely-cars-teach.md
@@ -1,0 +1,8 @@
+---
+'@sl-design-system/toggle-button': patch
+'@sl-design-system/breadcrumbs': patch
+'@sl-design-system/tooltip': patch
+'@sl-design-system/angular': patch
+---
+
+Add proper tooltip cleanup

--- a/packages/angular/src/tooltip.directive.ts
+++ b/packages/angular/src/tooltip.directive.ts
@@ -7,27 +7,32 @@ import '@sl-design-system/tooltip/register.js';
   standalone: true
 })
 export class TooltipDirective implements AfterViewInit, OnChanges, OnDestroy {
-  private tooltip?: Tooltip;
+  private tooltip?: Tooltip | (() => void);
 
   @Input() slTooltip = '';
 
   constructor(private elRef: ElementRef<HTMLElement>) {}
 
   ngOnChanges(): void {
-    if (this.tooltip) {
+    if (this.tooltip instanceof Tooltip) {
       this.tooltip.textContent = this.slTooltip;
     }
   }
 
   ngAfterViewInit(): void {
-    Tooltip.lazy(this.elRef.nativeElement, tooltip => {
+    this.tooltip = Tooltip.lazy(this.elRef.nativeElement, tooltip => {
       this.tooltip = tooltip;
       tooltip.textContent = this.slTooltip;
     });
   }
 
   ngOnDestroy(): void {
-    this.tooltip?.remove();
-    this.tooltip = undefined;
+    if (this.tooltip instanceof Tooltip) {
+      this.tooltip?.remove();
+      this.tooltip = undefined;
+    } else if (this.tooltip) {
+      this.tooltip();
+      this.tooltip = undefined;
+    }
   }
 }

--- a/packages/components/tooltip/src/tooltip-directive.ts
+++ b/packages/components/tooltip/src/tooltip-directive.ts
@@ -1,43 +1,52 @@
 import { render } from 'lit';
-import { Directive, type DirectiveParameters, type ElementPart, directive } from 'lit/directive.js';
+import { AsyncDirective } from 'lit/async-directive.js';
+import { type DirectiveParameters, type ElementPart, directive } from 'lit/directive.js';
 import { Tooltip } from './tooltip.js';
 
-export class TooltipDirective extends Directive {
+export class TooltipDirective extends AsyncDirective {
   content?: unknown;
-  didSetupLazy = false;
   part?: ElementPart;
-  tooltip?: Tooltip;
+  tooltip?: Tooltip | (() => void);
+
+  override disconnected(): void {
+    if (this.tooltip instanceof Tooltip) {
+      this.tooltip.remove();
+    } else if (this.tooltip) {
+      this.tooltip();
+    }
+
+    this.tooltip = undefined;
+  }
+
+  override reconnected(): void {
+    this.#setup();
+  }
 
   render(_content: unknown): void {}
 
   renderContent(): void {
-    render(this.content, this.tooltip!, this.part!.options);
+    render(this.content, this.tooltip as Tooltip, this.part!.options);
   }
 
   override update(part: ElementPart, [content]: DirectiveParameters<this>): void {
     this.content = content;
     this.part = part;
 
-    if (!this.didSetupLazy) {
-      this.setupLazy();
-    }
-
-    if (this.tooltip) {
-      this.renderContent();
-    }
+    this.#setup();
   }
 
-  /** @ignore */
-  setupLazy(): void {
-    this.didSetupLazy = true;
-
-    Tooltip.lazy(
+  #setup(): void {
+    this.tooltip ||= Tooltip.lazy(
       this.part!.element,
       tooltip => {
-        this.tooltip = tooltip;
-        this.renderContent();
+        if (this.isConnected) {
+          this.tooltip = tooltip;
+          this.renderContent();
+        }
       },
-      { context: this.part!.element.shadowRoot ?? document }
+      {
+        context: this.part!.element.shadowRoot ?? document
+      }
     );
   }
 }


### PR DESCRIPTION
This uses the new cleanup function that is returned from `Tooltip.lazy` to properly cleanup anything added by the tooltip code.