### PR TITLE
fix(accordion):  announce disabled accordion items to assistive technologies

### DIFF
--- a/.changeset/silent-spoons-matter.md
+++ b/.changeset/silent-spoons-matter.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/accordion': patch
+---
+
+Sync accessibility state on `sl-accordion-item` so disabled items are announced correctly by assistive technologies.
+
+Disabled accordion items now expose `aria-disabled="true"` on the focusable host element, while also keeping `aria-expanded` in sync. This improves screen reader support in browsers where the disabled state was not announced consistently.

--- a/.changeset/silent-spoons-matter.md
+++ b/.changeset/silent-spoons-matter.md
@@ -4,4 +4,4 @@
 
 Sync accessibility state on `sl-accordion-item` so disabled items are announced correctly by assistive technologies.
 
-Disabled accordion items now expose `aria-disabled="true"` on the focusable host element, while also keeping `aria-expanded` in sync. This improves screen reader support in browsers where the disabled state was not announced consistently.
+Disabled accordion items now expose `aria-disabled="true"` and keep `aria-expanded` in sync. This improves screen reader support in browsers where the disabled state was not announced consistently.

--- a/packages/components/accordion/src/accordion-item.spec.ts
+++ b/packages/components/accordion/src/accordion-item.spec.ts
@@ -22,7 +22,6 @@ describe('sl-accordion-item', () => {
 
     it('should not be disabled', () => {
       expect(el).not.to.have.attribute('disabled');
-      expect(el).not.to.have.attribute('aria-disabled');
       expect(el.disabled).not.to.be.true;
     });
 
@@ -59,8 +58,8 @@ describe('sl-accordion-item', () => {
 
     it('should have the correct attributes', () => {
       expect(summary).to.have.attribute('aria-controls', 'content');
-      expect(summary).to.have.attribute('aria-expanded', 'false');
       expect(summary).not.to.have.attribute('aria-disabled');
+      expect(summary).to.have.attribute('aria-expanded', 'false');
     });
 
     it('should open on click', async () => {
@@ -151,8 +150,8 @@ describe('sl-accordion-item', () => {
     });
 
     it('should be disabled', () => {
-      expect(el).to.have.attribute('aria-disabled', 'true');
       expect(el.disabled).to.be.true;
+      expect(summary).to.have.attribute('aria-disabled', 'true');
     });
 
     it('should have a tabindex of -1', () => {

--- a/packages/components/accordion/src/accordion-item.spec.ts
+++ b/packages/components/accordion/src/accordion-item.spec.ts
@@ -22,6 +22,7 @@ describe('sl-accordion-item', () => {
 
     it('should not be disabled', () => {
       expect(el).not.to.have.attribute('disabled');
+      expect(el).not.to.have.attribute('aria-disabled');
       expect(el.disabled).not.to.be.true;
     });
 
@@ -59,6 +60,7 @@ describe('sl-accordion-item', () => {
     it('should have the correct attributes', () => {
       expect(summary).to.have.attribute('aria-controls', 'content');
       expect(summary).to.have.attribute('aria-expanded', 'false');
+      expect(summary).not.to.have.attribute('aria-disabled');
     });
 
     it('should open on click', async () => {
@@ -142,12 +144,14 @@ describe('sl-accordion-item', () => {
           Content of disabled accordion item
         </sl-accordion-item>
       `);
+      await el.updateComplete;
 
       details = el.renderRoot.querySelector('details') as HTMLDetailsElement;
       summary = el.renderRoot.querySelector('summary') as HTMLElement;
     });
 
     it('should be disabled', () => {
+      expect(el).to.have.attribute('aria-disabled', 'true');
       expect(el.disabled).to.be.true;
     });
 

--- a/packages/components/accordion/src/accordion-item.ts
+++ b/packages/components/accordion/src/accordion-item.ts
@@ -46,6 +46,7 @@ export class AccordionItem extends LitElement {
 
   override firstUpdated(changes: PropertyValues<this>): void {
     super.firstUpdated(changes);
+    this.#syncAccessibilityState();
 
     if (this.open) {
       this.renderRoot.querySelector('details')?.setAttribute('open', '');
@@ -54,6 +55,7 @@ export class AccordionItem extends LitElement {
 
   override updated(changes: PropertyValues<this>): void {
     super.updated(changes);
+    this.#syncAccessibilityState();
 
     if (changes.has('open')) {
       this.#animateState(this.open ? 'opening' : 'closing');
@@ -136,6 +138,17 @@ export class AccordionItem extends LitElement {
   #onToggle(event: ToggleEvent): void {
     this.open = event.newState === 'open';
     this.toggleEvent.emit(this.open);
+  }
+
+  #syncAccessibilityState(): void {
+    this.setAttribute('role', 'button');
+    this.setAttribute('aria-expanded', this.open ? 'true' : 'false');
+
+    if (this.disabled) {
+      this.setAttribute('aria-disabled', 'true');
+    } else {
+      this.removeAttribute('aria-disabled');
+    }
   }
 
   /**

--- a/packages/components/accordion/src/accordion-item.ts
+++ b/packages/components/accordion/src/accordion-item.ts
@@ -3,6 +3,7 @@ import { type EventEmitter, event } from '@sl-design-system/shared';
 import { type SlToggleEvent } from '@sl-design-system/shared/events.js';
 import { type CSSResultGroup, LitElement, type PropertyValues, type TemplateResult, html } from 'lit';
 import { property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './accordion-item.scss.js';
 import { type AccordionIconType } from './accordion.js';
 
@@ -46,7 +47,6 @@ export class AccordionItem extends LitElement {
 
   override firstUpdated(changes: PropertyValues<this>): void {
     super.firstUpdated(changes);
-    this.#syncAccessibilityState();
 
     if (this.open) {
       this.renderRoot.querySelector('details')?.setAttribute('open', '');
@@ -55,7 +55,6 @@ export class AccordionItem extends LitElement {
 
   override updated(changes: PropertyValues<this>): void {
     super.updated(changes);
-    this.#syncAccessibilityState();
 
     if (changes.has('open')) {
       this.#animateState(this.open ? 'opening' : 'closing');
@@ -68,6 +67,7 @@ export class AccordionItem extends LitElement {
         <summary
           @click=${this.#onClick}
           aria-controls="content"
+          aria-disabled=${ifDefined(this.disabled ? 'true' : undefined)}
           aria-expanded=${this.open ? 'true' : 'false'}
           id="summary"
           part="summary"
@@ -138,17 +138,6 @@ export class AccordionItem extends LitElement {
   #onToggle(event: ToggleEvent): void {
     this.open = event.newState === 'open';
     this.toggleEvent.emit(this.open);
-  }
-
-  #syncAccessibilityState(): void {
-    this.setAttribute('role', 'button');
-    this.setAttribute('aria-expanded', this.open ? 'true' : 'false');
-
-    if (this.disabled) {
-      this.setAttribute('aria-disabled', 'true');
-    } else {
-      this.removeAttribute('aria-disabled');
-    }
   }
 
   /**


### PR DESCRIPTION
## Summary

This fixes an accessibility issue where disabled `sl-accordion-item` elements were not announced as disabled/dimmed by screen readers in some browser and screen reader combinations.
