### PR TITLE
Fix/1561 switch is not correctly marked for screen reader

### DIFF
--- a/.changeset/curly-windows-yell.md
+++ b/.changeset/curly-windows-yell.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/form': patch
+---
+
+Fix of `aria-describedby` in form field when there is a hint and validation message.

--- a/.changeset/metal-lamps-crash.md
+++ b/.changeset/metal-lamps-crash.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/switch': patch
+---
+
+Fix NVDA issues, using input native element as a form control, moving aria attributes to the right control to solve accessibility issues.

--- a/.changeset/twenty-bags-hide.md
+++ b/.changeset/twenty-bags-hide.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/text-field': patch
+'@sl-design-system/text-area': patch
+'@sl-design-system/checkbox': patch
+---
+
+Fix NVDA accessibility issues: moving aria attributes to the right control.

--- a/packages/components/checkbox/src/checkbox-group.stories.ts
+++ b/packages/components/checkbox/src/checkbox-group.stories.ts
@@ -114,6 +114,18 @@ export const WithoutValues: Story = {
   }
 };
 
+export const NoLabel: Story = {
+  render: () => {
+    return html`
+      <sl-checkbox-group aria-label="Choose at least one option">
+        <sl-checkbox value="1">One</sl-checkbox>
+        <sl-checkbox value="2">Two</sl-checkbox>
+        <sl-checkbox value="3">Three</sl-checkbox>
+      </sl-checkbox-group>
+    `;
+  }
+};
+
 export const CustomValidity: Story = {
   args: {
     hint: 'This story has both builtin validation (required) and custom validation. You need to select the middle option to make the field valid. The custom validation is done by listening to the sl-validate event and setting the custom validity on the checkbox group.',

--- a/packages/components/checkbox/src/checkbox.spec.ts
+++ b/packages/components/checkbox/src/checkbox.spec.ts
@@ -123,7 +123,7 @@ describe('sl-checkbox', () => {
 
     it('should be touched after losing focus', async () => {
       el.focus();
-      input.blur();
+      el.blur();
 
       await new Promise(resolve => setTimeout(resolve));
 
@@ -135,7 +135,7 @@ describe('sl-checkbox', () => {
 
       el.addEventListener('sl-update-state', onUpdateState);
       el.focus();
-      input.blur();
+      el.blur();
 
       await new Promise(resolve => setTimeout(resolve));
 
@@ -231,7 +231,7 @@ describe('sl-checkbox', () => {
 
       el.addEventListener('sl-blur', onBlur);
       el.focus();
-      input.blur();
+      el.blur();
 
       expect(onBlur).to.have.been.calledOnce;
     });

--- a/packages/components/checkbox/src/checkbox.spec.ts
+++ b/packages/components/checkbox/src/checkbox.spec.ts
@@ -295,6 +295,23 @@ describe('sl-checkbox', () => {
     });
   });
 
+  describe('aria attributes', () => {
+    beforeEach(async () => {
+      el = await fixture(html`<sl-checkbox aria-label="my checkbox label" aria-disabled="true"></sl-checkbox>`);
+      input = el.querySelector('input')!;
+
+      // Give time to rewrite arias
+      await new Promise(resolve => setTimeout(resolve, 100));
+    });
+
+    it('should have an input with proper arias', () => {
+      expect(el).not.to.have.attribute('aria-label', 'my checkbox label');
+      expect(el).not.to.have.attribute('aria-disabled', 'true');
+      expect(input).to.have.attribute('aria-label', 'my checkbox label');
+      expect(input).to.have.attribute('aria-disabled', 'true');
+    });
+  });
+
   describe('validation', () => {
     beforeEach(async () => {
       el = await fixture(html`<sl-checkbox>Hello world</sl-checkbox>`);

--- a/packages/components/checkbox/src/checkbox.ts
+++ b/packages/components/checkbox/src/checkbox.ts
@@ -30,6 +30,11 @@ let nextUniqueId = 0;
 @localized()
 export class Checkbox<T = unknown> extends FormControlMixin(LitElement) {
   /** @internal */
+  static override get observedAttributes(): string[] {
+    return [...super.observedAttributes, 'aria-disabled', 'aria-label', 'aria-labelledby'];
+  }
+
+  /** @internal */
   static override shadowRootOptions: ShadowRootInit = { ...LitElement.shadowRootOptions, delegatesFocus: true };
 
   /** @internal */
@@ -117,6 +122,16 @@ export class Checkbox<T = unknown> extends FormControlMixin(LitElement) {
     this.setFormControlElement(this.input);
 
     this.#onLabelSlotChange();
+  }
+
+  override attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+    super.attributeChangedCallback(name, oldValue, newValue);
+
+    requestAnimationFrame(() => {
+      if (this.input && (name === 'aria-disabled' || name === 'aria-label' || name === 'aria-labelledby')) {
+        this.#updateArias();
+      }
+    });
   }
 
   override updated(changes: PropertyValues<this>): void {
@@ -257,5 +272,18 @@ export class Checkbox<T = unknown> extends FormControlMixin(LitElement) {
     input.checked = !!this.checked;
     input.indeterminate = !!this.indeterminate;
     input.setAttribute('aria-checked', this.indeterminate ? 'mixed' : this.checked ? 'true' : 'false');
+  }
+
+  #updateArias(): void {
+    if (this.input) {
+      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby'];
+      attributes.forEach(attr => {
+        const value = this.getAttribute(attr);
+        if (value !== null) {
+          this.input.setAttribute(attr, value);
+          this.removeAttribute(attr);
+        }
+      });
+    }
   }
 }

--- a/packages/components/checkbox/src/checkbox.ts
+++ b/packages/components/checkbox/src/checkbox.ts
@@ -128,8 +128,15 @@ export class Checkbox<T = unknown> extends FormControlMixin(LitElement) {
     super.attributeChangedCallback(name, oldValue, newValue);
 
     requestAnimationFrame(() => {
-      if (this.input && (name === 'aria-disabled' || name === 'aria-label' || name === 'aria-labelledby')) {
-        this.#updateArias();
+      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby'];
+      if (this.input && attributes.includes(name)) {
+        attributes.forEach(attr => {
+          const value = this.getAttribute(attr);
+          if (value !== null) {
+            this.input.setAttribute(attr, value);
+            this.removeAttribute(attr);
+          }
+        });
       }
     });
   }
@@ -179,6 +186,10 @@ export class Checkbox<T = unknown> extends FormControlMixin(LitElement) {
 
   override focus(): void {
     this.input.focus();
+  }
+
+  override blur(): void {
+    this.input.blur();
   }
 
   override getLocalizedValidationMessage(): string {
@@ -272,18 +283,5 @@ export class Checkbox<T = unknown> extends FormControlMixin(LitElement) {
     input.checked = !!this.checked;
     input.indeterminate = !!this.indeterminate;
     input.setAttribute('aria-checked', this.indeterminate ? 'mixed' : this.checked ? 'true' : 'false');
-  }
-
-  #updateArias(): void {
-    if (this.input) {
-      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby'];
-      attributes.forEach(attr => {
-        const value = this.getAttribute(attr);
-        if (value !== null) {
-          this.input.setAttribute(attr, value);
-          this.removeAttribute(attr);
-        }
-      });
-    }
   }
 }

--- a/packages/components/form/src/form-control-mixin.ts
+++ b/packages/components/form/src/form-control-mixin.ts
@@ -173,6 +173,7 @@ export function FormControlMixin<T extends Constructor<ReactiveElement>>(constru
     /** @internal */
     get formControlElement(): FormControlElement {
       if (this.#formControlElement) {
+        console.log('this.#formControlElement', this.#formControlElement);
         return this.#formControlElement;
       } else {
         throw new Error('A formControlElement must be set for the FormControlMixin to work');
@@ -193,6 +194,7 @@ export function FormControlMixin<T extends Constructor<ReactiveElement>>(constru
      * @type {`NodeListOf<HTMLLabelElement>` | null}
      */
     get labels(): NodeListOf<HTMLLabelElement> | null {
+      console.log('this.formControlElement', this.formControlElement, isNative(this.formControlElement));
       if (isNative(this.formControlElement)) {
         return this.formControlElement.labels;
       } else {

--- a/packages/components/form/src/form-control-mixin.ts
+++ b/packages/components/form/src/form-control-mixin.ts
@@ -173,7 +173,6 @@ export function FormControlMixin<T extends Constructor<ReactiveElement>>(constru
     /** @internal */
     get formControlElement(): FormControlElement {
       if (this.#formControlElement) {
-        console.log('this.#formControlElement', this.#formControlElement);
         return this.#formControlElement;
       } else {
         throw new Error('A formControlElement must be set for the FormControlMixin to work');

--- a/packages/components/form/src/form-control-mixin.ts
+++ b/packages/components/form/src/form-control-mixin.ts
@@ -194,7 +194,6 @@ export function FormControlMixin<T extends Constructor<ReactiveElement>>(constru
      * @type {`NodeListOf<HTMLLabelElement>` | null}
      */
     get labels(): NodeListOf<HTMLLabelElement> | null {
-      console.log('this.formControlElement', this.formControlElement, isNative(this.formControlElement));
       if (isNative(this.formControlElement)) {
         return this.formControlElement.labels;
       } else {

--- a/packages/components/form/src/form-field.ts
+++ b/packages/components/form/src/form-field.ts
@@ -264,6 +264,8 @@ export class FormField extends ScopedElementsMixin(LitElement) {
         this.#label.for = this.#label.mark = undefined;
       }
     }
+
+    console.log('control', this.control);
   }
 
   #onUpdateValidity(event: SlUpdateValidityEvent): void {

--- a/packages/components/form/src/form-field.ts
+++ b/packages/components/form/src/form-field.ts
@@ -122,9 +122,14 @@ export class FormField extends ScopedElementsMixin(LitElement) {
             this.append(this.#error);
           }
         } else {
+          const describedby = this.control?.formControlElement.getAttribute('aria-describedby');
+          if (describedby) {
+            const ids = describedby.split(' ').filter(id => id !== this.#error!.id);
+            this.control?.formControlElement.setAttribute('aria-describedby', ids.join(' '));
+          }
+
           this.#error?.remove();
           this.#error = undefined;
-          this.control?.formControlElement.removeAttribute('aria-describedby');
         }
       }
     }
@@ -138,9 +143,14 @@ export class FormField extends ScopedElementsMixin(LitElement) {
           this.append(this.#hint);
         }
       } else {
+        const describedby = this.control?.formControlElement.getAttribute('aria-describedby');
+        if (describedby) {
+          const ids = describedby.split(' ').filter(id => id !== this.#hint!.id);
+          this.control?.formControlElement.setAttribute('aria-describedby', ids.join(' '));
+        }
+
         this.#hint?.remove();
         this.#hint = undefined;
-        this.control?.formControlElement.removeAttribute('aria-describedby');
       }
     }
 
@@ -185,7 +195,16 @@ export class FormField extends ScopedElementsMixin(LitElement) {
       this.#error.id ||= `sl-form-field-error-${nextUniqueId++}`;
 
       if (this.control) {
-        this.control.formControlElement.setAttribute('aria-describedby', this.#error.id);
+        const describedby = this.control.formControlElement.getAttribute('aria-describedby');
+        if (describedby) {
+          const ids = describedby.split(' ');
+          if (!ids.includes(this.#error.id)) {
+            ids.push(this.#error.id);
+            this.control.formControlElement.setAttribute('aria-describedby', ids.join(' '));
+          }
+        } else {
+          this.control.formControlElement.setAttribute('aria-describedby', this.#error.id);
+        }
       }
     } else {
       this.#label = undefined;
@@ -204,7 +223,16 @@ export class FormField extends ScopedElementsMixin(LitElement) {
       this.#hint.id ||= `sl-form-field-hint-${nextUniqueId++}`;
 
       if (this.control) {
-        this.control.formControlElement.setAttribute('aria-describedby', this.#hint.id);
+        const describedby = this.control.formControlElement.getAttribute('aria-describedby');
+        if (describedby) {
+          const ids = describedby.split(' ');
+          if (!ids.includes(this.#hint.id)) {
+            ids.push(this.#hint.id);
+            this.control.formControlElement.setAttribute('aria-describedby', ids.join(' '));
+          }
+        } else {
+          this.control.formControlElement.setAttribute('aria-describedby', this.#hint.id);
+        }
       }
     } else {
       this.#label = undefined;
@@ -250,7 +278,16 @@ export class FormField extends ScopedElementsMixin(LitElement) {
       }
 
       if (this.#hint) {
-        this.control.formControlElement.setAttribute('aria-describedby', this.#hint.id);
+        const describedby = this.control.formControlElement.getAttribute('aria-describedby');
+        if (describedby) {
+          const ids = describedby.split(' ');
+          if (!ids.includes(this.#hint.id)) {
+            ids.push(this.#hint.id);
+            this.control.formControlElement.setAttribute('aria-describedby', ids.join(' '));
+          }
+        } else {
+          this.control.formControlElement.setAttribute('aria-describedby', this.#hint.id);
+        }
       }
 
       if (this.#label) {
@@ -264,8 +301,6 @@ export class FormField extends ScopedElementsMixin(LitElement) {
         this.#label.for = this.#label.mark = undefined;
       }
     }
-
-    console.log('control', this.control);
   }
 
   #onUpdateValidity(event: SlUpdateValidityEvent): void {

--- a/packages/components/paginator/src/paginator.stories.ts
+++ b/packages/components/paginator/src/paginator.stories.ts
@@ -219,7 +219,6 @@ export const WithDataSource: Story = {
           }
 
           override render(): TemplateResult {
-            console.log('datasource in example', this.dataSource);
             return html`
               <div class="pagination">
                 <sl-paginator-status .dataSource=${this.dataSource}></sl-paginator-status>

--- a/packages/components/switch/src/switch.scss
+++ b/packages/components/switch/src/switch.scss
@@ -80,10 +80,14 @@ $sizes: sm, md, lg;
   order: -1;
 }
 
+:host([no-label]) {
+  .label {
+    display: none;
+  }
+}
+
 [part='track']:focus-visible {
   outline: var(--_focus-outline);
-
-  // outline-offset: var(--_focus-outline-offset);
 }
 
 ::slotted(input) {

--- a/packages/components/switch/src/switch.scss
+++ b/packages/components/switch/src/switch.scss
@@ -80,9 +80,23 @@ $sizes: sm, md, lg;
   order: -1;
 }
 
-:host(:focus-within) .track:focus-visible {
+[part='track']:focus-visible {
   outline: var(--_focus-outline);
-  outline-offset: var(--_focus-outline-offset);
+
+  // outline-offset: var(--_focus-outline-offset);
+}
+
+::slotted(input) {
+  block-size: 1px;
+  inline-size: 1px;
+  opacity: 0;
+  outline: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+::slotted(label) {
+  cursor: pointer;
 }
 
 slot {
@@ -98,7 +112,7 @@ slot {
   padding: var(--_toggle-container-padding);
 }
 
-.track {
+[part='track'] {
   background-color: var(--_main-background-color);
   border-radius: var(--_track-radius);
   box-shadow: var(--_box-shadow);
@@ -106,6 +120,7 @@ slot {
   inline-size: var(--_toggle-width);
   outline: none;
   outline-color: transparent;
+  outline-offset: var(--_focus-outline-offset);
   padding: var(--_toggle-padding);
 
   @media (prefers-reduced-motion: no-preference) {
@@ -114,7 +129,7 @@ slot {
   }
 }
 
-.track div {
+[part='track'] div {
   background-color: var(--_handle-color);
   block-size: var(--_handle-size);
   border-radius: calc(var(--_handle-size) / 2);

--- a/packages/components/switch/src/switch.spec.ts
+++ b/packages/components/switch/src/switch.spec.ts
@@ -108,7 +108,7 @@ describe('sl-switch', () => {
 
     it('should be touched after losing focus', () => {
       el.focus();
-      input.blur();
+      el.blur();
 
       expect(el.touched).to.be.true;
     });
@@ -118,7 +118,7 @@ describe('sl-switch', () => {
 
       el.addEventListener('sl-update-state', onUpdateState);
       el.focus();
-      input.blur();
+      el.blur();
 
       await el.updateComplete;
 
@@ -170,7 +170,7 @@ describe('sl-switch', () => {
 
       el.addEventListener('sl-blur', onBlur);
       el.focus();
-      input.blur();
+      el.blur();
 
       expect(onBlur).to.have.been.calledOnce;
     });
@@ -395,7 +395,7 @@ describe('sl-switch', () => {
       beforeEach(async () => {
         form = await fixture(html`
           <form>
-            <sl-switch checked value="toggled"></sl-switch>
+            <sl-switch checked></sl-switch>
           </form>
         `);
 

--- a/packages/components/switch/src/switch.spec.ts
+++ b/packages/components/switch/src/switch.spec.ts
@@ -9,11 +9,12 @@ import '../register.js';
 import { Switch } from './switch.js';
 
 describe('sl-switch', () => {
-  let el: Switch;
+  let el: Switch, input: HTMLInputElement;
 
   describe('defaults', () => {
     beforeEach(async () => {
       el = await fixture(html`<sl-switch></sl-switch>`);
+      input = el.querySelector('input')!;
     });
 
     it('should render correctly', () => {
@@ -23,7 +24,9 @@ describe('sl-switch', () => {
     it('should not be checked', () => {
       expect(el).not.to.have.attribute('checked');
       expect(el.checked).not.to.be.true;
-      // expect(el.internals.ariaChecked).not.to.equal('true');
+      expect(input).to.have.attribute('aria-checked', 'false');
+      expect(input).not.to.match(':checked');
+      expect(input.checked).to.be.false;
     });
 
     it('should be checked when set', async () => {
@@ -31,7 +34,9 @@ describe('sl-switch', () => {
       await el.updateComplete;
 
       expect(el).to.have.attribute('checked');
-      // expect(el.internals.ariaChecked).to.equal('true');
+      expect(input).to.have.attribute('aria-checked', 'true');
+      expect(input).to.match(':checked');
+      expect(input.checked).to.be.true;
     });
 
     it('should not be disabled', () => {
@@ -103,17 +108,19 @@ describe('sl-switch', () => {
 
     it('should be touched after losing focus', () => {
       el.focus();
-      el.blur();
+      input.blur();
 
       expect(el.touched).to.be.true;
     });
 
-    it('should emit an sl-update-state event after losing focus', () => {
+    it('should emit an sl-update-state event after losing focus', async () => {
       const onUpdateState = spy();
 
       el.addEventListener('sl-update-state', onUpdateState);
       el.focus();
-      el.blur();
+      input.blur();
+
+      await el.updateComplete;
 
       expect(onUpdateState).to.have.been.calledOnce;
     });
@@ -163,7 +170,7 @@ describe('sl-switch', () => {
 
       el.addEventListener('sl-blur', onBlur);
       el.focus();
-      el.blur();
+      input.blur();
 
       expect(onBlur).to.have.been.calledOnce;
     });
@@ -203,11 +210,17 @@ describe('sl-switch', () => {
       await el.updateComplete;
 
       expect(el.checked).to.equal(true);
+      expect(input).to.have.attribute('aria-checked', 'true');
+      expect(input).to.match(':checked');
+      expect(input.checked).to.be.true;
 
       el.click();
       await el.updateComplete;
 
       expect(el.checked).to.equal(false);
+      expect(input).to.have.attribute('aria-checked', 'false');
+      expect(input).not.to.match(':checked');
+      expect(input.checked).to.be.false;
     });
 
     it('should toggle the state on Enter', async () => {
@@ -215,10 +228,16 @@ describe('sl-switch', () => {
       await sendKeys({ press: 'Enter' });
 
       expect(el.checked).to.equal(true);
+      expect(input).to.have.attribute('aria-checked', 'true');
+      expect(input).to.match(':checked');
+      expect(input.checked).to.be.true;
 
       await sendKeys({ press: 'Enter' });
 
       expect(el.checked).to.equal(false);
+      expect(input).to.have.attribute('aria-checked', 'false');
+      expect(input).not.to.match(':checked');
+      expect(input.checked).to.be.false;
     });
 
     it('should toggle the state on Space', async () => {
@@ -226,10 +245,16 @@ describe('sl-switch', () => {
       await sendKeys({ press: ' ' });
 
       expect(el.checked).to.equal(true);
+      expect(input).to.have.attribute('aria-checked', 'true');
+      expect(input).to.match(':checked');
+      expect(input.checked).to.be.true;
 
       await sendKeys({ press: ' ' });
 
       expect(el.checked).to.equal(false);
+      expect(input).to.have.attribute('aria-checked', 'false');
+      expect(input).not.to.match(':checked');
+      expect(input.checked).to.be.false;
     });
 
     it('should support custom icons', async () => {
@@ -261,6 +286,9 @@ describe('sl-switch', () => {
       el.click();
 
       expect(el.checked).not.to.equal(true);
+      expect(input).to.have.attribute('aria-checked', 'true');
+      expect(input).to.match(':checked');
+      expect(input.checked).to.be.true;
     });
 
     it('should not change the state on Enter', async () => {
@@ -268,6 +296,9 @@ describe('sl-switch', () => {
       await sendKeys({ press: 'Enter' });
 
       expect(el.checked).not.to.equal(true);
+      expect(input).to.have.attribute('aria-checked', 'true');
+      expect(input).to.match(':checked');
+      expect(input.checked).to.be.true;
     });
 
     it('should not change the state on Space', async () => {
@@ -275,6 +306,9 @@ describe('sl-switch', () => {
       await sendKeys({ press: ' ' });
 
       expect(el.checked).not.to.equal(true);
+      expect(input).to.have.attribute('aria-checked', 'true');
+      expect(input).to.match(':checked');
+      expect(input.checked).to.be.true;
     });
   });
 
@@ -285,7 +319,26 @@ describe('sl-switch', () => {
 
     it('should be on when the property is set', () => {
       expect(el.checked).to.equal(true);
-      // expect(el.internals.ariaChecked).to.equal('true');
+      expect(input).to.have.attribute('aria-checked', 'true');
+      expect(input).to.match(':checked');
+      expect(input.checked).to.be.true;
+    });
+  });
+
+  describe('aria attributes', () => {
+    beforeEach(async () => {
+      el = await fixture(html`<sl-switch checked aria-label="my label" aria-disabled="true"></sl-switch>`);
+      input = el.querySelector('input')!;
+
+      // Give time to rewrite arias
+      await new Promise(resolve => setTimeout(resolve, 100));
+    });
+
+    it('should have an input with proper arias', () => {
+      expect(el).not.to.have.attribute('aria-label', 'my label');
+      expect(el).not.to.have.attribute('aria-disabled', 'true');
+      expect(input).to.have.attribute('aria-label', 'my label');
+      expect(input).to.have.attribute('aria-disabled', 'true');
     });
   });
 
@@ -301,16 +354,28 @@ describe('sl-switch', () => {
         `);
 
         el = form.firstElementChild as Switch;
+
+        input = el.querySelector('input')!;
       });
 
-      it('should revert back to the initial state', () => {
+      it('should revert back to the initial state', async () => {
         el.click();
 
+        await el.updateComplete;
+
         expect(el.checked).to.equal(true);
+        expect(input).to.have.attribute('aria-checked', 'true');
+        expect(input).to.match(':checked');
+        expect(input.checked).to.be.true;
 
         form.reset();
 
+        await el.updateComplete;
+
         expect(el.checked).to.equal(false);
+        expect(input).to.have.attribute('aria-checked', 'false');
+        expect(input).not.to.match(':checked');
+        expect(input.checked).to.be.false;
       });
 
       it('should emit an sl-change event', async () => {
@@ -330,21 +395,33 @@ describe('sl-switch', () => {
       beforeEach(async () => {
         form = await fixture(html`
           <form>
-            <sl-switch checked></sl-switch>
+            <sl-switch checked value="toggled"></sl-switch>
           </form>
         `);
 
         el = form.firstElementChild as Switch;
+
+        input = el.querySelector('input')!;
       });
 
-      it('should revert back to the initial states', () => {
+      it('should revert back to the initial states', async () => {
         el.click();
 
+        await el.updateComplete;
+
         expect(el.checked).to.equal(false);
+        expect(input).to.have.attribute('aria-checked', 'false');
+        expect(input).not.to.match(':checked');
+        expect(input.checked).to.be.false;
 
         form.reset();
 
+        await el.updateComplete;
+
         expect(el.checked).to.equal(true);
+        expect(input).to.have.attribute('aria-checked', 'true');
+        expect(input).to.match(':checked');
+        expect(input.checked).to.be.true;
       });
 
       it('should emit an sl-change event', async () => {
@@ -397,7 +474,18 @@ describe('sl-switch', () => {
       label?.click();
       await el.updateComplete;
 
-      expect(el.shadowRoot!.activeElement).to.equal(control);
+      expect(control).to.have.attribute('checked');
+      expect(control?.checked).to.be.true;
+    });
+
+    it('should focus the input when the label is clicked', async () => {
+      const input = el.renderRoot.querySelector('input'),
+        label = el.renderRoot.querySelector('label');
+
+      label?.click();
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.activeElement).to.equal(input);
     });
 
     it('should toggle the switch when the label is clicked', async () => {
@@ -409,6 +497,9 @@ describe('sl-switch', () => {
 
       expect(control).to.have.attribute('checked');
       expect(control?.checked).to.be.true;
+      expect(input).to.have.attribute('aria-checked', 'true');
+      expect(input).to.match(':checked');
+      expect(input.checked).to.be.true;
     });
   });
 });

--- a/packages/components/switch/src/switch.spec.ts
+++ b/packages/components/switch/src/switch.spec.ts
@@ -23,7 +23,7 @@ describe('sl-switch', () => {
     it('should not be checked', () => {
       expect(el).not.to.have.attribute('checked');
       expect(el.checked).not.to.be.true;
-      expect(el.internals.ariaChecked).not.to.equal('true');
+      // expect(el.internals.ariaChecked).not.to.equal('true');
     });
 
     it('should be checked when set', async () => {
@@ -31,7 +31,7 @@ describe('sl-switch', () => {
       await el.updateComplete;
 
       expect(el).to.have.attribute('checked');
-      expect(el.internals.ariaChecked).to.equal('true');
+      // expect(el.internals.ariaChecked).to.equal('true');
     });
 
     it('should not be disabled', () => {
@@ -285,7 +285,7 @@ describe('sl-switch', () => {
 
     it('should be on when the property is set', () => {
       expect(el.checked).to.equal(true);
-      expect(el.internals.ariaChecked).to.equal('true');
+      // expect(el.internals.ariaChecked).to.equal('true');
     });
   });
 

--- a/packages/components/switch/src/switch.stories.ts
+++ b/packages/components/switch/src/switch.stories.ts
@@ -6,6 +6,7 @@ import { Icon } from '@sl-design-system/icon';
 import '@sl-design-system/icon/register.js';
 import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import '../register.js';
 import { type Switch, type SwitchSize } from './switch.js';
 
@@ -64,7 +65,7 @@ export const Empty: Story = {
       ?checked=${checked}
       ?disabled=${disabled}
       ?reverse=${reverse}
-      .size=${size}
+      size=${ifDefined(size)}
       .value=${value}
     >
       ${text}

--- a/packages/components/switch/src/switch.stories.ts
+++ b/packages/components/switch/src/switch.stories.ts
@@ -57,7 +57,19 @@ export const Disabled: Story = {
 export const Empty: Story = {
   args: {
     text: ''
-  }
+  },
+  render: ({ checked, disabled, reverse, size, text, value }) => html`
+    <sl-switch
+      aria-label="test"
+      ?checked=${checked}
+      ?disabled=${disabled}
+      ?reverse=${reverse}
+      .size=${size}
+      .value=${value}
+    >
+      ${text}
+    </sl-switch>
+  `
 };
 
 export const Overflow: Story = {

--- a/packages/components/switch/src/switch.stories.ts
+++ b/packages/components/switch/src/switch.stories.ts
@@ -60,7 +60,7 @@ export const Empty: Story = {
   },
   render: ({ checked, disabled, reverse, size, text, value }) => html`
     <sl-switch
-      aria-label="test"
+      aria-label="Switch with no label"
       ?checked=${checked}
       ?disabled=${disabled}
       ?reverse=${reverse}

--- a/packages/components/switch/src/switch.ts
+++ b/packages/components/switch/src/switch.ts
@@ -104,7 +104,7 @@ export class Switch<T = unknown> extends FormControlMixin(ScopedElementsMixin(Li
   }
 
   override set formValue(value: T | null) {
-    this.checked = value === true || value === this.value;
+    this.checked = value === this.value || (this.value === undefined && value === true);
   }
 
   override connectedCallback(): void {
@@ -167,7 +167,7 @@ export class Switch<T = unknown> extends FormControlMixin(ScopedElementsMixin(Li
   override updated(changes: PropertyValues<this>): void {
     super.updated(changes);
 
-    const props: Array<keyof Switch> = ['checked', 'disabled']; // required???
+    const props: Array<keyof Switch> = ['checked', 'disabled'];
 
     if (props.some(prop => changes.has(prop))) {
       this.#syncInput(this.input);
@@ -303,6 +303,3 @@ export class Switch<T = unknown> extends FormControlMixin(ScopedElementsMixin(Li
     }
   }
 }
-
-// TODO: unit testing
-// TODO: aria-label, aria-labelledby, aria-required and aria-disabled for textarea and text field

--- a/packages/components/switch/src/switch.ts
+++ b/packages/components/switch/src/switch.ts
@@ -99,7 +99,7 @@ export class Switch<T = unknown> extends FormControlMixin(ScopedElementsMixin(Li
   override connectedCallback(): void {
     super.connectedCallback();
 
-    this.internals.role = 'switch';
+    // this.internals.role = 'switch';
 
     this.setFormControlElement(this);
 
@@ -132,24 +132,37 @@ export class Switch<T = unknown> extends FormControlMixin(ScopedElementsMixin(Li
       this.internals.ariaChecked = this.checked ? 'true' : 'false';
     }
 
-    if (changes.has('disabled')) {
-      this.tabIndex = this.disabled ? -1 : 0;
-    }
+    // if (changes.has('disabled')) {
+    //   this.tabIndex = this.disabled ? -1 : 0;
+    // }
   }
 
   override render(): TemplateResult {
     const icon = this.checked ? this.iconOn || 'check' : this.iconOff || 'xmark',
       size = this.size === 'md' ? 'xs' : 'md';
 
+    console.log('switch', this, this.getAttribute('aria-describedby'), this.hasAttribute('aria-describedby'));
+
+    // if (this.hasAttribute('aria-describedby')) {
+    //   this.internals.ariaDescription =  this.getAttribute('aria-describedby');
+    // }
+
     return html`
-      <slot></slot>
+      <slot id="label"></slot>
       <div class="toggle">
-        <div class="track" .tabIndex=${this.disabled ? -1 : 0}>
+        <div
+          class="track"
+          role="switch"
+          .tabIndex=${this.disabled ? -1 : 0}
+          aria-checked=${this.checked ? 'true' : 'false'}
+          aria-labelledby="label"
+          aria-describedby=${this.getAttribute('aria-describedby')}
+        >
           <div>${this.size === 'sm' ? nothing : html`<sl-icon .name=${icon} .size=${size}></sl-icon>`}</div>
         </div>
       </div>
     `;
-  }
+  } // TODO: aria-disabled aria-required...
 
   #onClick(event: Event): void {
     if (this.disabled) {
@@ -187,3 +200,6 @@ export class Switch<T = unknown> extends FormControlMixin(ScopedElementsMixin(Li
     this.updateValidity();
   }
 }
+
+// TODO: what about aria-label added by a user?
+// not working with aria-describedby yet

--- a/packages/components/switch/src/switch.ts
+++ b/packages/components/switch/src/switch.ts
@@ -141,8 +141,15 @@ export class Switch<T = unknown> extends FormControlMixin(ScopedElementsMixin(Li
     super.attributeChangedCallback(name, oldValue, newValue);
 
     requestAnimationFrame(() => {
-      if (this.input && (name === 'aria-label' || name === 'aria-labelledby' || name === 'aria-disabled')) {
-        this.#updateArias();
+      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby'];
+      if (this.input && attributes.includes(name)) {
+        attributes.forEach(attr => {
+          const value = this.getAttribute(attr);
+          if (value !== null) {
+            this.input.setAttribute(attr, value);
+            this.removeAttribute(attr);
+          }
+        });
       }
     });
   }
@@ -200,6 +207,10 @@ export class Switch<T = unknown> extends FormControlMixin(ScopedElementsMixin(Li
 
   override focus(): void {
     this.input.focus();
+  }
+
+  override blur(): void {
+    this.input.blur();
   }
 
   #onClick(event: Event): void {
@@ -288,18 +299,5 @@ export class Switch<T = unknown> extends FormControlMixin(ScopedElementsMixin(Li
 
     input.checked = !!this.checked;
     input.setAttribute('aria-checked', this.checked ? 'true' : 'false');
-  }
-
-  #updateArias(): void {
-    if (this.input) {
-      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby'];
-      attributes.forEach(attr => {
-        const value = this.getAttribute(attr);
-        if (value !== null) {
-          this.input.setAttribute(attr, value);
-          this.removeAttribute(attr);
-        }
-      });
-    }
   }
 }

--- a/packages/components/text-area/src/text-area.spec.ts
+++ b/packages/components/text-area/src/text-area.spec.ts
@@ -325,6 +325,23 @@ describe('sl-text-area', () => {
     });
   });
 
+  describe('aria attributes', () => {
+    beforeEach(async () => {
+      el = await fixture(html`<sl-text-area aria-label="my label" aria-disabled="true"></sl-checkbox>`);
+      textArea = el.querySelector('textarea')!;
+
+      // Give time to rewrite arias
+      await new Promise(resolve => setTimeout(resolve, 100));
+    });
+
+    it('should have an input with proper arias', () => {
+      expect(el).not.to.have.attribute('aria-label', 'my label');
+      expect(el).not.to.have.attribute('aria-disabled', 'true');
+      expect(textArea).to.have.attribute('aria-label', 'my label');
+      expect(textArea).to.have.attribute('aria-disabled', 'true');
+    });
+  });
+
   describe('maxlength', () => {
     beforeEach(async () => {
       el = await fixture(html`<sl-text-area maxlength="3"></sl-text-area>`);

--- a/packages/components/text-area/src/text-area.stories.ts
+++ b/packages/components/text-area/src/text-area.stories.ts
@@ -215,17 +215,39 @@ export const All: StoryObj = {
         <h2>Size: ${size}</h2>
         <div class="content-wrapper">
           <div class="wrapper">
-            <sl-text-area size=${size} placeholder="Placeholder ${size}"></sl-text-area>
-            <sl-text-area size=${size} value="I am ${size}"></sl-text-area>
-            <sl-text-area readonly size=${size} value="${size} readonly"></sl-text-area>
-            <sl-text-area disabled size=${size} value="${size} disabled"></sl-text-area>
-            <sl-text-area disabled size=${size} placeholder="Placeholder ${size} disabled"></sl-text-area>
+            <sl-text-area aria-label="label" size=${size} placeholder="Placeholder ${size}"></sl-text-area>
+            <sl-text-area aria-label="label" size=${size} value="I am ${size}"></sl-text-area>
+            <sl-text-area aria-label="label" readonly size=${size} value="${size} readonly"></sl-text-area>
+            <sl-text-area aria-label="label" disabled size=${size} value="${size} disabled"></sl-text-area>
+            <sl-text-area
+              aria-label="label"
+              disabled
+              size=${size}
+              placeholder="Placeholder ${size} disabled"
+            ></sl-text-area>
           </div>
           <div class="wrapper">
-            <sl-text-area show-validity="invalid" size=${size} value="${size} invalid"></sl-text-area>
-            <sl-text-area placeholder="Placeholder ${size} invalid" show-validity="invalid" size=${size}></sl-text-area>
-            <sl-text-area disabled show-validity="invalid" size=${size} value="${size} invalid disabled"></sl-text-area>
             <sl-text-area
+              aria-label="label"
+              show-validity="invalid"
+              size=${size}
+              value="${size} invalid"
+            ></sl-text-area>
+            <sl-text-area
+              aria-label="label"
+              placeholder="Placeholder ${size} invalid"
+              show-validity="invalid"
+              size=${size}
+            ></sl-text-area>
+            <sl-text-area
+              aria-label="label"
+              disabled
+              show-validity="invalid"
+              size=${size}
+              value="${size} invalid disabled"
+            ></sl-text-area>
+            <sl-text-area
+              aria-label="label"
               disabled
               placeholder="Placeholder ${size} disabled invalid"
               size=${size}
@@ -233,8 +255,14 @@ export const All: StoryObj = {
             ></sl-text-area>
           </div>
           <div class="wrapper">
-            <sl-text-area show-validity="valid" size=${size} value="I am md valid"></sl-text-area>
-            <sl-text-area disabled show-validity="valid" size=${size} value="${size} valid disabled"></sl-text-area>
+            <sl-text-area aria-label="label" show-validity="valid" size=${size} value="I am md valid"></sl-text-area>
+            <sl-text-area
+              aria-label="label"
+              disabled
+              show-validity="valid"
+              size=${size}
+              value="${size} valid disabled"
+            ></sl-text-area>
           </div>
         </div>
       `

--- a/packages/components/text-area/src/text-area.stories.ts
+++ b/packages/components/text-area/src/text-area.stories.ts
@@ -255,7 +255,12 @@ export const All: StoryObj = {
             ></sl-text-area>
           </div>
           <div class="wrapper">
-            <sl-text-area aria-label="label" show-validity="valid" size=${size} value="I am md valid"></sl-text-area>
+            <sl-text-area
+              aria-label="label"
+              show-validity="valid"
+              size=${size}
+              value="I am ${size} valid"
+            ></sl-text-area>
             <sl-text-area
               aria-label="label"
               disabled

--- a/packages/components/text-area/src/text-area.ts
+++ b/packages/components/text-area/src/text-area.ts
@@ -83,7 +83,7 @@ export class TextArea extends FormControlMixin(ScopedElementsMixin(LitElement)) 
   /** Minimum length (number of characters). */
   @property({ type: Number, attribute: 'minlength' }) minLength?: number;
 
-  /** Placeholder text in the input. */
+  /** Placeholder text in the textarea. */
   @property() placeholder?: string;
 
   /** Whether you can interact with the textarea or if it is just a static, readonly display. */
@@ -141,11 +141,15 @@ export class TextArea extends FormControlMixin(ScopedElementsMixin(LitElement)) 
     super.attributeChangedCallback(name, oldValue, newValue);
 
     requestAnimationFrame(() => {
-      if (
-        this.textarea &&
-        (name === 'aria-disabled' || name === 'aria-label' || name === 'aria-labelledby' || name === 'aria-required')
-      ) {
-        this.#updateArias();
+      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby', 'aria-required'];
+      if (this.textarea && attributes.includes(name)) {
+        attributes.forEach(attr => {
+          const value = this.getAttribute(attr);
+          if (value !== null) {
+            this.textarea.setAttribute(attr, value);
+            this.removeAttribute(attr);
+          }
+        });
       }
     });
   }
@@ -261,19 +265,6 @@ export class TextArea extends FormControlMixin(ScopedElementsMixin(LitElement)) 
       textarea.setAttribute('minlength', this.minLength.toString());
     } else {
       textarea.removeAttribute('minlength');
-    }
-  }
-
-  #updateArias(): void {
-    if (this.textarea) {
-      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby', 'aria-required'];
-      attributes.forEach(attr => {
-        const value = this.getAttribute(attr);
-        if (value !== null) {
-          this.textarea.setAttribute(attr, value);
-          this.removeAttribute(attr);
-        }
-      });
     }
   }
 }

--- a/packages/components/text-area/src/text-area.ts
+++ b/packages/components/text-area/src/text-area.ts
@@ -31,6 +31,11 @@ let nextUniqueId = 0;
 @localized()
 export class TextArea extends FormControlMixin(ScopedElementsMixin(LitElement)) {
   /** @internal */
+  static override get observedAttributes(): string[] {
+    return [...super.observedAttributes, 'aria-disabled', 'aria-label', 'aria-labelledby', 'aria-required'];
+  }
+
+  /** @internal */
   static get scopedElements(): ScopedElementsMap {
     return {
       'sl-icon': Icon
@@ -130,6 +135,19 @@ export class TextArea extends FormControlMixin(ScopedElementsMixin(LitElement)) 
     this.#observer.disconnect();
 
     super.disconnectedCallback();
+  }
+
+  override attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+    super.attributeChangedCallback(name, oldValue, newValue);
+
+    requestAnimationFrame(() => {
+      if (
+        this.textarea &&
+        (name === 'aria-disabled' || name === 'aria-label' || name === 'aria-labelledby' || name === 'aria-required')
+      ) {
+        this.#updateArias();
+      }
+    });
   }
 
   override updated(changes: PropertyValues<this>): void {
@@ -243,6 +261,19 @@ export class TextArea extends FormControlMixin(ScopedElementsMixin(LitElement)) 
       textarea.setAttribute('minlength', this.minLength.toString());
     } else {
       textarea.removeAttribute('minlength');
+    }
+  }
+
+  #updateArias(): void {
+    if (this.textarea) {
+      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby', 'aria-required'];
+      attributes.forEach(attr => {
+        const value = this.getAttribute(attr);
+        if (value !== null) {
+          this.textarea.setAttribute(attr, value);
+          this.removeAttribute(attr);
+        }
+      });
     }
   }
 }

--- a/packages/components/text-field/src/text-field.spec.ts
+++ b/packages/components/text-field/src/text-field.spec.ts
@@ -284,6 +284,23 @@ describe('sl-text-field', () => {
     });
   });
 
+  describe('aria attributes', () => {
+    beforeEach(async () => {
+      el = await fixture(html`<sl-text-field aria-label="my label" aria-disabled="true"></sl-checkbox>`);
+      input = el.querySelector('input')!;
+
+      // Give time to rewrite arias
+      await new Promise(resolve => setTimeout(resolve, 100));
+    });
+
+    it('should have an input with proper arias', () => {
+      expect(el).not.to.have.attribute('aria-label', 'my label');
+      expect(el).not.to.have.attribute('aria-disabled', 'true');
+      expect(input).to.have.attribute('aria-label', 'my label');
+      expect(input).to.have.attribute('aria-disabled', 'true');
+    });
+  });
+
   describe('invalid', () => {
     beforeEach(async () => {
       el = await fixture(html`<sl-text-field required></sl-text-field>`);

--- a/packages/components/text-field/src/text-field.stories.ts
+++ b/packages/components/text-field/src/text-field.stories.ts
@@ -300,26 +300,39 @@ export const All: StoryObj = {
         <h2>Size: ${size}</h2>
         <div class="content-wrapper">
           <div class="wrapper">
-            <sl-text-field size=${size} placeholder="Placeholder ${size}"></sl-text-field>
-            <sl-text-field size=${size} value="I am ${size}"></sl-text-field>
-            <sl-text-field readonly size=${size} value="${size} readonly"></sl-text-field>
-            <sl-text-field disabled size=${size} value="${size} disabled"></sl-text-field>
-            <sl-text-field disabled size=${size} placeholder="Placeholder ${size} disabled"></sl-text-field>
+            <sl-text-field aria-label="label" size=${size} placeholder="Placeholder ${size}"></sl-text-field>
+            <sl-text-field aria-label="label" size=${size} value="I am ${size}"></sl-text-field>
+            <sl-text-field aria-label="label" readonly size=${size} value="${size} readonly"></sl-text-field>
+            <sl-text-field aria-label="label" disabled size=${size} value="${size} disabled"></sl-text-field>
+            <sl-text-field
+              aria-label="label"
+              disabled
+              size=${size}
+              placeholder="Placeholder ${size} disabled"
+            ></sl-text-field>
           </div>
           <div class="wrapper">
-            <sl-text-field .size=${size} show-validity="invalid" value="I am ${size} invalid"></sl-text-field>
             <sl-text-field
+              aria-label="label"
+              .size=${size}
+              show-validity="invalid"
+              value="I am ${size} invalid"
+            ></sl-text-field>
+            <sl-text-field
+              aria-label="label"
               .size=${size}
               placeholder="Placeholder ${size} invalid"
               show-validity="invalid"
             ></sl-text-field>
             <sl-text-field
+              aria-label="label"
               .size=${size}
               disabled
               show-validity="invalid"
               value="${size} invalid disabled"
             ></sl-text-field>
             <sl-text-field
+              aria-label="label"
               .size=${size}
               disabled
               placeholder="Placeholder ${size} disabled invalid"
@@ -327,8 +340,19 @@ export const All: StoryObj = {
             ></sl-text-field>
           </div>
           <div class="wrapper">
-            <sl-text-field show-validity="valid" .size=${size} value="I am ${size} valid"></sl-text-field>
-            <sl-text-field .size=${size} disabled show-validity="valid" value="${size} valid disabled"></sl-text-field>
+            <sl-text-field
+              aria-label="label"
+              show-validity="valid"
+              .size=${size}
+              value="I am ${size} valid"
+            ></sl-text-field>
+            <sl-text-field
+              aria-label="label"
+              .size=${size}
+              disabled
+              show-validity="valid"
+              value="${size} valid disabled"
+            ></sl-text-field>
           </div>
         </div>
       `

--- a/packages/components/text-field/src/text-field.ts
+++ b/packages/components/text-field/src/text-field.ts
@@ -143,11 +143,15 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
     super.attributeChangedCallback(name, oldValue, newValue);
 
     requestAnimationFrame(() => {
-      if (
-        this.input &&
-        (name === 'aria-disabled' || name === 'aria-label' || name === 'aria-labelledby' || name === 'aria-required')
-      ) {
-        this.#updateArias();
+      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby', 'aria-required'];
+      if (this.input && attributes.includes(name)) {
+        attributes.forEach(attr => {
+          const value = this.getAttribute(attr);
+          if (value !== null) {
+            this.input.setAttribute(attr, value);
+            this.removeAttribute(attr);
+          }
+        });
       }
     });
   }
@@ -305,19 +309,6 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
     this.input.addEventListener('focus', () => this.#onFocus());
     this.updateInputElement(this.input);
     this.setFormControlElement(this.input);
-  }
-
-  #updateArias(): void {
-    if (this.input) {
-      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby', 'aria-required'];
-      attributes.forEach(attr => {
-        const value = this.getAttribute(attr);
-        if (value !== null) {
-          this.input.setAttribute(attr, value);
-          this.removeAttribute(attr);
-        }
-      });
-    }
   }
 
   /** @internal Synchronize the input element with the component properties. */

--- a/packages/components/text-field/src/text-field.ts
+++ b/packages/components/text-field/src/text-field.ts
@@ -31,6 +31,11 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
   ScopedElementsMixin(LitElement)
 ) {
   /** @internal */
+  static override get observedAttributes(): string[] {
+    return [...super.observedAttributes, 'aria-disabled', 'aria-label', 'aria-labelledby', 'aria-required'];
+  }
+
+  /** @internal */
   static get scopedElements(): ScopedElementsMap {
     return {
       'sl-icon': Icon
@@ -132,6 +137,19 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
     }
 
     this.setFormControlElement(this.input);
+  }
+
+  override attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+    super.attributeChangedCallback(name, oldValue, newValue);
+
+    requestAnimationFrame(() => {
+      if (
+        this.input &&
+        (name === 'aria-disabled' || name === 'aria-label' || name === 'aria-labelledby' || name === 'aria-required')
+      ) {
+        this.#updateArias();
+      }
+    });
   }
 
   override updated(changes: PropertyValues<this>): void {
@@ -287,6 +305,19 @@ export class TextField<T extends { toString(): string } = string> extends FormCo
     this.input.addEventListener('focus', () => this.#onFocus());
     this.updateInputElement(this.input);
     this.setFormControlElement(this.input);
+  }
+
+  #updateArias(): void {
+    if (this.input) {
+      const attributes = ['aria-disabled', 'aria-label', 'aria-labelledby', 'aria-required'];
+      attributes.forEach(attr => {
+        const value = this.getAttribute(attr);
+        if (value !== null) {
+          this.input.setAttribute(attr, value);
+          this.removeAttribute(attr);
+        }
+      });
+    }
   }
 
   /** @internal Synchronize the input element with the component properties. */


### PR DESCRIPTION
Fixes:
* #1561 
  - native `input` element with `type="checkbox"` and `role="switch"`: https://www.w3.org/WAI/ARIA/apg/patterns/switch/examples/switch-checkbox/
* aria(s) fixes for NVDA:
  - switch,
  - checkbox, 
  - text-field
  - text-area
* fix of `aria-describedby` in form field when there is a hint and validation message