### PR TITLE
Fix/3216 buttons in actions slot are covered by empty body

### DIFF
--- a/.changeset/new-socks-draw.md
+++ b/.changeset/new-socks-draw.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/card': patch
+---
+
+Fix: ensure body slot doesn't overlay button when there is no body text.

--- a/packages/components/card/src/card.scss
+++ b/packages/components/card/src/card.scss
@@ -165,6 +165,10 @@
     overflow: hidden;
   }
 
+  :host(:not(.sl-has-article)) slot[name='body'] {
+    display: contents;
+  }
+
   slot.title::slotted(*),
   slot[name='body']::slotted(*) {
     margin-block: 0;

--- a/packages/components/card/src/card.spec.ts
+++ b/packages/components/card/src/card.spec.ts
@@ -291,13 +291,16 @@ describe('<sl-card>', () => {
 
       // Add body content
       const bodySlot = el.shadowRoot!.querySelector('slot[name="body"]') as HTMLSlotElement;
-      let slotChangePromise = new Promise(resolve => bodySlot.addEventListener('slotchange', resolve, { once: true }));
+      const waitForSlotChange = () =>
+        new Promise<void>(resolve => bodySlot.addEventListener('slotchange', () => resolve(), { once: true }));
+
+      let slotChangePromise = waitForSlotChange();
       el.appendChild(bodyElement);
       await slotChangePromise;
       expect(el.classList.contains('sl-has-article')).to.be.true;
 
       // Remove body content
-      slotChangePromise = new Promise(resolve => bodySlot.addEventListener('slotchange', resolve, { once: true }));
+      slotChangePromise = waitForSlotChange();
       el.removeChild(bodyElement);
       await slotChangePromise;
       expect(el.classList.contains('sl-has-article')).to.be.false;

--- a/packages/components/card/src/card.spec.ts
+++ b/packages/components/card/src/card.spec.ts
@@ -290,13 +290,16 @@ describe('<sl-card>', () => {
       expect(el.classList.contains('sl-has-article')).to.be.false;
 
       // Add body content
+      const bodySlot = el.shadowRoot!.querySelector('slot[name="body"]') as HTMLSlotElement;
+      let slotChangePromise = new Promise(resolve => bodySlot.addEventListener('slotchange', resolve, { once: true }));
       el.appendChild(bodyElement);
-      await el.updateComplete;
+      await slotChangePromise;
       expect(el.classList.contains('sl-has-article')).to.be.true;
 
       // Remove body content
+      slotChangePromise = new Promise(resolve => bodySlot.addEventListener('slotchange', resolve, { once: true }));
       el.removeChild(bodyElement);
-      await el.updateComplete;
+      await slotChangePromise;
       expect(el.classList.contains('sl-has-article')).to.be.false;
 
       document.body.removeChild(container);

--- a/packages/components/card/src/card.spec.ts
+++ b/packages/components/card/src/card.spec.ts
@@ -244,4 +244,62 @@ describe('<sl-card>', () => {
       expect(el.classList.contains('sl-media-explicit-size')).to.be.true;
     });
   });
+
+  describe('body slot behavior', () => {
+    it('should add sl-has-article class when body slot has content', async () => {
+      el = await fixture(html`
+        <sl-card>
+          <h2>${title}</h2>
+          <p slot="body">${bodyCopy}</p>
+          <sl-button slot="actions">Action</sl-button>
+        </sl-card>
+      `);
+      await el.updateComplete;
+
+      expect(el.classList.contains('sl-has-article')).to.be.true;
+    });
+
+    it('should remove sl-has-article class when body slot is empty', async () => {
+      el = await fixture(html`
+        <sl-card>
+          <h2>${title}</h2>
+          <sl-button slot="actions">Action</sl-button>
+        </sl-card>
+      `);
+      await el.updateComplete;
+
+      expect(el.classList.contains('sl-has-article')).to.be.false;
+    });
+
+    it('should toggle sl-has-article class when body slot content changes', async () => {
+      const container = document.createElement('div');
+      const bodyElement = document.createElement('p');
+      bodyElement.setAttribute('slot', 'body');
+      bodyElement.textContent = bodyCopy;
+
+      container.innerHTML = `
+        <sl-card>
+          <h2>${title}</h2>
+          <sl-button slot="actions">Action</sl-button>
+        </sl-card>
+      `;
+      document.body.appendChild(container);
+      el = container.querySelector('sl-card') as Card;
+      await el.updateComplete;
+
+      expect(el.classList.contains('sl-has-article')).to.be.false;
+
+      // Add body content
+      el.appendChild(bodyElement);
+      await el.updateComplete;
+      expect(el.classList.contains('sl-has-article')).to.be.true;
+
+      // Remove body content
+      el.removeChild(bodyElement);
+      await el.updateComplete;
+      expect(el.classList.contains('sl-has-article')).to.be.false;
+
+      document.body.removeChild(container);
+    });
+  });
 });

--- a/packages/components/card/src/card.stories.ts
+++ b/packages/components/card/src/card.stories.ts
@@ -547,7 +547,7 @@ export const MediaOptions: Story = {
         ${card(settings, 0)} ${card({ ...settings, fitImage: true }, 1)}
         <span>Fit image with background-color set with <code>--sl-card-image-backdrop</code>:</span
         ><span>Fit image with background set to gradient with <code>--sl-card-image-backdrop</code>:</span>
-        ${card({ ...settings, fitImage: true }, 2)} ${card({ ...settings, fitImage: true, bodyText: '' }, 3)}
+        ${card({ ...settings, fitImage: true }, 2)} ${card({ ...settings, fitImage: true, bodyText: undefined }, 3)}
         <span>Fit image with imageBackdrop:</span><span>With media-margin</span>
         ${card({ ...settings, fitImage: true, imageBackdrop: true }, 1)} ${card({ ...settings, mediaMargin: true }, 0)}
       </div>

--- a/packages/components/card/src/card.stories.ts
+++ b/packages/components/card/src/card.stories.ts
@@ -547,7 +547,7 @@ export const MediaOptions: Story = {
         ${card(settings, 0)} ${card({ ...settings, fitImage: true }, 1)}
         <span>Fit image with background-color set with <code>--sl-card-image-backdrop</code>:</span
         ><span>Fit image with background set to gradient with <code>--sl-card-image-backdrop</code>:</span>
-        ${card({ ...settings, fitImage: true }, 2)} ${card({ ...settings, fitImage: true }, 3)}
+        ${card({ ...settings, fitImage: true }, 2)} ${card({ ...settings, fitImage: true, bodyText: '' }, 3)}
         <span>Fit image with imageBackdrop:</span><span>With media-margin</span>
         ${card({ ...settings, fitImage: true, imageBackdrop: true }, 1)} ${card({ ...settings, mediaMargin: true }, 0)}
       </div>

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -169,9 +169,12 @@ export class Card extends ScopedElementsMixin(LitElement) {
 
   #setLineClamp(): void {
     //calculate the number of lines in the article
-    const article = this.renderRoot.querySelector('slot[name="body"]');
-    if (!article) {
+    const article: HTMLSlotElement | null = this.renderRoot.querySelector('slot[name="body"]');
+    if (!article || article.assignedNodes({ flatten: true }).length === 0) {
+      this.classList.remove('sl-has-article');
       return;
+    } else {
+      this.classList.add('sl-has-article');
     }
 
     (article as HTMLElement).style.removeProperty('--_line-clamp'); // otherwise it can't calculate the height correctly

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -172,14 +172,14 @@ export class Card extends ScopedElementsMixin(LitElement) {
     const article: HTMLSlotElement | null = this.renderRoot.querySelector('slot[name="body"]');
     if (!article || article.assignedNodes({ flatten: true }).length === 0) {
       this.classList.remove('sl-has-article');
-      (article as HTMLElement)?.style.removeProperty('--_line-clamp');
+      article?.style.removeProperty('--_line-clamp');
       this.#setGridSpan();
       return;
     } else {
       this.classList.add('sl-has-article');
     }
 
-    (article as HTMLElement).style.removeProperty('--_line-clamp'); // otherwise it can't calculate the height correctly
+    article.style.removeProperty('--_line-clamp'); // otherwise it can't calculate the height correctly
     const lineHeight = getComputedStyle(article).lineHeight;
 
     const lineHeightFont =
@@ -188,7 +188,7 @@ export class Card extends ScopedElementsMixin(LitElement) {
         : parseInt(lineHeight);
     const lines = Math.floor(article.getBoundingClientRect().height / lineHeightFont);
     if (!isNaN(lines) && lines > 0) {
-      (article as HTMLElement).style.setProperty('--_line-clamp', lines.toString());
+      article.style.setProperty('--_line-clamp', lines.toString());
     }
     this.#setGridSpan();
   }

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -172,6 +172,8 @@ export class Card extends ScopedElementsMixin(LitElement) {
     const article: HTMLSlotElement | null = this.renderRoot.querySelector('slot[name="body"]');
     if (!article || article.assignedNodes({ flatten: true }).length === 0) {
       this.classList.remove('sl-has-article');
+      (article as HTMLElement)?.style.removeProperty('--_line-clamp');
+      this.#setGridSpan();
       return;
     } else {
       this.classList.add('sl-has-article');

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -175,9 +175,9 @@ export class Card extends ScopedElementsMixin(LitElement) {
       article?.style.removeProperty('--_line-clamp');
       this.#setGridSpan();
       return;
-    } else {
-      this.classList.add('sl-has-article');
     }
+
+    this.classList.add('sl-has-article');
 
     article.style.removeProperty('--_line-clamp'); // otherwise it can't calculate the height correctly
     const lineHeight = getComputedStyle(article).lineHeight;


### PR DESCRIPTION
This pull request fixes an issue in the `@sl-design-system/card` component where the body slot could overlay the button when there is no body text. The changes ensure that the card layout correctly handles the absence of body content, preventing UI overlap and improving the component's robustness.

**Bug fix for card body content handling:**

* Updated the `#setLineClamp` method in `card.ts` to add or remove the `sl-has-article` class based on whether the body slot contains content, ensuring correct styling and layout.
* Modified `card.scss` so that when the card does not have body content (`:not(.sl-has-article)`), the body slot uses `display: contents`, preventing overlay issues.

**Storybook and documentation updates:**

* Adjusted a story in `card.stories.ts` to explicitly test the case where `bodyText` is an empty string, reflecting the fix and improving coverage.
* Added a changeset file documenting the patch and its intent to prevent the body slot from overlaying the button when empty.