### PR TITLE
Improve form integration

### DIFF
--- a/.changeset/chilly-coins-attack.md
+++ b/.changeset/chilly-coins-attack.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/text-field': minor
+---
+
+Improve implicit form submit behavior
+
+Previously when you pressed enter in a text field, it would call `requestSubmit()` on the associated `<form>` element. This mimics the behavior of the native `<input>` element. With this change, the behavior now also works if there is only a parent `<sl-form>` element. If both `<form>` and `<sl-form>` elements are present, then the `<form>` element will take precedence. This makes it a minor change.

--- a/.changeset/hot-impalas-exercise.md
+++ b/.changeset/hot-impalas-exercise.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/button': minor
+---
+
+Improve form integration behavior
+
+Previously, if you had an `<sl-button>` with `type` `reset` or `submit`, it would call the `<form>`'s `reset()` or `requestSubmit()` methods. With this change, the same behavior now works if you only have an `<sl-form>` element as the parent. If both `<form>` and `<sl-form>` elements are present, then the `<form>` element will take precedence. This makes it a minor change.

--- a/.changeset/soft-needles-tan.md
+++ b/.changeset/soft-needles-tan.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/shared': minor
+---
+
+Add new `closestElementComposed` DOM utility method
+
+This new utility method is a wrapper around `HTMLElement.prototype.closest` that also considers the composed tree. This makes it easier to find the closest ancestor that matches a given selector, even if the element is in a shadow tree.

--- a/.changeset/ten-lies-drive.md
+++ b/.changeset/ten-lies-drive.md
@@ -1,0 +1,8 @@
+---
+'@sl-design-system/form': minor
+---
+
+Improve reset and submit behavior:
+- Add new `requestSubmit()` method on `<sl-form>`
+- Add `sl-reset` and `sl-submit` events on `<sl-form>`
+- Fix bug where resetting a form did not clear the validation messages

--- a/packages/components/button/src/button.spec.ts
+++ b/packages/components/button/src/button.spec.ts
@@ -1,4 +1,6 @@
 import { expect, fixture } from '@open-wc/testing';
+import { type Form } from '@sl-design-system/form';
+import '@sl-design-system/form/register.js';
 import { a11ySnapshot, sendKeys } from '@web/test-runner-commands';
 import { html } from 'lit';
 import { restore, spy, stub } from 'sinon';
@@ -153,6 +155,36 @@ describe('sl-button', () => {
   });
 
   describe('form integration', () => {
+    it('should call reset() on the parent form when the button type is reset', async () => {
+      const form: Form = await fixture(html`
+        <sl-form>
+          <sl-button type="reset">Button</sl-button>
+        </sl-form>
+      `);
+
+      spy(form, 'reset');
+
+      form.querySelector('sl-button')?.click();
+
+      expect(form.reset).to.have.been.calledOnce;
+    });
+
+    it('should call requestSubmit() on the parent form when the button type is submit', async () => {
+      const form: Form = await fixture(html`
+        <sl-form>
+          <sl-button type="submit">Button</sl-button>
+        </sl-form>
+      `);
+
+      spy(form, 'requestSubmit');
+
+      form.querySelector('sl-button')?.click();
+
+      expect(form.requestSubmit).to.have.been.calledOnce;
+    });
+  });
+
+  describe('native form integration', () => {
     let form: HTMLFormElement;
 
     const setup = async (type: ButtonType): Promise<void> => {

--- a/packages/components/button/src/button.ts
+++ b/packages/components/button/src/button.ts
@@ -1,4 +1,4 @@
-import { EventsController } from '@sl-design-system/shared';
+import { EventsController, closestElementComposed } from '@sl-design-system/shared';
 import { type CSSResultGroup, LitElement, type PropertyValues, type TemplateResult, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import styles from './button.scss.js';
@@ -86,9 +86,19 @@ export class Button extends LitElement {
       event.preventDefault();
       event.stopPropagation();
     } else if (this.type === 'reset') {
-      this.internals.form?.reset();
+      if (this.internals.form) {
+        this.internals.form.reset();
+      } else {
+        // Workaround for not wanting a dependency on the `@sl-design-system/form` package
+        (closestElementComposed(this, 'sl-form') as unknown as { reset(): void })?.reset();
+      }
     } else if (this.type === 'submit') {
-      this.internals.form?.requestSubmit();
+      if (this.internals.form) {
+        this.internals.form?.requestSubmit();
+      } else {
+        // Workaround for not wanting a dependency on the `@sl-design-system/form` package
+        (closestElementComposed(this, 'sl-form') as unknown as { requestSubmit(): void })?.requestSubmit();
+      }
     }
   }
 

--- a/packages/components/form/src/examples.stories.ts
+++ b/packages/components/form/src/examples.stories.ts
@@ -14,7 +14,7 @@ import '@sl-design-system/text-area/register.js';
 import '@sl-design-system/text-field/register.js';
 import { type StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
-import { type Form } from './form.js';
+import { type SlSubmitEvent } from './form.js';
 
 type Story = StoryObj;
 
@@ -24,18 +24,14 @@ export default {
 
 export const LogIn: Story = {
   render: () => {
-    const onSubmit = (event: Event & { target: HTMLElement }): void => {
-      const form = event.target.closest('sl-form') as Form;
+    const onReset = (): void => console.log('Form has been reset');
 
-      console.log(form.reportValidity(), form.value);
-    };
-
-    const onReset = (event: Event & { target: HTMLElement }): void => {
-      (event.target.closest('sl-form') as Form).reset();
+    const onSubmit = (event: SlSubmitEvent): void => {
+      console.log('submit', event.target.value);
     };
 
     return html`
-      <sl-form>
+      <sl-form @sl-reset=${onReset} @sl-submit=${onSubmit}>
         <sl-form-field label="Username">
           <sl-text-field
             name="username"
@@ -54,8 +50,8 @@ export const LogIn: Story = {
 
         <sl-button-bar align="end">
           <sl-button fill="link" style="margin-inline-end:auto">Forgot password?</sl-button>
-          <sl-button @click=${onReset} fill="outline" variant="primary">Reset</sl-button>
-          <sl-button @click=${onSubmit} variant="primary">Log in</sl-button>
+          <sl-button fill="outline" type="reset" variant="primary">Reset</sl-button>
+          <sl-button type="submit" variant="primary">Log in</sl-button>
         </sl-button-bar>
       </sl-form>
     `;

--- a/packages/components/form/src/form-control-mixin.ts
+++ b/packages/components/form/src/form-control-mixin.ts
@@ -335,7 +335,13 @@ export function FormControlMixin<T extends Constructor<ReactiveElement>>(constru
     }
 
     reset(value: unknown): void {
+      this.dirty = false;
       this.formValue = value;
+      this.report = false;
+      this.showValidity = undefined;
+      this.touched = false;
+
+      this.updateValidity();
     }
 
     /**

--- a/packages/components/form/src/form.spec.ts
+++ b/packages/components/form/src/form.spec.ts
@@ -173,6 +173,22 @@ describe('sl-form', () => {
       expect(el.touched).to.be.true;
       expect(el.untouched).to.be.false;
     });
+
+    it('should emit an sl-submit event when requestSubmit() is called and the form is valid', async () => {
+      const onSubmit = spy();
+
+      el.addEventListener('sl-submit', onSubmit);
+      el.requestSubmit();
+
+      expect(onSubmit).to.not.have.been.calledOnce;
+
+      el.querySelector<HTMLElement>('sl-text-field[name="bar"]')?.focus();
+      await sendKeys({ type: 'asdf' });
+
+      el.requestSubmit();
+
+      expect(onSubmit).to.have.been.calledOnce;
+    });
   });
 
   describe('reset', () => {
@@ -209,6 +225,15 @@ describe('sl-form', () => {
       el.reset();
 
       expect(el.value).to.deep.equal({ foo: 'lorem', bar: '' });
+    });
+
+    it('should emit an sl-reset event when reset() is called', () => {
+      const onReset = spy();
+
+      el.addEventListener('sl-reset', onReset);
+      el.reset();
+
+      expect(onReset).to.have.been.calledOnce;
     });
   });
 

--- a/packages/components/shared/src/dom.ts
+++ b/packages/components/shared/src/dom.ts
@@ -12,3 +12,24 @@ export const getScrollParent = (element: Element): Element => {
     return element;
   }
 };
+
+export function closestElementComposed<K extends keyof HTMLElementTagNameMap>(
+  element: Node,
+  selector: K
+): HTMLElementTagNameMap[K] | null;
+
+export function closestElementComposed<E extends Element = Element>(element: Node, selector: string): E | null;
+
+/**
+ * Returns the closest element that matches the selector, across all
+ * parent shadow roots.
+ */
+export function closestElementComposed(element: Node, selector: string): Element | null {
+  if (element instanceof HTMLElement) {
+    const found = element.closest(selector);
+
+    return found ?? closestElementComposed(element.getRootNode({ composed: true }), selector);
+  } else {
+    return null;
+  }
+}

--- a/packages/components/text-field/src/text-field.spec.ts
+++ b/packages/components/text-field/src/text-field.spec.ts
@@ -429,9 +429,11 @@ describe('sl-text-field', () => {
 
       override render(): TemplateResult {
         return html`
-          <sl-form-field label="Label">
-            <sl-text-field @sl-form-control=${this.onFormControl}></sl-text-field>
-          </sl-form-field>
+          <sl-form>
+            <sl-form-field label="Label">
+              <sl-text-field @sl-form-control=${this.onFormControl}></sl-text-field>
+            </sl-form-field>
+          </sl-form>
         `;
       }
     }
@@ -458,6 +460,17 @@ describe('sl-text-field', () => {
       await el.updateComplete;
 
       expect(el.shadowRoot!.activeElement).to.equal(input);
+    });
+
+    it('should call requestSubmit after pressing Enter in the text-field', async () => {
+      const form = el.renderRoot.querySelector('sl-form')!;
+
+      spy(form, 'requestSubmit');
+
+      el.renderRoot.querySelector('input')?.focus();
+      await sendKeys({ press: 'Enter' });
+
+      expect(form.requestSubmit).to.have.been.calledOnce;
     });
   });
 

--- a/packages/components/text-field/src/text-field.ts
+++ b/packages/components/text-field/src/text-field.ts
@@ -2,7 +2,7 @@ import { localized, msg, str } from '@lit/localize';
 import { type ScopedElementsMap, ScopedElementsMixin } from '@open-wc/scoped-elements/lit-element.js';
 import { FormControlMixin } from '@sl-design-system/form';
 import { Icon } from '@sl-design-system/icon';
-import { type EventEmitter, event } from '@sl-design-system/shared';
+import { type EventEmitter, closestElementComposed, event } from '@sl-design-system/shared';
 import { type SlBlurEvent, type SlChangeEvent, type SlFocusEvent } from '@sl-design-system/shared/events.js';
 import { type CSSResultGroup, LitElement, type PropertyValues, type TemplateResult, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
@@ -265,7 +265,11 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
   #onKeydown(event: KeyboardEvent): void {
     // Simulate native behavior where pressing Enter in a text field will submit the form
     if (!this.disabled && event.key === 'Enter') {
-      this.form?.requestSubmit();
+      if (this.form) {
+        this.form.requestSubmit();
+      } else {
+        closestElementComposed(this, 'sl-form')?.requestSubmit();
+      }
     }
   }
 


### PR DESCRIPTION
- Implement reset & submit behavior in `<button>` when there is only an `<sl-form>` parent present
- Implement submit behavior in `<sl-text-field>` when there is only an `<sl-form>` parent present
- Add `sl-reset` and `sl-submit` events on `<sl-form>`
- Fix bug where resetting a form did not clear the validation messages
- Add `closestElementComposed` utility method to shared package

Fixes #1566 
