### PR TITLE
Fix regression in filter-column with text mode

### DIFF
--- a/packages/components/grid/src/filter-column.spec.ts
+++ b/packages/components/grid/src/filter-column.spec.ts
@@ -1,5 +1,6 @@
 import { setupIgnoreWindowResizeObserverLoopErrors } from '@lit-labs/virtualizer/support/resize-observer-errors.js';
 import { expect, fixture } from '@open-wc/testing';
+import { type TextField } from '@sl-design-system/text-field';
 import { html } from 'lit';
 import '../register.js';
 import { type Grid } from './grid.js';
@@ -269,7 +270,7 @@ describe('sl-grid-filter-column', () => {
     beforeEach(async () => {
       el = await fixture(html`
         <sl-grid .items=${ITEMS}>
-          <sl-grid-filter-column mode="text" path="profession" value="Endocrinologist"></sl-grid-filter-column>
+          <sl-grid-filter-column mode="text" path="profession" value="Endo"></sl-grid-filter-column>
           <sl-grid-filter-column mode="text" path="status"></sl-grid-filter-column>
           <sl-grid-filter-column mode="text" path="membership"></sl-grid-filter-column>
         </sl-grid>
@@ -282,15 +283,28 @@ describe('sl-grid-filter-column', () => {
     });
 
     it('should have text field', () => {
-      const filters = el.renderRoot.querySelectorAll('sl-grid-filter'),
-        popovers = Array.from(filters).map(o => o.renderRoot.querySelector('sl-popover'));
-
-      expect(popovers).to.exist;
-
-      const textFields = Array.from(popovers).map(o => o!.querySelector('sl-text-field'));
+      const textFields = Array.from(el.renderRoot.querySelectorAll('sl-grid-filter')).map(f =>
+        f.renderRoot.querySelector('sl-popover sl-text-field')
+      ) as TextField[];
 
       expect(textFields).to.exist;
       expect(textFields).to.have.length(3);
+    });
+
+    it('should have proper value in the text field', () => {
+      const textFields = Array.from(el.renderRoot.querySelectorAll('sl-grid-filter')).map(f =>
+        f.renderRoot.querySelector('sl-popover sl-text-field')
+      ) as TextField[];
+
+      expect(textFields).to.exist;
+      expect(textFields.map(t => t.value)).to.deep.equal(['Endo', '', '']);
+    });
+
+    it('should partially match the value in the text field', () => {
+      const rows = Array.from(el.renderRoot.querySelectorAll('tbody td[part~="profession"]'));
+
+      expect(rows).to.have.length(1);
+      expect(rows.map(r => r.textContent)).to.deep.equal(['Endocrinologist']);
     });
   });
 });

--- a/packages/components/grid/src/filter.ts
+++ b/packages/components/grid/src/filter.ts
@@ -7,7 +7,7 @@ import { Checkbox, CheckboxGroup } from '@sl-design-system/checkbox';
 import { type DataSourceFilterFunction } from '@sl-design-system/data-source';
 import { Icon } from '@sl-design-system/icon';
 import { Popover } from '@sl-design-system/popover';
-import { type EventEmitter, event, getNameByPath } from '@sl-design-system/shared';
+import { type EventEmitter, event, getNameByPath, getValueByPath } from '@sl-design-system/shared';
 import { type SlChangeEvent } from '@sl-design-system/shared/events.js';
 import { TextField } from '@sl-design-system/text-field';
 import { type CSSResultGroup, LitElement, type TemplateResult, html } from 'lit';
@@ -106,6 +106,18 @@ export class GridFilter<T = any> extends ScopedElementsMixin(LitElement) {
 
   override connectedCallback(): void {
     super.connectedCallback();
+
+    if (this.mode === 'text' && !this.filter) {
+      this.filter = item => {
+        const itemValue = getValueByPath(item, this.column.path);
+
+        if (typeof itemValue !== 'string') {
+          return false;
+        }
+
+        return itemValue.toLowerCase().includes((this.value?.toString() ?? '').toLowerCase());
+      };
+    }
 
     this.filterChangeEvent.emit('added');
   }

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -758,8 +758,8 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
       const id = f.column.id,
         empty = (Array.isArray(f.value) && f.value.length === 0) || !f.value;
 
-      if (!empty && (f.path || f.filter)) {
-        this.dataSource?.addFilter(id, f.path! || f.filter!, f.value);
+      if (!empty && (f.filter || f.path)) {
+        this.dataSource?.addFilter(id, f.filter! || f.path!, f.value);
       } else {
         this.dataSource?.removeFilter(id);
       }


### PR DESCRIPTION
The #1575 PR broke partial matching for `<sl-grid-filter-column mode="text">`. This PR fixes that.