### PR TITLE
Move `<sl-format-number>` to preview status

### DIFF
--- a/.changeset/major-streets-prove.md
+++ b/.changeset/major-streets-prove.md
@@ -1,0 +1,8 @@
+---
+'@sl-design-system/format-number': patch
+---
+
+Minor fixes and promote to preview status
+
+- Fixed unreachable `return html\`<slot></slot>\``dead code in`render()`
+- Added missing unit tests for `minimumIntegerDigits`, `minimumSignificantDigits`, `maximumSignificantDigits`, `notation`, `signDisplay`, `currencyDisplay`, negative numbers, zero, `useGrouping: true`, explicit `NaN`, no number set, and locale-aware formatting

--- a/.changeset/major-streets-prove.md
+++ b/.changeset/major-streets-prove.md
@@ -4,5 +4,5 @@
 
 Minor fixes and promote to preview status
 
-- Fixed unreachable `return html\`<slot></slot>\``dead code in`render()`
+- Fixed unreachable `return html\`<slot></slot>\`` dead code in `render()`
 - Added missing unit tests for `minimumIntegerDigits`, `minimumSignificantDigits`, `maximumSignificantDigits`, `notation`, `signDisplay`, `currencyDisplay`, negative numbers, zero, `useGrouping: true`, explicit `NaN`, no number set, and locale-aware formatting

--- a/packages/components/format-number/src/format-number.spec.ts
+++ b/packages/components/format-number/src/format-number.spec.ts
@@ -68,6 +68,99 @@ describe('sl-format-number', () => {
 
       expect(el.renderRoot).to.have.text('1,234.560');
     });
+
+    it('should pad integer digits according to minimumIntegerDigits', async () => {
+      el.number = 5;
+      el.minimumIntegerDigits = 3;
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('005');
+    });
+
+    it('should render according to minimumSignificantDigits', async () => {
+      el.number = 1.5;
+      el.minimumSignificantDigits = 4;
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('1.500');
+    });
+
+    it('should render according to maximumSignificantDigits', async () => {
+      el.number = 1234.56;
+      el.maximumSignificantDigits = 3;
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('1,230');
+    });
+
+    it('should render in compact notation', async () => {
+      el.notation = 'compact';
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('1.2K');
+    });
+
+    it('should render in scientific notation', async () => {
+      el.number = 1230;
+      el.notation = 'scientific';
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('1.23E3');
+    });
+
+    it('should always show the sign', async () => {
+      el.signDisplay = 'always';
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('+1,234.56');
+    });
+
+    it('should never show the sign', async () => {
+      el.number = -42;
+      el.signDisplay = 'never';
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('42');
+    });
+
+    it('should render a negative number', async () => {
+      el.number = -1234.56;
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('-1,234.56');
+    });
+
+    it('should render zero', async () => {
+      el.number = 0;
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('0');
+    });
+
+    it('should render currency with code display', async () => {
+      el.numberStyle = 'currency';
+      el.currency = 'USD';
+      el.currencyDisplay = 'code';
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('USD\u00a01,234.56');
+    });
+
+    it('should render currency with name display', async () => {
+      el.numberStyle = 'currency';
+      el.currency = 'USD';
+      el.currencyDisplay = 'name';
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('1,234.56 US dollars');
+    });
+
+    it('should use grouping if useGrouping is set to true', async () => {
+      el.useGrouping = true;
+      await el.updateComplete;
+
+      expect(el.renderRoot).to.have.text('1,234.56');
+    });
   });
 
   describe('fallback', () => {
@@ -80,6 +173,21 @@ describe('sl-format-number', () => {
       await el.updateComplete;
 
       expect(el.renderRoot).to.have.text('1,234');
+    });
+
+    it('should render the slotted content if the number is NaN', async () => {
+      el.number = NaN;
+      await el.updateComplete;
+
+      const slot = el.renderRoot.querySelector('slot');
+
+      expect(slot).to.exist;
+      expect(
+        slot!
+          .assignedNodes()
+          .map(n => n.textContent)
+          .join('')
+      ).to.equal('Hello world');
     });
 
     it('should render the slotted content if the number is not a number', async () => {
@@ -95,6 +203,26 @@ describe('sl-format-number', () => {
           .map(n => n.textContent)
           .join('')
       ).to.equal('Hello world');
+    });
+
+    it('should render the slotted content if no number is set', () => {
+      const slot = el.renderRoot.querySelector('slot');
+
+      expect(slot).to.exist;
+      expect(
+        slot!
+          .assignedNodes()
+          .map(n => n.textContent)
+          .join('')
+      ).to.equal('Hello world');
+    });
+  });
+
+  describe('locale', () => {
+    it('should format using the element locale attribute', async () => {
+      el = await fixture(html`<sl-format-number number="1234.56" locale="nl-NL"></sl-format-number>`);
+
+      expect(el.renderRoot).to.have.text('1.234,56');
     });
   });
 });

--- a/packages/components/format-number/src/format-number.stories.ts
+++ b/packages/components/format-number/src/format-number.stories.ts
@@ -27,7 +27,7 @@ type Story = StoryObj<Props>;
 
 export default {
   title: 'Utilities/Format number',
-  tags: ['draft'],
+  tags: ['preview'],
   argTypes: {
     currency: {
       type: 'string'

--- a/packages/components/format-number/src/format-number.ts
+++ b/packages/components/format-number/src/format-number.ts
@@ -122,7 +122,5 @@ export class FormatNumber extends LocaleMixin(LitElement) {
       useGrouping,
       ...this.formatOptions
     });
-
-    return html`<slot></slot>`;
   }
 }

--- a/website/src/categories/utilities/format-number.md
+++ b/website/src/categories/utilities/format-number.md
@@ -1,0 +1,254 @@
+---
+title: Format number
+eleventyNavigation:
+  parent: Utilities
+  key: Format number
+---
+
+<header class="ds-tokens__main-heading">
+<div class="ds-tokens__heading-wrapper">
+  <h1 class="ds-heading-1">{{title}}</h1>
+  <p class="ds-tokens__heading-description">
+  A utility component for formatting numbers using the browser's <code>Intl.NumberFormat</code> API, with automatic locale support.
+  </p>
+</div>
+</header>
+
+<section class="ds-subpage-section">
+<div class="ds-subpage-section__wrapper">
+
+<section>
+
+## Overview
+
+`sl-format-number` renders a formatted number string based on a `number` property and a set of formatting options. It wraps the native [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) API, covering decimal numbers, currencies, percentages, and units.
+
+When `number` is not set or is not a valid number, the element falls back to rendering its slotted content — useful for showing a placeholder or an error message.
+
+The component uses `LocaleMixin`, which automatically picks up the locale from the nearest `lang` attribute in the DOM. This means the formatted output adapts to the language and regional conventions of the surrounding page without any extra configuration. You can also override it explicitly with the `locale` property.
+
+<div class="ds-example">
+
+<sl-format-number number="1234567.89"></sl-format-number>
+
+</div>
+
+<div class="ds-code">
+
+```html
+<sl-format-number number="1234567.89"></sl-format-number>
+```
+
+</div>
+
+</section>
+
+<section>
+
+<ds-install-info package="format-number"></ds-install-info>
+
+</section>
+
+<section>
+
+## Usage
+
+### Decimal numbers
+
+By default (no `number-style` set), numbers are formatted as plain decimals using the locale's conventions for digit grouping and decimal separators.
+
+<div class="ds-code">
+
+```html
+<sl-format-number number="1234567.89"></sl-format-number>
+<!-- en: 1,234,567.89 | nl: 1.234.567,89 -->
+```
+
+</div>
+
+### Currency
+
+Set `number-style="currency"` and provide a `currency` code (ISO 4217) to format a monetary value.
+
+<div class="ds-code">
+
+```html
+<sl-format-number number-style="currency" currency="EUR" number="9.90"></sl-format-number>
+<!-- en: €9.90 | nl: € 9,90 -->
+```
+
+</div>
+
+Control how the currency symbol is displayed with `currency-display`:
+
+<div class="ds-table-wrapper">
+
+| Value | Example |
+|-------|---------|
+| `symbol` (default) | €9.90 |
+| `narrowSymbol` | €9.90 |
+| `code` | EUR 9.90 |
+| `name` | 9.90 euros |
+
+{.ds-table}
+
+</div>
+
+### Percent
+
+Set `number-style="percent"` to format a number as a percentage. Pass values between `0` and `1`.
+
+<div class="ds-code">
+
+```html
+<sl-format-number number-style="percent" number="0.42"></sl-format-number>
+<!-- 42% -->
+```
+
+</div>
+
+### Unit
+
+Set `number-style="unit"` together with a `unit` (a valid [CLDR unit identifier](https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers)) to format a measurement.
+
+<div class="ds-code">
+
+```html
+<sl-format-number number-style="unit" unit="kilometer-per-hour" number="120"></sl-format-number>
+<!-- 120 km/h -->
+```
+
+</div>
+
+Control how the unit is displayed with `unit-display`:
+
+<div class="ds-table-wrapper">
+
+| Value | Example |
+|-------|---------|
+| `short` (default) | 120 km/h |
+| `long` | 120 kilometers per hour |
+| `narrow` | 120km/h |
+
+{.ds-table}
+
+</div>
+
+### Notation
+
+Use `notation` to control the number format style:
+
+<div class="ds-table-wrapper">
+
+| Value | Description | Example |
+|-------|-------------|---------|
+| `standard` (default) | Plain formatting | 1,234,567 |
+| `scientific` | Scientific notation | 1.235E6 |
+| `engineering` | Engineering notation (exponents divisible by 3) | 1.235E6 |
+| `compact` | Abbreviated for readability | 1.2M |
+
+{.ds-table}
+
+</div>
+
+### Grouping separators
+
+Grouping separators (e.g. thousands separators) are enabled by default. Set `use-grouping="false"` to disable them.
+
+<div class="ds-code">
+
+```html
+<sl-format-number number="1234567" use-grouping="false"></sl-format-number>
+<!-- 1234567 -->
+```
+
+</div>
+
+### Digit precision
+
+Control the number of displayed digits with the precision properties. See the [Properties table](#properties) for the full list.
+
+<div class="ds-code">
+
+```html
+<sl-format-number number="3.14159" maximum-fraction-digits="2"></sl-format-number>
+<!-- 3.14 -->
+```
+
+</div>
+
+### Advanced formatting options
+
+For options not exposed as individual properties, use `format-options` to pass an `Intl.NumberFormatOptions` object directly. These are merged with and can override the individual property values.
+
+<div class="ds-code">
+
+```js
+const el = document.querySelector('sl-format-number');
+el.number = 1234567;
+el.formatOptions = { notation: 'compact', compactDisplay: 'long' };
+```
+
+</div>
+
+### Fallback content
+
+When `number` is not set or is not a valid number, the default slot is rendered:
+
+<div class="ds-code">
+
+```html
+<sl-format-number>N/A</sl-format-number>
+```
+
+</div>
+
+</section>
+
+<section>
+
+## API
+
+### Properties
+
+<div class="ds-table-wrapper">
+
+| Property | Attribute | Type | Description |
+|----------|-----------|------|-------------|
+| `number` | `number` | `number` | The number to format. Falls back to slot content when not set or `NaN`. |
+| `numberStyle` | `number-style` | `'decimal' \| 'currency' \| 'percent' \| 'unit'` | The formatting style. Defaults to `'decimal'`. |
+| `currency` | `currency` | `string` | ISO 4217 currency code (e.g. `'EUR'`). Required when `numberStyle` is `'currency'`. |
+| `currencyDisplay` | `currency-display` | `'code' \| 'symbol' \| 'narrowSymbol' \| 'name'` | How to display the currency. Defaults to `'symbol'`. |
+| `unit` | `unit` | `string` | A CLDR unit identifier (e.g. `'kilometer-per-hour'`). Required when `numberStyle` is `'unit'`. |
+| `unitDisplay` | `unit-display` | `'short' \| 'long' \| 'narrow'` | How to display the unit. Defaults to `'short'`. |
+| `notation` | `notation` | `'standard' \| 'scientific' \| 'engineering' \| 'compact'` | The number notation style. Defaults to `'standard'`. |
+| `signDisplay` | `sign-display` | `'auto' \| 'never' \| 'always' \| 'exceptZero'` | When to show the sign. Defaults to `'auto'`. |
+| `useGrouping` | `use-grouping` | `boolean` | Whether to use grouping separators (e.g. thousands separator). Defaults to `true`. |
+| `minimumIntegerDigits` | `minimum-integer-digits` | `number` | Minimum integer digits. Range 1–21. Defaults to `1`. |
+| `minimumFractionDigits` | `minimum-fraction-digits` | `number` | Minimum fraction digits. Range 0–100. |
+| `maximumFractionDigits` | `maximum-fraction-digits` | `number` | Maximum fraction digits. Range 0–100. |
+| `minimumSignificantDigits` | `minimum-significant-digits` | `number` | Minimum significant digits. Range 1–21. |
+| `maximumSignificantDigits` | `maximum-significant-digits` | `number` | Maximum significant digits. Range 1–21. |
+| `locale` | `locale` | `string` | BCP 47 locale tag. Inherits from the nearest `lang` attribute by default. |
+| `formatOptions` | `format-options` | `Intl.NumberFormatOptions` | Advanced options passed directly to `Intl.NumberFormat`. Merged with and overrides individual property values. |
+
+{.ds-table .ds-table-align-top}
+
+</div>
+
+### Slots
+
+<div class="ds-table-wrapper">
+
+| Name | Description |
+|------|-------------|
+| *(default)* | Fallback content shown when `number` is not set or is `NaN`. |
+
+{.ds-table}
+
+</div>
+
+</section>
+
+</div>
+</section>

--- a/website/src/ts/scripts/slds-components.ts
+++ b/website/src/ts/scripts/slds-components.ts
@@ -63,6 +63,7 @@ import '@sl-design-system/dialog/register.js';
 import '@sl-design-system/drawer/register.js';
 import '@sl-design-system/editor/register.js';
 import '@sl-design-system/form/register.js';
+import '@sl-design-system/format-number/register.js';
 import '@sl-design-system/grid/register.js';
 import { Icon } from '@sl-design-system/icon';
 import '@sl-design-system/icon/register.js';


### PR DESCRIPTION
Closes #3205

## Summary

Promotes `<sl-format-number>` to preview status. The API is stable and not expected to change.

## Changes

- Fixed unreachable `return html`<slot></slot>`` dead code in `render()`
- Added comprehensive unit tests for `minimumIntegerDigits`, `minimumSignificantDigits`, `maximumSignificantDigits`, `notation`, `signDisplay`, `currencyDisplay`, negative numbers, zero, `useGrouping: true`, explicit `NaN`, no number set, and locale-aware formatting
- Updated Storybook status from `draft` to `preview`
- Added documentation page for the website
- Registered the component in the website's component list