### PR TITLE
fix(eslint-plugin-slds): avoid false positives for spaces between html template expressions

### DIFF
--- a/.changeset/pretty-cats-open.md
+++ b/.changeset/pretty-cats-open.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/eslint-plugin-slds': patch
+---
+
+Fixed a false positive in `slds/singleline-html-template-trimmed` where spaces between expressions in single-line `html` template literals were incorrectly reported as leading or trailing whitespace.

--- a/tools/eslint-plugin-slds/lib/rules/singleline-html-template-trimmed.js
+++ b/tools/eslint-plugin-slds/lib/rules/singleline-html-template-trimmed.js
@@ -21,25 +21,21 @@ export const singlelineHtmlTemplateTrimmed = {
         if (isHtmlTaggedTemplate(node, context)) {
           const { quasi } = node;
           const { quasis } = quasi;
-
-          // Get the raw template content
-          const templateContent = quasis.map(q => q.value.raw).join('');
+          const firstQuasi = quasis[0]?.value.raw ?? '';
+          const lastQuasi = quasis.at(-1)?.value.raw ?? '';
 
           // Skip multiline templates - this rule only applies to single-line templates
-          if (templateContent.includes('\n')) {
+          if (quasis.some(templateElement => templateElement.value.raw.includes('\n'))) {
             return;
           }
 
-          // Skip templates that only contain expressions with spaces between them
-          // For example: html`${firstName} ${lastName}`
-          if (templateContent.trim() === '' && quasi.expressions.length > 0) {
-            return;
-          }
+          // Only the outermost template segments can introduce unnecessary
+          // surrounding whitespace. Inner quasis may legitimately contain
+          // spaces between expressions, e.g. html`${first} ${last}`.
+          const hasLeadingWhitespace = /^\s+/.test(firstQuasi);
+          const hasTrailingWhitespace = /\s+$/.test(lastQuasi);
 
-          // Check if the template has leading or trailing whitespace
-          const hasSurroundingWhitespace = /^\s+|\s+$/.test(templateContent);
-
-          if (hasSurroundingWhitespace) {
+          if (hasLeadingWhitespace || hasTrailingWhitespace) {
             const templateText = context.sourceCode.getText(quasi);
 
             context.report({

--- a/tools/eslint-plugin-slds/tests/lib/rules/singleline-html-template-trimmed.test.js
+++ b/tools/eslint-plugin-slds/tests/lib/rules/singleline-html-template-trimmed.test.js
@@ -18,7 +18,9 @@ ruleTester.run('singleline-html-template-trimmed', singlelineHtmlTemplateTrimmed
     { code: "someOtherTag` Space is allowed here `;" },
     { code: "html`\n<h1>Hello world</h1>\n`;" },
     { code: "html`<h1>\nHello world\n</h1>`;" },
-    { code: "html`${firstName} ${lastName}`" }
+    { code: "html`${firstName} ${lastName}`" },
+    { code: "html`${study} &middot; ${perStudy[0].schoolPeriodCode}`;" },
+    { code: "html`${prefix}<span>content</span>${suffix}`;" }
   ],
   invalid: [
     {
@@ -40,6 +42,21 @@ ruleTester.run('singleline-html-template-trimmed', singlelineHtmlTemplateTrimmed
       code: "html`   <sl-button>Click me</sl-button>   `;" ,
       errors: [{ messageId: 'unnecessaryWhitespace' }],
       output: "html`<sl-button>Click me</sl-button>`;"
+    },
+    {
+      code: "html` ${firstName}`;",
+      errors: [{ messageId: 'unnecessaryWhitespace' }],
+      output: "html`${firstName}`;"
+    },
+    {
+      code: "html`${lastName} `;",
+      errors: [{ messageId: 'unnecessaryWhitespace' }],
+      output: "html`${lastName}`;"
+    },
+    {
+      code: "html` ${firstName} ${lastName} `;",
+      errors: [{ messageId: 'unnecessaryWhitespace' }],
+      output: "html`${firstName} ${lastName}`;"
     }
   ]
 });


### PR DESCRIPTION
## Summary

Fixes a false positive in `slds/singleline-html-template-trimmed`.

The rule previously concatenated all template quasis and checked the combined string
for leading/trailing whitespace. This caused valid templates such as 👇 to fail

```ts
html`${study} &middot; ${perStudy[0].schoolPeriodCode}`
```

<img width="1350" height="274" alt="Screenshot 2026-04-17 at 12 21 45" src="https://github.com/user-attachments/assets/249ff06c-3176-4960-820d-b4a597dd906a" />
