### PR TITLE
Propagate the `aria-disabled` state to the overflow menu

### DIFF
--- a/.changeset/small-olives-sing.md
+++ b/.changeset/small-olives-sing.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/tool-bar': patch
+---
+
+Propagate the `aria-disabled` state to the overflow menu.

--- a/packages/components/tool-bar/src/tool-bar.ts
+++ b/packages/components/tool-bar/src/tool-bar.ts
@@ -130,7 +130,7 @@ export class ToolBar extends ScopedElementsMixin(LitElement) {
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ['disabled']
+      attributeFilter: ['aria-disabled', 'disabled']
     });
     this.#resizeObserver.observe(this);
   }


### PR DESCRIPTION
Fixes #2730 