### PR TITLE
Fix data not being invalidated when calling `FetchListDataSource.update()`

### DIFF
--- a/.changeset/bright-guests-float.md
+++ b/.changeset/bright-guests-float.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/data-source': patch
+---
+
+Fix data not being invalidated when calling `FetchListDataSource.update()`
+
+This fixes a bug where after adding a filter and calling `update()`, the `fetchPage` callback was not being called again. Instead the data source was still serving the old data from the previous `fetchPage` calls.

--- a/packages/components/data-source/src/fetch-list-data-source.ts
+++ b/packages/components/data-source/src/fetch-list-data-source.ts
@@ -212,7 +212,10 @@ export class FetchListDataSource<T = any> extends ListDataSource<T> {
 
   update(emitEvent = true): void {
     // Reset the cached items
-    this.#groups.forEach(group => (group.pages = {}));
+    this.#groups.forEach(group => {
+      group.members = undefined;
+      group.pages = {};
+    });
 
     this.#items = this.#createItemsArray();
     this.#proxy = this.#createProxy(this.#items);


### PR DESCRIPTION
Fixes #2814 