### PR TITLE
Chore/3157 improve bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yaml
@@ -1,6 +1,7 @@
 name: 🐛 Bug Report
 description: File a bug report
-labels: ["triage"]
+labels: ["triage", "bug"]
+type: "Bug"
 projects: ["projects/9"]
 body:
   - type: markdown
@@ -10,50 +11,87 @@ body:
     attributes:
       value: "# 🐛 Bug Report "
   - type: textarea
-    id: general-summary
+    id: current-behavior
     attributes:
-      label: Provide a general summary of the issue here
+      label: 😯 Current Behavior
+      description: |
+        Tell us what happens instead of the expected behavior. Include screenshots if possible.
     validations:
       required: true
   - type: textarea
     id: expected-behavior
     attributes:
-      label: 🤔 Expected Behavior?
-      description: Tell us what should happen
+      label: 🤔 Expected Behavior/possible solution?
+      description: Tell us what should happen, or suggest a fix/reason for the bug.
     validations:
       required: true
-  - type: textarea
-    id: current-behavior
-    attributes:
-      label: 😯 Current Behavior
-      description: |
-        Tell us what happens instead of the expected behavior.
-    validations:
-      required: true
-  - type: textarea
-    id: possible-solution
-    attributes:
-      label: 💁 Possible Solution
-      description: Suggest a fix/reason for the bug
-    validations:
-      required: false
   - type: textarea
     id: base-reproduction
     attributes:
       label: 🖥️ Steps to Reproduce
       description: |
+        Provide steps to reproduce the bug. Include a video if possible.
         For example: 1. Go to '...', 2. Click on '....', 3. Scroll to '....', 4. Check console, 5. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: storybook-reproduced
+    attributes:
+      label: Were you able to reproduce this in our storybook?
+      description: "Please check whether this bug is reproducible in [our storybook](https://storybook.slds.io)."
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+  - type: input
+    id: storybook-url
+    attributes:
+      label: If yes, provide the storybook URL
+      description: Provide the URL of the storybook story where the bug is visible.
+    validations:
+      required: false
+  - type: textarea
+    id: code-reproduction
+    attributes:
+      label: If no, provide a code reproduction
+      description: If the bug is not reproducible in storybook, please provide a code snippet or repository that reproduces the issue.
+    validations:
+      required: false
+  - type: dropdown
+    id: impact
+    attributes:
+      label: ⚖️ Impact
+      description: How impactful is this bug?
+      options:
+        - "This blocks our release or stops us from using this component"
+        - "Not a huge problem, we have a workaround"
+        - "Just a visual issue / needs some polishing"
     validations:
       required: true
   - type: markdown
     attributes:
       value: "## 🌍 Your Environment"
   - type: dropdown
+    id: framework
+    attributes:
+      label: Framework
+      description: In which framework does this bug occur?
+      options:
+        - Angular
+        - React
+        - Vue
+        - Vanilla JS / HTML
+        - Other
+    validations:
+      required: true
+  - type: dropdown
     id: browsers
     attributes:
       label: What browsers are you seeing the problem on? (only for bugs in code)
       multiple: true
       options:
+        - All
         - Firefox
         - Chrome
         - Safari
@@ -73,6 +111,20 @@ body:
       label: What operating system are you using?
     validations:
       required: true
+  - type: input
+    id: component-version
+    attributes:
+      label: Component version
+      description: Which version of the component are you using?
+    validations:
+      required: true
+  - type: input
+    id: theme-version
+    attributes:
+      label: Theme version
+      description: Which version of the theme are you using? (only when relevant)
+    validations:
+      required: false
   - type: markdown
     attributes:
       value: "## 🦄 Other"
@@ -91,12 +143,12 @@ body:
       description: |
         Which product team is this bug impacting? (i.e. Bingel DC/Pokemon)
     validations:
-      required: true
+      required: false
   - type: dropdown
     id: theme
     attributes:
       label: 🎨 Your Theme(s)
-      description: Which theme(s) do you use?
+      description: Which theme(s) do you use? (only when relevant)
       multiple: true
       options:
       - Bingel DC
@@ -116,4 +168,4 @@ body:
       - TEAS
       - TIG
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/1-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yaml
@@ -1,6 +1,6 @@
 name: 🐛 Bug Report
 description: File a bug report
-labels: ["triage", "bug"]
+labels: ["triage"]
 type: "Bug"
 projects: ["projects/9"]
 body:
@@ -38,7 +38,7 @@ body:
     id: storybook-reproduced
     attributes:
       label: Were you able to reproduce this in our storybook?
-      description: "Please check whether this bug is reproducible in [our storybook](https://storybook.slds.io)."
+      description: "Please check whether this bug is reproducible in [our storybook](https://storybook.sanomalearning.design)."
       options:
         - "Yes"
         - "No"
@@ -81,6 +81,8 @@ body:
         - Angular
         - React
         - Vue
+        - Lit
+        - Svelte
         - Vanilla JS / HTML
         - Other
     validations:
@@ -88,7 +90,7 @@ body:
   - type: dropdown
     id: browsers
     attributes:
-      label: What browsers are you seeing the problem on? (only for bugs in code)
+      label: What browsers are you seeing the problem on?
       multiple: true
       options:
         - All
@@ -109,20 +111,20 @@ body:
     id: operating-system
     attributes:
       label: What operating system are you using?
+      description: Mention when the bug is OS specific; when it only happens on Chrome on Windows, not on Chrome on MacOS for example.
     validations:
-      required: true
+      required: false
   - type: input
     id: component-version
     attributes:
       label: Component version
-      description: Which version of the component are you using?
     validations:
       required: true
   - type: input
     id: theme-version
     attributes:
       label: Theme version
-      description: Which version of the theme are you using? (only when relevant)
+      description: Only when relevant
     validations:
       required: false
   - type: markdown
@@ -133,7 +135,7 @@ body:
     attributes:
       label: 👤 Your name
       description: |
-        Please provide your full name
+        Please provide your full name so we can reach out to you via Slack or email for more information if needed.
     validations:
       required: true
   - type: input
@@ -141,7 +143,7 @@ body:
     attributes:
       label: 🧢 Your product/team
       description: |
-        Which product team is this bug impacting? (i.e. Bingel DC/Pokemon)
+        So we have an idea of the context of the bug.
     validations:
       required: false
   - type: dropdown


### PR DESCRIPTION
This pull request updates the bug report issue template to improve the clarity and usefulness of bug submissions. The changes reorganize the structure, add new fields for better reproducibility and context, and clarify existing prompts to help maintainers triage and resolve issues more effectively.

**Improvements to bug report structure and clarity:**

* Renamed and reorganized fields for reporting current behavior, expected behavior, and reproduction steps to make the process clearer for users.
* Added dropdowns for impact assessment, framework, and browser selection, allowing more precise categorization of bugs.
* Included new fields for component and theme versions to help with version-specific bug tracking.
* Added options to indicate whether the bug can be reproduced in Storybook, and fields to provide a Storybook URL or code reproduction if not.

**Enhancements for context and triage:**

* Made product/team, theme, and operating system fields optional, and improved descriptions to reduce required information to only what's relevant. [[1]](diffhunk://#diff-6c8b1f6f401c343daa33a1ec673ebd4c8732336c0f13690c7fe4e47c6fd7fb9eL84-R153) [[2]](diffhunk://#diff-6c8b1f6f401c343daa33a1ec673ebd4c8732336c0f13690c7fe4e47c6fd7fb9eL119-R173) [[3]](diffhunk://#diff-6c8b1f6f401c343daa33a1ec673ebd4c8732336c0f13690c7fe4e47c6fd7fb9eR114-R129)
* Clarified the purpose of name and product/team fields to facilitate follow-up and contextual understanding.

**Minor metadata updates:**

* Added a `type: "Bug"` field and associated the template with a specific GitHub project for better tracking.