### PR TITLE
fix(menu): ensure selectable menu items always set aria-checked

### DIFF
--- a/.changeset/tough-heads-allow.md
+++ b/.changeset/tough-heads-allow.md
@@ -1,0 +1,8 @@
+---
+'@sl-design-system/menu': patch
+---
+
+Fix an accessibility issue where selectable `sl-menu-item` elements only exposed `aria-checked` when selected.
+
+Selectable items now always set `aria-checked` to `"true"` or `"false"` based on state, and non-selectable items remove the attribute.
+This improves screen reader announcements and resolves ARIA required attribute violations in menu selection variants.

--- a/packages/components/menu/src/menu-item.spec.ts
+++ b/packages/components/menu/src/menu-item.spec.ts
@@ -139,6 +139,29 @@ describe('sl-menu-item', () => {
     });
   });
 
+  describe('selectable aria state', () => {
+    it('should set aria-checked to false for not selected selectable item', async () => {
+      el = await fixture(html`<sl-menu-item selectable>Item 1</sl-menu-item>`);
+
+      expect(el).to.have.attribute('aria-checked', 'false');
+    });
+
+    it('should set aria-checked to true for selected selectable item', async () => {
+      el = await fixture(html`<sl-menu-item selectable selected>Item 1</sl-menu-item>`);
+
+      expect(el).to.have.attribute('aria-checked', 'true');
+    });
+
+    it('should remove aria-checked when item is no longer selectable', async () => {
+      el = await fixture(html`<sl-menu-item selectable>Item 1</sl-menu-item>`);
+
+      el.selectable = false;
+      await el.updateComplete;
+
+      expect(el).not.to.have.attribute('aria-checked');
+    });
+  });
+
   describe('shortcut', () => {
     beforeEach(async () => {
       el = await fixture(html`<sl-menu-item shortcut="$mod+Digit1">Item 1</sl-menu-item>`);

--- a/packages/components/menu/src/menu-item.spec.ts
+++ b/packages/components/menu/src/menu-item.spec.ts
@@ -160,6 +160,12 @@ describe('sl-menu-item', () => {
 
       expect(el).not.to.have.attribute('aria-checked');
     });
+
+    it('should not render a check icon when selected but not selectable', async () => {
+      el = await fixture(html`<sl-menu-item selected>Item 1</sl-menu-item>`);
+
+      expect(el.renderRoot.querySelector('sl-icon[name="check"]')).not.to.exist;
+    });
   });
 
   describe('shortcut', () => {

--- a/packages/components/menu/src/menu-item.ts
+++ b/packages/components/menu/src/menu-item.ts
@@ -137,7 +137,7 @@ export class MenuItem extends ScopedElementsMixin(LitElement) {
       <div @pointermove=${this.#onPointermove} class="container">
         <div aria-hidden="true" class="safe-triangle"></div>
         <div part="wrapper">
-          ${this.selected ? html`<sl-icon name="check"></sl-icon>` : nothing}
+          ${this.selectable && this.selected ? html`<sl-icon name="check"></sl-icon>` : nothing}
           <slot></slot>
           ${this.shortcut
             ? html`<kbd aria-hidden="true">${this.#shortcut.renderAsLabel(this.shortcut)}</kbd>`

--- a/packages/components/menu/src/menu-item.ts
+++ b/packages/components/menu/src/menu-item.ts
@@ -111,8 +111,12 @@ export class MenuItem extends ScopedElementsMixin(LitElement) {
       this.role = this.selectable ? selectMode : 'menuitem';
     }
 
-    if (changes.has('selected')) {
-      this.setAttribute('aria-checked', (this.selected || false).toString());
+    if (changes.has('selectable') || changes.has('selected')) {
+      if (this.selectable) {
+        this.setAttribute('aria-checked', (this.selected || false).toString());
+      } else {
+        this.removeAttribute('aria-checked');
+      }
     }
 
     if (changes.has('submenu')) {

--- a/scripts/extract-story-templates.js
+++ b/scripts/extract-story-templates.js
@@ -176,13 +176,17 @@ class StoryTemplateExtractor {
     }
 
     // Extract description
-    let descriptionMatch = storyContent.match(/description:\s*{\s*story:\s*['"`]([\s\S]*?)['"`]/);
+    let descriptionMatch = storyContent.match(
+      /description:\s*{\s*story:\s*(["'`])((?:\\.|(?!\1)[\s\S])*?)\1/
+    );
     if (descriptionMatch) {
-      description = descriptionMatch[1].trim();
+      description = descriptionMatch[2].trim();
     } else {
-      descriptionMatch = storyContent.match(/description:\s*['"`]([\s\S]*?)['"`]/);
+      descriptionMatch = storyContent.match(
+        /description:\s*(["'`])((?:\\.|(?!\1)[\s\S])*?)\1/
+      );
       if (descriptionMatch) {
-        description = descriptionMatch[1].trim();
+        description = descriptionMatch[2].trim();
       }
     }
 


### PR DESCRIPTION
## Summary:

1. A11y fix for menu (aria-checked + visual state consistency with ARIA).
2. Parser fix in scripts/extract-story-templates.js for description extraction in Angular stories.

### BEFORE

https://github.com/user-attachments/assets/556817d5-1b3b-483e-a36d-fc31935939d5

#AFTER

https://github.com/user-attachments/assets/6f0b844e-23bb-4e4a-863a-60545dca3964
