### PR TITLE
fix(panel): Fix invalid aria-labelledby on non-collapsible panel body

### DIFF
--- a/.changeset/all-ghosts-love.md
+++ b/.changeset/all-ghosts-love.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/panel': patch
+---
+
+Fixed an accessibility issue where non-collapsible panels rendered `aria-labelledby` on the body container without a `region` role. `aria-labelledby` is now applied only when the panel is collapsible (and the body is a `region`), preventing duplicate heading announcements in screen readers and resolving ARIA prohibited attributes warnings.

--- a/packages/components/panel/src/panel.spec.ts
+++ b/packages/components/panel/src/panel.spec.ts
@@ -44,6 +44,12 @@ describe('sl-panel', () => {
       expect(body).not.to.have.attribute('role', 'region');
     });
 
+    it('should not set aria-labelledby on the body', () => {
+      const body = el.renderRoot.querySelector('[part="body"]');
+
+      expect(body).not.to.have.attribute('aria-labelledby');
+    });
+
     it('should render the heading into the heading slot', () => {
       const heading = el.renderRoot.querySelector<HTMLSlotElement>('slot[name="heading"]');
 
@@ -95,6 +101,12 @@ describe('sl-panel', () => {
       const body = el.renderRoot.querySelector('[part="body"]');
 
       expect(body).to.have.attribute('role', 'region');
+    });
+
+    it('should set aria-labelledby on the body', () => {
+      const body = el.renderRoot.querySelector('[part="body"]');
+
+      expect(body).to.have.attribute('aria-labelledby', 'heading');
     });
 
     it('should emit an sl-toggle event when button is clicked', async () => {

--- a/packages/components/panel/src/panel.ts
+++ b/packages/components/panel/src/panel.ts
@@ -175,7 +175,12 @@ export class Panel extends ScopedElementsMixin(LitElement) {
           </sl-tool-bar>
         </slot>
       </div>
-      <div id="body" part="body" aria-labelledby="heading" role=${ifDefined(this.collapsible ? 'region' : undefined)}>
+      <div
+        id="body"
+        part="body"
+        aria-labelledby=${ifDefined(this.collapsible ? 'heading' : undefined)}
+        role=${ifDefined(this.collapsible ? 'region' : undefined)}
+      >
         <div part="inner">
           <div part="content">
             <slot></slot>


### PR DESCRIPTION
## Summary
This PR fixes an accessibility issue in `sl-panel` where non-collapsible panels incorrectly rendered `aria-labelledby` on the body container