### PR TITLE
Fix empty `date-style` and `time-style` attributes in `sl-format-date`

### DIFF
--- a/.changeset/lucky-terms-find.md
+++ b/.changeset/lucky-terms-find.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/format-date': patch
+---
+
+Fix for empty `date-style` and `time-style` attributes
+
+Previously, setting `date-style` or `time-style` to an empty string would cause an error due to invalid formatting options being passed to `Intl.DateTimeFormat`. This update ensures that empty string values are treated as `undefined`, allowing the component to fall back to default formatting behavior without throwing an error.

--- a/packages/components/format-date/src/format-date.spec.ts
+++ b/packages/components/format-date/src/format-date.spec.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import '../register.js';
 import { FormatDate } from './format-date.js';
 
-describe('sl-format-number', () => {
+describe('sl-format-date', () => {
   let el: FormatDate;
   const date = new Date(2022, 11, 17, 14, 5, 42);
 
@@ -123,6 +123,86 @@ describe('sl-format-number', () => {
       await el.updateComplete;
       expect(el.renderRoot).to.have.trimmed.text('14:05');
     });
+
+    it('should format date (time) with 12h time when hour12 is true', async () => {
+      el.hour = 'numeric';
+      el.minute = 'numeric';
+      el.hour12 = true;
+
+      await el.updateComplete;
+      expect(el.renderRoot).to.have.trimmed.text('2:05 PM');
+    });
+
+    it('should use dateStyle and timeStyle together when both are set', async () => {
+      el.dateStyle = 'long';
+      el.timeStyle = 'medium';
+
+      await el.updateComplete;
+      expect(el.renderRoot).to.have.trimmed.text('December 17, 2022 at 2:05:42 PM');
+    });
+
+    it('should prefer individual options over dateStyle/timeStyle when any individual option is set', async () => {
+      el.dateStyle = 'long';
+      el.timeStyle = 'medium';
+      el.year = 'numeric';
+
+      await el.updateComplete;
+      // Only year is rendered — dateStyle/timeStyle are ignored
+      expect(el.renderRoot).to.have.trimmed.text('2022');
+    });
+
+    it('should apply dateTimeOptions when set', async () => {
+      el.dateTimeOptions = { year: 'numeric', month: 'long', day: 'numeric' };
+
+      await el.updateComplete;
+      expect(el.renderRoot).to.have.trimmed.text('December 17, 2022');
+    });
+
+    it('should merge dateTimeOptions with other properties, with dateTimeOptions taking precedence', async () => {
+      el.year = 'numeric';
+      el.dateTimeOptions = { month: 'long' };
+
+      await el.updateComplete;
+      // dateTimeOptions merges with individual options: year from property, month from dateTimeOptions
+      expect(el.renderRoot).to.have.trimmed.text('December 2022');
+    });
+  });
+
+  describe('date setter', () => {
+    beforeEach(async () => {
+      el = await fixture(html`<sl-format-date>fallback</sl-format-date>`);
+    });
+
+    it('should accept a numeric timestamp', async () => {
+      el.date = new Date(2022, 11, 17).getTime();
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.trimmed.text('12/17/2022');
+    });
+
+    it('should accept a valid ISO date string', async () => {
+      el.date = '2022-12-17';
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.trimmed.text('12/17/2022');
+    });
+
+    it('should fall back to slot content when date is set to null', async () => {
+      el.date = null;
+      await el.updateComplete;
+
+      expect(el.renderRoot.querySelector('slot')).to.exist;
+    });
+
+    it('should fall back to slot content when date is set to undefined', async () => {
+      el.date = new Date(2022, 11, 17);
+      await el.updateComplete;
+
+      el.date = undefined;
+      await el.updateComplete;
+
+      expect(el.renderRoot.querySelector('slot')).to.exist;
+    });
   });
 
   describe('fallback', () => {
@@ -150,6 +230,33 @@ describe('sl-format-number', () => {
           .map(n => n.textContent)
           .join('')
       ).to.equal('This is not a proper date.');
+    });
+  });
+
+  describe('empty style attributes', () => {
+    it('should treat an empty date-style attribute as undefined when formatting', async () => {
+      el = await fixture(html`<sl-format-date date-style .date=${date}></sl-format-date>`);
+
+      // el.dateStyle is '' (raw Lit attribute reflection), but '' is falsy so it is
+      // coerced to undefined before being passed to Intl.DateTimeFormat. The rendered
+      // output should match the numeric default (same as when the attribute is absent).
+      expect(el.dateStyle).to.equal('');
+      expect(el.renderRoot).to.have.trimmed.text('12/17/2022');
+    });
+
+    it('should treat an empty time-style attribute as undefined when formatting', async () => {
+      el = await fixture(html`<sl-format-date time-style .date=${date}></sl-format-date>`);
+
+      expect(el.timeStyle).to.equal('');
+      expect(el.renderRoot).to.have.trimmed.text('12/17/2022');
+    });
+
+    it('should treat empty date-style and time-style attributes as undefined when formatting', async () => {
+      el = await fixture(html`<sl-format-date date-style time-style .date=${date}></sl-format-date>`);
+
+      expect(el.dateStyle).to.equal('');
+      expect(el.timeStyle).to.equal('');
+      expect(el.renderRoot).to.have.trimmed.text('12/17/2022');
     });
   });
 });

--- a/packages/components/format-date/src/format-date.stories.ts
+++ b/packages/components/format-date/src/format-date.stories.ts
@@ -29,7 +29,7 @@ const locales = ['de', 'en-GB', 'es', 'fi', 'fr', 'it', 'nl', 'nl-BE', 'no', 'pl
 
 export default {
   title: 'Utilities/Format date',
-  tags: ['draft'],
+  tags: ['preview'],
   args: {
     fallback: 'invalid date',
     dateStyle: 'long',

--- a/packages/components/format-date/src/format-date.ts
+++ b/packages/components/format-date/src/format-date.ts
@@ -140,7 +140,7 @@ export class FormatDate extends LocaleMixin(LitElement) {
         weekday,
         year
       } = this,
-      predefinedStyles = { dateStyle, timeStyle },
+      predefinedStyles = { dateStyle: dateStyle || undefined, timeStyle: timeStyle || undefined },
       options = { weekday, era, year, month, day, dayPeriod, hour, minute, second, timeZoneName, timeZone, hour12 },
       formatOptions = Object.values(options).every(value => value === undefined) ? predefinedStyles : options;
 

--- a/website/src/categories/utilities/format-date.md
+++ b/website/src/categories/utilities/format-date.md
@@ -1,0 +1,185 @@
+---
+title: Format date
+eleventyNavigation:
+  parent: Utilities
+  key: Format date
+---
+
+<header class="ds-tokens__main-heading">
+<div class="ds-tokens__heading-wrapper">
+  <h1 class="ds-heading-1">{{title}}</h1>
+  <p class="ds-tokens__heading-description">
+  A utility component for formatting dates and times using the browser's <code>Intl.DateTimeFormat</code> API, with automatic locale support.
+  </p>
+</div>
+</header>
+
+<section class="ds-subpage-section">
+<div class="ds-subpage-section__wrapper">
+
+<section>
+
+## Overview
+
+`sl-format-date` renders a formatted date or time string based on a `date` property and a set of formatting options. It wraps the native [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) API, so all standard formatting options are available as element properties.
+
+When no valid date is provided, the element falls back to rendering its slotted content — useful for showing a placeholder or an error message.
+
+<div class="ds-example">
+
+<sl-format-date date="2026-04-01" time-style></sl-format-date>
+
+</div>
+
+<div class="ds-code">
+
+```html
+<sl-format-date date="2026-04-01" time-style></sl-format-date>
+```
+
+</div>
+
+</section>
+
+<section>
+
+<ds-install-info package="format-date"></ds-install-info>
+
+</section>
+
+<section>
+
+## Usage
+
+### Date and time styles
+
+The quickest way to format a date is to use `date-style` and/or `time-style`. These map directly to [`Intl.DateTimeFormatOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options).
+
+<div class="ds-table-wrapper">
+
+| Style | Example output |
+|-------|---------------|
+| `full` | Wednesday, April 9, 2025 |
+| `long` | April 9, 2025 |
+| `medium` | Apr 9, 2025 |
+| `short` | 4/9/25 |
+
+{.ds-table}
+
+</div>
+
+<div class="ds-code">
+
+```html
+<sl-format-date date-style="long" time-style="short"></sl-format-date>
+```
+
+</div>
+
+### Individual date/time parts
+
+For precise control you can set individual part properties. When any of these are set, `date-style` and `time-style` are ignored. See the [Properties table](#properties) below for all available options.
+
+### Locale
+
+The component uses `LocaleMixin`, which automatically picks up the locale from the nearest `lang` attribute in the DOM. This means the formatted output adapts to the language and regional conventions of the surrounding page without any extra configuration. You can also override it explicitly with the `locale` property:
+
+<div class="ds-code">
+
+```html
+<sl-format-date locale="nl" date-style="long"></sl-format-date>
+```
+
+</div>
+
+### Advanced formatting options
+
+For formatting options not exposed as individual properties, use `date-time-options` to pass an `Intl.DateTimeFormatOptions` object directly:
+
+<div class="ds-code">
+
+```js
+const el = document.querySelector('sl-format-date');
+el.date = new Date();
+el.dateTimeOptions = { calendar: 'hebrew' };
+```
+
+</div>
+
+### Fallback content
+
+When `date` is not set or is invalid, the default slot is rendered. Use this to show a placeholder or error message:
+
+<div class="ds-code">
+
+```html
+<sl-format-date>No date available</sl-format-date>
+```
+
+</div>
+
+</section>
+
+<section>
+
+## API
+
+### Properties
+
+<div class="ds-table-wrapper">
+
+| Property | Attribute | Type | Description |
+|----------|-----------|------|-------------|
+| `date` | `date` | `Date \| string \| number \| null \| undefined` | The date to format. Accepts a `Date` object, a date string, or a timestamp. Falls back to slot content when invalid or unset. |
+| `dateStyle` | `date-style` | `'full' \| 'long' \| 'medium' \| 'short'` | Shorthand date format. Used together with `timeStyle`. Ignored when individual date/time part properties are set. |
+| `timeStyle` | `time-style` | `'full' \| 'long' \| 'medium' \| 'short'` | Shorthand time format. Used together with `dateStyle`. Ignored when individual date/time part properties are set. |
+| `weekday` | `weekday` | `'narrow' \| 'short' \| 'long'` | How to display the weekday. |
+| `era` | `era` | `'narrow' \| 'short' \| 'long'` | How to display the era. |
+| `year` | `year` | `'numeric' \| '2-digit'` | How to display the year. |
+| `month` | `month` | `'numeric' \| '2-digit' \| 'narrow' \| 'short' \| 'long'` | How to display the month. |
+| `day` | `day` | `'numeric' \| '2-digit'` | How to display the day. |
+| `dayPeriod` | `day-period` | `'narrow' \| 'short' \| 'long'` | How to display the day period (AM/PM). Only effective when `hour12` is `true`. |
+| `hour` | `hour` | `'numeric' \| '2-digit'` | How to display the hour. |
+| `minute` | `minute` | `'numeric' \| '2-digit'` | How to display the minute. |
+| `second` | `second` | `'numeric' \| '2-digit'` | How to display the second. |
+| `timeZoneName` | `time-zone-name` | `'short' \| 'long'` | How to display the time zone name. |
+| `timeZone` | `time-zone` | `string` | The IANA time zone to use (e.g. `Europe/Amsterdam`). Defaults to the runtime's local time zone. |
+| `hour12` | `hour12` | `boolean` | Whether to use 12-hour time. Defaults to locale-dependent behaviour. |
+| `locale` | `locale` | `string` | The BCP 47 locale tag to use. Inherits from the nearest `lang` attribute by default. |
+| `dateTimeOptions` | `date-time-options` | `Intl.DateTimeFormatOptions` | Advanced formatting options passed directly to `Intl.DateTimeFormat`. These are merged with and can override the individual property values. |
+
+{.ds-table .ds-table-align-top}
+
+</div>
+
+### Slots
+
+<div class="ds-table-wrapper">
+
+| Name | Description |
+|------|-------------|
+| *(default)* | Fallback content shown when `date` is not set or is invalid. |
+
+{.ds-table}
+
+</div>
+
+### Static properties
+
+The default values of `dateStyle` and `timeStyle` can be changed globally for all future instances:
+
+<div class="ds-code">
+
+```js
+import { FormatDate } from '@sl-design-system/format-date';
+
+FormatDate.dateStyle = 'short';
+FormatDate.timeStyle = 'short';
+```
+
+</div>
+
+</section>
+
+</div>
+</section>

--- a/website/src/styles/categories/design-tokens/base-tokens.scss
+++ b/website/src/styles/categories/design-tokens/base-tokens.scss
@@ -5,12 +5,16 @@
   border-radius: 0.6rem;
   color: var(--heading-color);
   padding: 4rem;
+
+  code {
+    background-color: rgb(255 255 255 / 30%);
+  }
 }
 
 .ds-tokens__heading-description {
   font-size: 1.8rem;
   line-height: 2.4rem;
-  margin-top: 1.6rem;
+  margin-block-start: 1.6rem;
 }
 
 @media screen and (min-width: $xl-breakpoint) {
@@ -29,7 +33,7 @@
 
 @media screen and (min-width: $xl-breakpoint) {
   .ds-tokens__wrapper {
-    width: calc((100% / 8) * 7 - 7.2rem);
+    inline-size: calc((100% / 8) * 7 - 7.2rem);
   }
 }
 
@@ -42,43 +46,43 @@
 }
 
 .ds-tokens__heading {
-  margin-bottom: 2.4rem;
+  margin-block-end: 2.4rem;
 }
 
 .ds-tokens__color {
+  block-size: 8rem;
   border: 1px solid var(--vertical-slider-background);
   border-radius: 50%;
-  height: 8rem;
-  margin-bottom: 0.8rem;
-  width: 8rem;
+  inline-size: 8rem;
+  margin-block-end: 0.8rem;
 }
 
 .ds-tokens__text {
   font-size: 2.4rem;
   line-height: 1;
-  margin-bottom: 0.8rem;
+  margin-block-end: 0.8rem;
 }
 
 .ds-tokens__border {
   background-color: var(--picture-background);
+  block-size: 8rem;
   border: 1px solid var(--heading-background);
-  height: 8rem;
-  margin-bottom: 0.8rem;
-  width: 8rem;
+  inline-size: 8rem;
+  margin-block-end: 0.8rem;
 }
 
 .ds-tokens__border-example {
   align-items: center;
   display: flex;
   flex-direction: column;
-  width: fit-content;
+  inline-size: fit-content;
 }
 
 .ds-tokens__space {
   background-color: var(--ds-color-light-grey);
-  height: 8rem;
-  margin-bottom: 0.8rem;
-  width: 8rem;
+  block-size: 8rem;
+  inline-size: 8rem;
+  margin-block-end: 0.8rem;
 }
 
 .ds-tokens__space-example,
@@ -86,28 +90,28 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  min-width: 6rem;
-  width: fit-content;
+  inline-size: fit-content;
+  min-inline-size: 6rem;
 }
 
 .ds-tokens__opacity {
   background-color: var(--heading-background);
-  height: 6rem;
-  margin-bottom: 0.8rem;
-  width: 6rem;
+  block-size: 6rem;
+  inline-size: 6rem;
+  margin-block-end: 0.8rem;
 }
 
 .ds-tokens__size {
   background-color: var(--ds-color-light-grey);
-  margin-bottom: 0.8rem;
+  margin-block-end: 0.8rem;
 }
 
 .ds-tokens__size-example {
   align-items: center;
   display: flex;
   flex-direction: column;
-  min-width: 7.2rem;
-  width: fit-content;
+  inline-size: fit-content;
+  min-inline-size: 7.2rem;
 }
 
 .ds-tokens__description {
@@ -118,14 +122,14 @@
   background-color: var(--picture-background);
   border-radius: 0.3rem;
   display: inline-flex;
-  margin-bottom: 0.8rem;
+  margin-block-end: 0.8rem;
   overflow: hidden;
 }
 
 .ds-tokens__triangle {
+  block-size: 0;
   border-color: var(--heading-background) transparent transparent transparent;
   border-style: solid;
   border-width: 6rem 6rem 0 0;
-  height: 0;
-  width: 0;
+  inline-size: 0;
 }

--- a/website/src/ts/scripts/slds-components.ts
+++ b/website/src/ts/scripts/slds-components.ts
@@ -63,6 +63,7 @@ import '@sl-design-system/dialog/register.js';
 import '@sl-design-system/drawer/register.js';
 import '@sl-design-system/editor/register.js';
 import '@sl-design-system/form/register.js';
+import '@sl-design-system/format-date/register.js';
 import '@sl-design-system/grid/register.js';
 import { Icon } from '@sl-design-system/icon';
 import '@sl-design-system/icon/register.js';


### PR DESCRIPTION
## Summary

Fixes a bug where setting `date-style` or `time-style` to an empty string would pass an invalid value to `Intl.DateTimeFormat`, causing a runtime error. Empty string values are now coerced to `undefined`, falling back to default formatting behavior.

Also adds documentation for `sl-format-date` and expands the unit test suite.

Closes #3204 

## Changes

### `@sl-design-system/format-date`

- **Bug fix**: `dateStyle` and `timeStyle` values are now coerced via `|| undefined` before being passed to `Intl.DateTimeFormat`, so an empty `date-style=""` or `time-style=""` attribute no longer causes an error
- **Tests**: Expanded test suite covering:
  - Empty `date-style` / `time-style` attributes
  - `date` setter accepting numeric timestamps, ISO strings, `null`, and `undefined`
  - `dateStyle` + `timeStyle` used together
  - Individual options overriding `dateStyle`/`timeStyle`
  - `dateTimeOptions` property
  - `hour12: true`
  - Fixed outer `describe` title typo (`sl-format-number` → `sl-format-date`)

### Website

- Added documentation page for `sl-format-date` under Utilities, covering overview, installation, usage patterns, and full API reference