### PR TITLE
Disable `lit-a11y/anchor-is-valid` rule for now

### DIFF
--- a/.changeset/lemon-masks-rest.md
+++ b/.changeset/lemon-masks-rest.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/eslint-config': patch
+---
+
+Disable `lit-a11y/anchor-is-valid` rule for now

--- a/tools/eslint-config/index.js
+++ b/tools/eslint-config/index.js
@@ -51,7 +51,9 @@ export default tseslint.config(
   {
     plugins: { 'lit-a11y': litA11y },
     rules: {
-      ...litA11y.configs.recommended.rules
+      ...litA11y.configs.recommended.rules,
+      // https://github.com/open-wc/open-wc/issues/2814
+      'lit-a11y/anchor-is-valid': 'off',
     }
   },
   {


### PR DESCRIPTION
If you are using the `href` *property* instead of the attribute, then `anchor-is-valid` will mark that as incorrect. It doesn't matter if you use the attribute or the property. The value of the property is automatically reflected in the attribute.