### PR TITLE
Fix/3174 textarea   rows attributeprop does not affect textarea sizerows shown

### DIFF
--- a/.changeset/puny-crews-post.md
+++ b/.changeset/puny-crews-post.md
@@ -2,7 +2,8 @@
 '@sl-design-system/text-area': minor
 ---
 
-The default number of rows is now explicitly set to 3 (previously relied on browser default of 2), and the minimum height now properly respects the `rows` attribute when resizing. The `--sl-text-area-rows` CSS custom property has been removed and replaced with an internal css-variable for better minimum height handling; this means you only need the `rows` property to set the height of the text-area.
+The default number of rows is now explicitly set to 3 (previously it mimiced the browser default of 2). The `--sl-text-area-rows` CSS custom property has been removed and replaced with an internal css-variable for better minimum height handling; this means you only need the `rows` property to set the height of the text-area and no longer need to set `--sl-text-area-rows` when the minimum height is smaller than 3 rows.
 
-If you have a scenario where you set `--sl-text-area-rows` to a bigger value than `rows` this will be a "breaking" change in your application. It will still work, but it might look different.
+If you currently have a scenario where you set `--sl-text-area-rows` to a bigger value than `rows` this will be a "breaking" change in your application. It will still work, but it might look different.
+For example, if you have a component with `rows=6` and `--sl-text-area-rows: 7`, with this version it will get a height of `6lh`, making it smaller than in the previous version.
 

--- a/.changeset/puny-crews-post.md
+++ b/.changeset/puny-crews-post.md
@@ -2,5 +2,5 @@
 '@sl-design-system/text-area': minor
 ---
 
-The default number of rows is now explicitly set to 3 (previously relied on browser default of 2), and the minimum height now properly respects the `rows` attribute when resizing. The `--sl-text-area-rows` CSS custom property has been removed and replaced with an internal css-variable for better minimum height handling; this mean you only need the `rows` property to set the height of the text-area.
+The default number of rows is now explicitly set to 3 (previously relied on browser default of 2), and the minimum height now properly respects the `rows` attribute when resizing. The `--sl-text-area-rows` CSS custom property has been removed and replaced with an internal css-variable for better minimum height handling; this means you only need the `rows` property to set the height of the text-area.
 

--- a/.changeset/puny-crews-post.md
+++ b/.changeset/puny-crews-post.md
@@ -1,0 +1,6 @@
+---
+'@sl-design-system/text-area': minor
+---
+
+The default number of rows is now explicitly set to 3 (previously relied on browser default of 2), and the minimum height now properly respects the `rows` attribute when resizing. The `--sl-text-area-rows` CSS custom property has been removed and replaced with an internal css-variable for better minimum height handling; this mean you only need the `rows` property to set the height of the text-area.
+

--- a/.changeset/puny-crews-post.md
+++ b/.changeset/puny-crews-post.md
@@ -4,3 +4,5 @@
 
 The default number of rows is now explicitly set to 3 (previously relied on browser default of 2), and the minimum height now properly respects the `rows` attribute when resizing. The `--sl-text-area-rows` CSS custom property has been removed and replaced with an internal css-variable for better minimum height handling; this means you only need the `rows` property to set the height of the text-area.
 
+If you have a scenario where you set `--sl-text-area-rows` to a bigger value than `rows` this will be a "breaking" change in your application. It will still work, but it might look different.
+

--- a/.changeset/puny-crews-post.md
+++ b/.changeset/puny-crews-post.md
@@ -1,5 +1,5 @@
 ---
-'@sl-design-system/text-area': minor
+'@sl-design-system/text-area': patch
 ---
 
 The default number of rows is now explicitly set to 3 (previously it mimiced the browser default of 2). The `--sl-text-area-rows` CSS custom property has been removed and replaced with an internal css-variable for better minimum height handling; this means you only need the `rows` property to set the height of the text-area and no longer need to set `--sl-text-area-rows` when the minimum height is smaller than 3 rows.

--- a/packages/components/text-area/src/text-area.scss
+++ b/packages/components/text-area/src/text-area.scss
@@ -62,7 +62,7 @@
 }
 
 :host(:where([resize='vertical'], [resize='auto'])) slot[name='textarea']::slotted(textarea) {
-  min-block-size: calc(var(--sl-text-area-rows) * 1lh);
+  min-block-size: calc(var(--_sl-text-area-rows, 1) * 1lh);
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/packages/components/text-area/src/text-area.scss
+++ b/packages/components/text-area/src/text-area.scss
@@ -3,7 +3,8 @@
   --_bg-mix-color: var(--sl-color-background-input-interactive);
   --_bg-opacity: var(--sl-opacity-interactive-plain-idle);
   --_border: var(--sl-color-border-input);
-  --sl-text-area-rows: 3;
+
+  // --sl-text-area-rows: 3;
 
   align-items: start;
   background: color-mix(in srgb, var(--_bg-color), var(--_bg-mix-color) calc(100% * var(--_bg-opacity)));
@@ -62,9 +63,9 @@
   }
 }
 
-:host(:where([resize='vertical'], [resize='auto'])) slot[name='textarea']::slotted(textarea) {
-  min-block-size: calc(var(--sl-text-area-rows) * 1lh);
-}
+// :host(:where([resize='vertical'], [resize='auto'])) slot[name='textarea']::slotted(textarea) {
+//   min-block-size: calc(var(--sl-text-area-rows) * 1lh);
+// }
 
 @media (prefers-reduced-motion: no-preference) {
   :host(:where(:hover, :focus-within)) {
@@ -82,6 +83,7 @@ slot[name='textarea']::slotted(textarea) {
   flex: 1;
   font: inherit;
   margin: 0;
+  min-block-size: 1lh;
   outline: none;
   padding-block: calc(var(--sl-size-100) - var(--sl-size-borderWidth-default));
   padding-inline: calc(var(--sl-size-150) - var(--sl-size-borderWidth-default));

--- a/packages/components/text-area/src/text-area.scss
+++ b/packages/components/text-area/src/text-area.scss
@@ -4,8 +4,6 @@
   --_bg-opacity: var(--sl-opacity-interactive-plain-idle);
   --_border: var(--sl-color-border-input);
 
-  // --sl-text-area-rows: 3;
-
   align-items: start;
   background: color-mix(in srgb, var(--_bg-color), var(--_bg-mix-color) calc(100% * var(--_bg-opacity)));
   border: var(--sl-size-borderWidth-default) solid var(--_border);
@@ -63,9 +61,9 @@
   }
 }
 
-// :host(:where([resize='vertical'], [resize='auto'])) slot[name='textarea']::slotted(textarea) {
-//   min-block-size: calc(var(--sl-text-area-rows) * 1lh);
-// }
+:host(:where([resize='vertical'], [resize='auto'])) slot[name='textarea']::slotted(textarea) {
+  min-block-size: calc(var(--sl-text-area-rows) * 1lh);
+}
 
 @media (prefers-reduced-motion: no-preference) {
   :host(:where(:hover, :focus-within)) {

--- a/packages/components/text-area/src/text-area.scss
+++ b/packages/components/text-area/src/text-area.scss
@@ -62,7 +62,7 @@
 }
 
 :host(:where([resize='vertical'], [resize='auto'])) slot[name='textarea']::slotted(textarea) {
-  min-block-size: calc(var(--_sl-text-area-rows, 1) * 1lh);
+  min-block-size: calc(var(--_sl-text-area-rows, 3) * 1lh);
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/packages/components/text-area/src/text-area.scss
+++ b/packages/components/text-area/src/text-area.scss
@@ -62,6 +62,10 @@
   }
 }
 
+:host(:where([resize='vertical'], [resize='auto'])) slot[name='textarea']::slotted(textarea) {
+  min-block-size: calc(var(--sl-text-area-rows) * 1lh);
+}
+
 @media (prefers-reduced-motion: no-preference) {
   :host(:where(:hover, :focus-within)) {
     transition: 200ms ease-in-out;
@@ -78,7 +82,6 @@ slot[name='textarea']::slotted(textarea) {
   flex: 1;
   font: inherit;
   margin: 0;
-  min-block-size: calc(var(--sl-text-area-rows, 3) * 1lh);
   outline: none;
   padding-block: calc(var(--sl-size-100) - var(--sl-size-borderWidth-default));
   padding-inline: calc(var(--sl-size-150) - var(--sl-size-borderWidth-default));

--- a/packages/components/text-area/src/text-area.spec.ts
+++ b/packages/components/text-area/src/text-area.spec.ts
@@ -497,7 +497,7 @@ describe('sl-text-area', () => {
 
         expect(el.resize).to.equal('vertical');
         expect(textArea.style.resize).to.equal('vertical');
-        expect(textArea.style.height).to.equal('74px');
+        expect(textArea.style.height).to.equal('');
       });
 
       it('should update from vertical to none', async () => {
@@ -571,7 +571,7 @@ describe('sl-text-area', () => {
       el.resize = 'vertical';
       await el.updateComplete;
 
-      expect(textArea.style.height).to.equal('74px');
+      expect(textArea.style.height).to.equal('');
       expect(textArea.style.resize).to.equal('vertical');
     });
   });

--- a/packages/components/text-area/src/text-area.spec.ts
+++ b/packages/components/text-area/src/text-area.spec.ts
@@ -497,7 +497,7 @@ describe('sl-text-area', () => {
 
         expect(el.resize).to.equal('vertical');
         expect(textArea.style.resize).to.equal('vertical');
-        expect(textArea.style.height).to.equal('');
+        expect(textArea.style.height).to.equal('74px');
       });
 
       it('should update from vertical to none', async () => {
@@ -571,7 +571,7 @@ describe('sl-text-area', () => {
       el.resize = 'vertical';
       await el.updateComplete;
 
-      expect(textArea.style.height).to.equal('');
+      expect(textArea.style.height).to.equal('74px');
       expect(textArea.style.resize).to.equal('vertical');
     });
   });

--- a/packages/components/text-area/src/text-area.spec.ts
+++ b/packages/components/text-area/src/text-area.spec.ts
@@ -310,6 +310,101 @@ describe('sl-text-area', () => {
     });
   });
 
+  describe('rows', () => {
+    it('should default to 3 rows when not set', async () => {
+      el = await fixture(html`<sl-text-area></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      expect(textArea.rows).to.equal(3);
+    });
+
+    it('should set the --_sl-text-area-rows CSS variable to 3 by default', async () => {
+      el = await fixture(html`<sl-text-area></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      expect(textArea.style.getPropertyValue('--_sl-text-area-rows')).to.equal('3');
+    });
+
+    it('should use the specified number of rows when set', async () => {
+      el = await fixture(html`<sl-text-area rows="5"></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      expect(el.rows).to.equal(5);
+      expect(textArea.rows).to.equal(5);
+    });
+
+    it('should update the --_sl-text-area-rows CSS variable when rows is set', async () => {
+      el = await fixture(html`<sl-text-area rows="5"></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      expect(textArea.style.getPropertyValue('--_sl-text-area-rows')).to.equal('5');
+    });
+
+    it('should fall back to 3 rows when set to 0', async () => {
+      el = await fixture(html`<sl-text-area rows="0"></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      expect(textArea.rows).to.equal(3);
+      expect(textArea.style.getPropertyValue('--_sl-text-area-rows')).to.equal('3');
+    });
+
+    it('should fall back to 3 rows when set to a negative value', async () => {
+      el = await fixture(html`<sl-text-area rows="-5"></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      expect(textArea.rows).to.equal(3);
+      expect(textArea.style.getPropertyValue('--_sl-text-area-rows')).to.equal('3');
+    });
+
+    it('should update rows and CSS variable when property changes', async () => {
+      el = await fixture(html`<sl-text-area rows="3"></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      el.rows = 7;
+      await el.updateComplete;
+
+      expect(textArea.rows).to.equal(7);
+      expect(textArea.style.getPropertyValue('--_sl-text-area-rows')).to.equal('7');
+    });
+
+    it('should fall back to 3 when property changes to invalid value', async () => {
+      el = await fixture(html`<sl-text-area rows="5"></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      el.rows = 0;
+      await el.updateComplete;
+
+      expect(textArea.rows).to.equal(3);
+      expect(textArea.style.getPropertyValue('--_sl-text-area-rows')).to.equal('3');
+    });
+
+    it('should maintain CSS variable with resize="vertical"', async () => {
+      el = await fixture(html`<sl-text-area rows="6" resize="vertical"></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      expect(textArea.rows).to.equal(6);
+      expect(textArea.style.getPropertyValue('--_sl-text-area-rows')).to.equal('6');
+      expect(textArea.style.resize).to.equal('vertical');
+    });
+
+    it('should maintain CSS variable with resize="auto"', async () => {
+      el = await fixture(html`<sl-text-area rows="4" resize="auto"></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      expect(textArea.rows).to.equal(4);
+      expect(textArea.style.getPropertyValue('--_sl-text-area-rows')).to.equal('4');
+    });
+
+    it('should maintain CSS variable with resize="none"', async () => {
+      el = await fixture(html`<sl-text-area rows="8" resize="none"></sl-text-area>`);
+      textArea = el.querySelector('textarea')!;
+
+      expect(textArea.rows).to.equal(8);
+      expect(textArea.style.getPropertyValue('--_sl-text-area-rows')).to.equal('8');
+      expect(textArea.style.resize).to.equal('none');
+    });
+  });
+
   describe('required', () => {
     beforeEach(async () => {
       el = await fixture(html`<sl-text-area required></sl-text-area>`);

--- a/packages/components/text-area/src/text-area.stories.ts
+++ b/packages/components/text-area/src/text-area.stories.ts
@@ -139,14 +139,14 @@ export const Required: Story = {
 
 export const Resize: Story = {
   args: {
-    hint: 'This field will resize automatically as you type. By default the minimum number height of the container is 3 rows, but you can change that by setting the `--sl-text-area-rows ` CSS variable.',
+    hint: 'This field will resize automatically as you type. By default the minimum number height of the container is  determined by the rows attribute, which is 3 by default.',
     resize: 'auto'
   }
 };
 
 export const Rows: Story = {
   args: {
-    hint: 'This field will have a specific number of rows.',
+    hint: 'This field will have a specific number of rows. By default, the number of rows is 3. When the resize property is set to auto or vertical, the field will have a minimum height based on the number of rows.',
     rows: 4
   }
 };

--- a/packages/components/text-area/src/text-area.stories.ts
+++ b/packages/components/text-area/src/text-area.stories.ts
@@ -139,8 +139,15 @@ export const Required: Story = {
 
 export const Resize: Story = {
   args: {
-    hint: 'This field will resize automatically as you type.',
+    hint: 'This field will resize automatically as you type. By default the minimum number height of the container is 3 rows, but you can change that by setting the `--sl-text-area-rows ` CSS variable.',
     resize: 'auto'
+  }
+};
+
+export const Rows: Story = {
+  args: {
+    hint: 'This field will have a specific number of rows.',
+    rows: 4
   }
 };
 

--- a/packages/components/text-area/src/text-area.stories.ts
+++ b/packages/components/text-area/src/text-area.stories.ts
@@ -139,7 +139,7 @@ export const Required: Story = {
 
 export const Resize: Story = {
   args: {
-    hint: 'This field will resize automatically as you type. By default the minimum number height of the container is  determined by the rows attribute, which is 3 by default.',
+    hint: 'This field will resize automatically as you type. By default, the minimum height is determined by the rows attribute (default: 3).',
     resize: 'auto'
   }
 };

--- a/packages/components/text-area/src/text-area.ts
+++ b/packages/components/text-area/src/text-area.ts
@@ -25,7 +25,6 @@ let nextUniqueId = 0;
 /**
  * Multi line text area component.
  *
- * @cssprop --sl-text-area-rows - The number of rows initially visible in the textarea
  * @slot textarea - The slot for the textarea element
  */
 @localized()
@@ -97,7 +96,7 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
 
   /**
    * The number of rows the textarea should initially have.
-   * If not set, the browser defaults to 3 rows.
+   * If not set, the component defaults to 3 rows.
    */
   @property({ type: Number }) rows?: number;
 
@@ -245,7 +244,7 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
     textarea.style.resize = this.resize ?? 'vertical';
     textarea.wrap = this.wrap ?? 'soft';
 
-    textarea.style.setProperty('--sl-text-area-rows', textarea.rows?.toString());
+    textarea.style.setProperty('--_sl-text-area-rows', textarea.rows?.toString());
 
     this.setAttributesTarget(textarea);
 

--- a/packages/components/text-area/src/text-area.ts
+++ b/packages/components/text-area/src/text-area.ts
@@ -222,12 +222,13 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
   }
 
   #setSize(): void {
+    console.log('set size', this.resize);
     if (this.resize === 'auto') {
       this.textarea.style.height = 'auto';
       this.textarea.style.height = `${this.textarea.scrollHeight}px`;
       this.textarea.style.resize = 'none';
     } else {
-      (this.textarea.style.height as string | undefined) = undefined;
+      this.textarea.style.height = 'auto';
     }
   }
 
@@ -239,7 +240,7 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
     textarea.placeholder = this.placeholder ?? '';
     textarea.readOnly = !!this.readonly;
     textarea.required = !!this.required;
-    textarea.rows = this.rows ?? 2;
+    textarea.rows = this.rows ?? 3;
     textarea.style.resize = this.resize ?? 'vertical';
     textarea.wrap = this.wrap ?? 'soft';
 

--- a/packages/components/text-area/src/text-area.ts
+++ b/packages/components/text-area/src/text-area.ts
@@ -95,7 +95,8 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
   @property({ reflect: true }) resize: ResizeType = 'vertical';
 
   /**
-   * The number of rows the textarea should initially have.
+   * The number of rows the textarea should have.
+   * For resize auto and vertical, this will determine the *minimum* height of the textarea.
    * If not set, the component defaults to 3 rows.
    */
   @property({ type: Number }) rows?: number;

--- a/packages/components/text-area/src/text-area.ts
+++ b/packages/components/text-area/src/text-area.ts
@@ -97,7 +97,7 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
 
   /**
    * The number of rows the textarea should initially have.
-   * If not set, the browser defaults to 2 rows.
+   * If not set, the browser defaults to 3 rows.
    */
   @property({ type: Number }) rows?: number;
 
@@ -227,8 +227,7 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
       this.textarea.style.height = `${this.textarea.scrollHeight}px`;
       this.textarea.style.resize = 'none';
     } else {
-      this.textarea.style.removeProperty('height');
-      // this.textarea.style.height = 'auto';
+      (this.textarea.style.height as string | undefined) = undefined;
     }
   }
 
@@ -240,7 +239,7 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
     textarea.placeholder = this.placeholder ?? '';
     textarea.readOnly = !!this.readonly;
     textarea.required = !!this.required;
-    textarea.rows = this.rows ?? 3;
+    textarea.rows = this.rows && this.rows > 0 ? this.rows : 3;
     textarea.style.resize = this.resize ?? 'vertical';
     textarea.wrap = this.wrap ?? 'soft';
 

--- a/packages/components/text-area/src/text-area.ts
+++ b/packages/components/text-area/src/text-area.ts
@@ -226,8 +226,10 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
       this.textarea.style.height = 'auto';
       this.textarea.style.height = `${this.textarea.scrollHeight}px`;
       this.textarea.style.resize = 'none';
-    } else {
+    } else if (this.resize === 'vertical') {
       (this.textarea.style.height as string | undefined) = undefined;
+    } else {
+      this.textarea.style.removeProperty('height');
     }
   }
 
@@ -242,6 +244,8 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
     textarea.rows = this.rows && this.rows > 0 ? this.rows : 3;
     textarea.style.resize = this.resize ?? 'vertical';
     textarea.wrap = this.wrap ?? 'soft';
+
+    textarea.style.setProperty('--sl-text-area-rows', textarea.rows?.toString());
 
     this.setAttributesTarget(textarea);
 

--- a/packages/components/text-area/src/text-area.ts
+++ b/packages/components/text-area/src/text-area.ts
@@ -222,13 +222,13 @@ export class TextArea extends ObserveAttributesMixin(FormControlMixin(ScopedElem
   }
 
   #setSize(): void {
-    console.log('set size', this.resize);
     if (this.resize === 'auto') {
       this.textarea.style.height = 'auto';
       this.textarea.style.height = `${this.textarea.scrollHeight}px`;
       this.textarea.style.resize = 'none';
     } else {
-      this.textarea.style.height = 'auto';
+      this.textarea.style.removeProperty('height');
+      // this.textarea.style.height = 'auto';
     }
   }
 


### PR DESCRIPTION
This pull request updates the `TextArea` component to standardize its default row behavior and improve how the minimum height is handled when resizing. The changes clarify and enforce that the default number of visible rows is 3 (instead of the browser default of 2), improve the CSS for minimum height calculation, and enhance documentation and storybook examples.

**Default rows behavior and minimum height handling:**

* The default number of rows for the textarea is now explicitly set to 3 if not provided or if an invalid value is given, both in the property and when rendering the textarea. [[1]](diffhunk://#diff-b1dcaede9b2911a3dcb6b027509b86f38b40494831597795ab92e25f7a943da8L100-R99) [[2]](diffhunk://#diff-b1dcaede9b2911a3dcb6b027509b86f38b40494831597795ab92e25f7a943da8L242-R248)
* The minimum block size for the textarea is now controlled via a CSS variable (`--_sl-text-area-rows`), which is set according to the number of rows, ensuring the minimum height matches the intended number of rows when `resize="vertical"` or `resize="auto"` is used. [[1]](diffhunk://#diff-93fa36dfb182542316302632ac6c9bcbf26ce5bef7498d706ca4291732d7ce7cR64-R67) [[2]](diffhunk://#diff-93fa36dfb182542316302632ac6c9bcbf26ce5bef7498d706ca4291732d7ce7cL81-R84) [[3]](diffhunk://#diff-b1dcaede9b2911a3dcb6b027509b86f38b40494831597795ab92e25f7a943da8L242-R248)
* The CSS custom property `--sl-text-area-rows` was removed as it is no longer used.

**Resize logic improvements:**

* The resize logic in the component was updated to properly clear or reset the textarea height depending on the `resize` property, ensuring consistent behavior for all resize modes.

**Documentation and storybook updates:**

* Storybook stories and hint texts were updated to clarify the default row behavior, and a new story was added to demonstrate setting a custom number of rows.
* The outdated JSDoc comment for the removed CSS property was deleted.