### PR TITLE
fix(button): fix link styling in button

### DIFF
--- a/.changeset/clear-crews-laugh.md
+++ b/.changeset/clear-crews-laugh.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed styling of slotted `<a href>` elements inside `<sl-button>`. Global CSS from the application could override the link color and text decoration, causing the button to render incorrectly.
+
+> **Note:** Slotting an `<a href>` inside an `<sl-button>` is considered bad practice. Use an `<a href>` directly. There are already styles for that in the theme's `global.css`.

--- a/.changeset/clear-crews-laugh.md
+++ b/.changeset/clear-crews-laugh.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/button': patch
+---
+
+Fixed styling of slotted `<a href>` elements inside `<sl-button>`. Global CSS from the application could override the link color and text decoration, causing the button to render incorrectly.

--- a/packages/components/button/src/button.scss
+++ b/packages/components/button/src/button.scss
@@ -172,15 +172,6 @@
   border-radius: var(--sl-size-borderRadius-full);
 }
 
-button:disabled {
-  pointer-events: none;
-}
-
-button:is(:disabled, [aria-disabled]) {
-  color: var(--sl-color-foreground-disabled);
-  cursor: default;
-}
-
 :host(:where(:not([fill]), [fill='solid'])) button:is(:disabled, [aria-disabled]) {
   background: var(--sl-color-background-disabled);
 }
@@ -224,6 +215,11 @@ button:is(:disabled, [aria-disabled]) {
   border-color: var(--sl-color-border-inverted);
 }
 
+::slotted(a) {
+  color: inherit !important;
+  text-decoration: none !important;
+}
+
 button {
   --_bg-color: var(--sl-color-background-secondary-bold);
   --_bg-mix-color: var(--sl-color-background-secondary-interactive-bold);
@@ -259,6 +255,15 @@ button {
   &:active {
     --_bg-opacity: var(--sl-opacity-interactive-bold-active);
   }
+
+  &:disabled {
+    pointer-events: none;
+  }
+}
+
+button:is(:disabled, [aria-disabled]) {
+  color: var(--sl-color-foreground-disabled);
+  cursor: default;
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/packages/components/button/src/button.stories.ts
+++ b/packages/components/button/src/button.stories.ts
@@ -161,20 +161,6 @@ export const IconOnly: Story = {
   }
 };
 
-export const Link: Story = {
-  render: ({ disabled, shape, size, text, variant }) => html`
-    <sl-button
-      ?disabled=${disabled}
-      fill="link"
-      shape=${ifDefined(shape)}
-      size=${ifDefined(size)}
-      variant=${ifDefined(variant)}
-    >
-      <a href="https://example.com">${text}</a>
-    </sl-button>
-  `
-};
-
 export const Pill: Story = {
   args: {
     shape: 'pill'
@@ -399,42 +385,42 @@ export const All: Story = {
         <span>Link</span>
         <sl-button fill="link" variant="primary">
           <sl-icon name="far-universal-access"></sl-icon>
-          <a href="https://example.com">Button</a>
+          Button
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="secondary">
           <sl-icon name="far-universal-access"></sl-icon>
-          <a href="https://example.com">Button</a>
+          Button
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="success">
           <sl-icon name="far-universal-access"></sl-icon>
-          <a href="https://example.com">Button</a>
+          Button
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="warning">
           <sl-icon name="far-universal-access"></sl-icon>
-          <a href="https://example.com">Button</a>
+          Button
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="danger">
           <sl-icon name="far-universal-access"></sl-icon>
-          <a href="https://example.com">Button</a>
+          Button
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="info">
           <sl-icon name="far-universal-access"></sl-icon>
-          <a href="https://example.com">Button</a>
+          Button
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="inverted">
           <sl-icon name="far-universal-access"></sl-icon>
-          <a href="https://example.com">Button</a>
+          Button
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button disabled fill="link">
           <sl-icon name="far-universal-access"></sl-icon>
-          <a href="https://example.com">Button</a>
+          Button
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
 

--- a/packages/components/button/src/button.stories.ts
+++ b/packages/components/button/src/button.stories.ts
@@ -161,6 +161,20 @@ export const IconOnly: Story = {
   }
 };
 
+export const Link: Story = {
+  render: ({ disabled, shape, size, text, variant }) => html`
+    <sl-button
+      ?disabled=${disabled}
+      fill="link"
+      shape=${ifDefined(shape)}
+      size=${ifDefined(size)}
+      variant=${ifDefined(variant)}
+    >
+      <a href="https://example.com">${text}</a>
+    </sl-button>
+  `
+};
+
 export const Pill: Story = {
   args: {
     shape: 'pill'
@@ -385,42 +399,42 @@ export const All: Story = {
         <span>Link</span>
         <sl-button fill="link" variant="primary">
           <sl-icon name="far-universal-access"></sl-icon>
-          Button
+          <a href="https://example.com">Button</a>
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="secondary">
           <sl-icon name="far-universal-access"></sl-icon>
-          Button
+          <a href="https://example.com">Button</a>
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="success">
           <sl-icon name="far-universal-access"></sl-icon>
-          Button
+          <a href="https://example.com">Button</a>
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="warning">
           <sl-icon name="far-universal-access"></sl-icon>
-          Button
+          <a href="https://example.com">Button</a>
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="danger">
           <sl-icon name="far-universal-access"></sl-icon>
-          Button
+          <a href="https://example.com">Button</a>
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="info">
           <sl-icon name="far-universal-access"></sl-icon>
-          Button
+          <a href="https://example.com">Button</a>
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button fill="link" variant="inverted">
           <sl-icon name="far-universal-access"></sl-icon>
-          Button
+          <a href="https://example.com">Button</a>
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
         <sl-button disabled fill="link">
           <sl-icon name="far-universal-access"></sl-icon>
-          Button
+          <a href="https://example.com">Button</a>
           <sl-icon name="far-universal-access"></sl-icon>
         </sl-button>
 


### PR DESCRIPTION
Fixes #3218

## Summary

Fixed styling of slotted `<a>` elements inside `<sl-button>`. Global CSS from the application could override the link color and text decoration, causing the button to render incorrectly. Styles are now explicitly reset using `::slotted(a)` to ensure the button's own color and text-decoration styles are always applied.

## Changes

- Added `::slotted(a)` rule to reset `color` and `text-decoration` on slotted anchor elements
- Moved `button:disabled { pointer-events: none }` inside the `button {}` rule scope
- Added a new `Link` story to demonstrate `<sl-button fill="link">` with a slotted `<a href>`
- Updated the `All` story to use `<a href>` elements inside link-fill buttons