### PR TITLE
Added transparant token in system

### DIFF
--- a/packages/tokens/src/system.json
+++ b/packages/tokens/src/system.json
@@ -385,6 +385,10 @@
     "white": {
       "value": "#ffffff",
       "type": "color"
+    },
+    "transparant": {
+      "value": "#00000000",
+      "type": "color"
     }
   },
   "opacity": {


### PR DESCRIPTION
Added transparent color token in system. Mainly to get Figma working correctly when switching between outline and ghost buttons. Somehow it not able to know how to switch the border with correctly, but does know how to set the color. Making the border transparent helps to bypass this quirk.