### PR TITLE
Fix `@lit-labs/lit-virtualizer` imports to not accidentally register `<lit-virtualizer>` on the global custom element registry

### DIFF
--- a/.changeset/five-cars-call.md
+++ b/.changeset/five-cars-call.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/listbox': patch
+'@sl-design-system/shared': patch
+'@sl-design-system/tree': patch
+---
+
+Fix `@lit-labs/lit-virtualizer` imports to not accidentally register `<lit-virtualizer>` on the global custom element registry

--- a/packages/components/listbox/src/listbox.ts
+++ b/packages/components/listbox/src/listbox.ts
@@ -11,6 +11,7 @@ import { Option, type OptionEmphasis } from './option.js';
 declare global {
   interface HTMLElementTagNameMap {
     'sl-listbox': Listbox;
+    'lit-virtualizer': LitVirtualizer;
   }
 
   interface ShadowRoot {

--- a/packages/components/listbox/src/listbox.ts
+++ b/packages/components/listbox/src/listbox.ts
@@ -1,4 +1,4 @@
-import { LitVirtualizer } from '@lit-labs/virtualizer';
+import { LitVirtualizer } from '@lit-labs/virtualizer/LitVirtualizer.js';
 import { type ScopedElementsMap, ScopedElementsMixin } from '@open-wc/scoped-elements/lit-element.js';
 import { type PathKeys, getStringByPath, getValueByPath } from '@sl-design-system/shared';
 import { type CSSResultGroup, LitElement, type PropertyValues, type TemplateResult, html } from 'lit';

--- a/packages/components/shared/src/controllers/focus-group.ts
+++ b/packages/components/shared/src/controllers/focus-group.ts
@@ -1,4 +1,4 @@
-import { RangeChangedEvent } from '@lit-labs/virtualizer';
+import { RangeChangedEvent } from '@lit-labs/virtualizer/events.js';
 import { type ReactiveController, type ReactiveElement } from 'lit';
 
 type DirectionTypes = 'horizontal' | 'vertical' | 'both' | 'grid';

--- a/packages/components/tree/src/tree.ts
+++ b/packages/components/tree/src/tree.ts
@@ -1,4 +1,4 @@
-import { type RangeChangedEvent } from '@lit-labs/virtualizer';
+import { type RangeChangedEvent } from '@lit-labs/virtualizer/events.js';
 import { type VirtualizerHostElement, virtualize, virtualizerRef } from '@lit-labs/virtualizer/virtualize.js';
 import { type ScopedElementsMap, ScopedElementsMixin } from '@open-wc/scoped-elements/lit-element.js';
 import { Icon } from '@sl-design-system/icon';


### PR DESCRIPTION
Fixes #1987 