### PR TITLE
Log a warning when you use `<sl-select>` without having `<sl-option>` registered

### DIFF
--- a/.changeset/floppy-tires-marry.md
+++ b/.changeset/floppy-tires-marry.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/select': patch
+---
+
+Log a warning when you use `<sl-select>` without having `<sl-option>` registered

--- a/packages/components/select/src/select.ts
+++ b/packages/components/select/src/select.ts
@@ -402,6 +402,8 @@ export class Select<T = any> extends ObserveAttributesMixin(FormControlMixin(Sco
   }
 
   #onSlotchange(): void {
+    this.#verifyRegisteredListboxElements();
+
     this.options.forEach(option => option.setAttribute('aria-selected', 'false'));
 
     if (this.value !== undefined && this.value !== null) {
@@ -480,5 +482,15 @@ export class Select<T = any> extends ObserveAttributesMixin(FormControlMixin(Sco
     );
 
     this.updateValidity();
+  }
+
+  #verifyRegisteredListboxElements(): void {
+    const option = this.querySelector('sl-option');
+
+    if (option && !(option instanceof Option)) {
+      console.warn(
+        'sl-option elements must be registered as custom elements via the @sl-design-system/listbox package'
+      );
+    }
   }
 }


### PR DESCRIPTION
Fixed #1894 