### PR TITLE
Add working tree filter example story

### DIFF
--- a/packages/components/tree/src/tree.stories.ts
+++ b/packages/components/tree/src/tree.stories.ts
@@ -341,24 +341,24 @@ export const Filter: Story = {
     ...Icons.args
   },
   render: ({ hideGuides: showGuides }) => {
+    const filterTree = (nodes: NestedDataNode[], regex: RegExp): NestedDataNode[] => {
+      return nodes.reduce<NestedDataNode[]>((acc, node) => {
+        const filteredChildren = node.children ? filterTree(node.children, regex) : undefined;
+        const hasMatchingChildren = filteredChildren && filteredChildren.length > 0;
+        const isLeafMatch = !node.children && regex.test(node.name);
+
+        if (isLeafMatch || hasMatchingChildren) {
+          acc.push({ ...node, children: filteredChildren });
+        }
+
+        return acc;
+      }, []);
+    };
+
     const createDataSource = (filter?: string) => {
-      const filterTree = (nodes: NestedDataNode[]): NestedDataNode[] => {
-        if (!filter) return nodes;
+      const data = filter ? filterTree(nestedData, new RegExp(filter, 'i')) : nestedData;
 
-        const regex = new RegExp(filter, 'i');
-
-        return nodes.reduce<NestedDataNode[]>((acc, node) => {
-          const filteredChildren = node.children ? filterTree(node.children) : undefined;
-
-          if (regex.test(node.name) || (filteredChildren && filteredChildren.length > 0)) {
-            acc.push({ ...node, children: filteredChildren });
-          }
-
-          return acc;
-        }, []);
-      };
-
-      return new NestedTreeDataSource(filterTree(nestedData), {
+      return new NestedTreeDataSource(data, {
         getChildren: ({ children }) => children,
         getIcon: ({ name }, expanded) =>
           name.includes('.') ? 'far-file-lines' : `far-folder${expanded ? '-open' : ''}`,
@@ -369,14 +369,21 @@ export const Filter: Story = {
       });
     };
 
-    let dataSource = createDataSource();
+    let dataSource = createDataSource(),
+      empty = false;
 
     const updateTree = (filter?: string) => {
       dataSource = createDataSource(filter);
+      empty = !!filter && dataSource.size === 0;
 
-      const tree = document.querySelector('sl-tree');
+      const tree = document.querySelector('sl-tree') as Tree;
       if (tree) {
         tree.dataSource = dataSource;
+      }
+
+      const msg = document.getElementById('no-results');
+      if (msg) {
+        msg.hidden = !empty;
       }
     };
 
@@ -406,6 +413,7 @@ export const Filter: Story = {
         aria-label="Filtered tree"
         style="max-inline-size: 300px"
       ></sl-tree>
+      <p id="no-results" ?hidden=${!empty}>No matching results.</p>
     `;
   }
 };

--- a/packages/components/tree/src/tree.stories.ts
+++ b/packages/components/tree/src/tree.stories.ts
@@ -337,31 +337,63 @@ export const Icons: Story = {
 };
 
 export const Filter: Story = {
-  tags: ['!dev'],
   args: {
     ...Icons.args
   },
-  render: ({ dataSource, hideGuides: showGuides }) => {
-    const onChange = (event: SlChangeEvent<string | undefined>): void => {
-      const value = event.detail ?? '';
+  render: ({ hideGuides: showGuides }) => {
+    const createDataSource = (filter?: string) => {
+      const filterTree = (nodes: NestedDataNode[]): NestedDataNode[] => {
+        if (!filter) return nodes;
 
-      if (value) {
-        const regex = new RegExp(value, 'i');
+        const regex = new RegExp(filter, 'i');
 
-        dataSource?.addFilter('search', (item: NestedDataNode) => regex.test(item.name));
-      } else {
-        dataSource?.removeFilter('search');
+        return nodes.reduce<NestedDataNode[]>((acc, node) => {
+          const filteredChildren = node.children ? filterTree(node.children) : undefined;
+
+          if (regex.test(node.name) || (filteredChildren && filteredChildren.length > 0)) {
+            acc.push({ ...node, children: filteredChildren });
+          }
+
+          return acc;
+        }, []);
+      };
+
+      return new NestedTreeDataSource(filterTree(nestedData), {
+        getChildren: ({ children }) => children,
+        getIcon: ({ name }, expanded) =>
+          name.includes('.') ? 'far-file-lines' : `far-folder${expanded ? '-open' : ''}`,
+        getId: item => item.id,
+        getLabel: ({ name }) => name,
+        isExpandable: ({ children }) => !!children,
+        isExpanded: filter ? () => true : ({ name }) => ['components', 'tree', 'src'].includes(name)
+      });
+    };
+
+    let dataSource = createDataSource();
+
+    const updateTree = (filter?: string) => {
+      dataSource = createDataSource(filter);
+
+      const tree = document.querySelector('sl-tree');
+      if (tree) {
+        tree.dataSource = dataSource;
       }
+    };
 
-      dataSource?.update();
+    const onChange = (event: SlChangeEvent<string | undefined>): void => {
+      updateTree(event.detail || undefined);
     };
 
     const onClear = () => {
-      dataSource?.removeFilter('search');
-      dataSource?.update();
+      updateTree();
     };
 
     return html`
+      <p style="margin-block: 0 1rem">
+        This example shows how filtering can be implemented by creating a new data source with the filtered data and
+        assigning it to the tree. Note that this <strong>does not</strong> use the Filter API of DataSource. That API
+        hasn't been implemented yet.
+      </p>
       <sl-search-field
         @sl-change=${onChange}
         @sl-clear=${onClear}
@@ -371,7 +403,7 @@ export const Filter: Story = {
       <sl-tree
         .dataSource=${dataSource}
         ?show-guides=${showGuides}
-        aria-label="Tree label"
+        aria-label="Filtered tree"
         style="max-inline-size: 300px"
       ></sl-tree>
     `;


### PR DESCRIPTION
## Summary
- Rewrote the `Filter` tree story to work without the not-yet-implemented `NestedTreeDataSource` filter API
- Instead of calling `addFilter`/`removeFilter` on the datasource, the story recursively filters the nested data and creates a new `NestedTreeDataSource` with the filtered result
- When a filter is active, all nodes are expanded so the user can see the matching results
- Added an explanatory note in the story clarifying this approach

Fixes #3195

## Test plan
- [x] Open the `Filter` story in Storybook
- [x] Type a filter value (e.g. "tree") and verify matching nodes and their ancestors are shown, all expanded
- [x] Clear the filter and verify the tree returns to its default expanded state

🤖 Generated with [Claude Code](https://claude.com/claude-code)