### PR TITLE
Fix: Add 'overlay' to transition properties for sl-listbox

### DIFF
--- a/.changeset/eleven-beers-pump.md
+++ b/.changeset/eleven-beers-pump.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/select': patch
+---
+
+Fixes issue in chrome where the dropdown would flicker when one of its parents has a transform:translate on it.

--- a/packages/components/select/src/select.scss
+++ b/packages/components/select/src/select.scss
@@ -16,7 +16,7 @@ sl-listbox {
   @media (prefers-reduced-motion: no-preference) {
     transition: 0.2s cubic-bezier(0.25, 0, 0.3, 1);
     transition-behavior: allow-discrete;
-    transition-property: display, opacity;
+    transition-property: display, opacity, overlay;
   }
 }
 


### PR DESCRIPTION
The moment you close the popover it moves back from the toplayer to the actual parent node. But that of course is translated, so it moves along with that translation and jump to another spot.
To make sure the popover isn't removed from the toplayer until the animations are finished you can add overlay to the list of transition-properties, but https://github.com/web-platform-tests/interop/issues/1031.

For now we will not put in more effort to fix this issue, since it's cosmetic and only occurs when one of the parents of the select is translated, and then only in safari.