### PR TITLE
Fix/2738 [tool-bar] improve fit-content story

### DIFF
--- a/packages/components/tool-bar/src/tool-bar.stories.ts
+++ b/packages/components/tool-bar/src/tool-bar.stories.ts
@@ -231,8 +231,13 @@ export const Empty: Story = {
 
 export const FitContent: Story = {
   args: {
-    description: 'This example shows a tool bar with a single button that fits its content.',
-    items: () => html`<sl-button fill="outline">Simple</sl-button>`,
+    description: 'This example shows a tool bar with items that fit their content.',
+    items: () => html`
+      <sl-button fill="outline">Bold</sl-button>
+      <sl-button fill="outline">Italic</sl-button>
+      <sl-button fill="outline">Underline</sl-button>
+      <sl-button fill="outline">Other</sl-button>
+    `,
     width: 'fit-content',
     contained: true
   }


### PR DESCRIPTION
Add more children to show how `fit-content` works

<img width="523" height="170" alt="Screenshot 2026-02-02 at 17 14 29" src="https://github.com/user-attachments/assets/996dd548-2119-402f-a60c-fcf54fb8e678" />

<img width="526" height="166" alt="Screenshot 2026-02-02 at 17 14 42" src="https://github.com/user-attachments/assets/941cabff-8c08-4732-a992-4f4c6f017a08" />
