### PR TITLE
Chore/709 Documentation website automated accessibility testing

### DIFF
--- a/.github/workflows/a11y_tests_website.yml
+++ b/.github/workflows/a11y_tests_website.yml
@@ -1,0 +1,76 @@
+name: Website a11y automated tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'website/src/**'
+      - 'website/tests/**'
+
+  push:
+    branches:
+      - main
+    paths:
+      - 'website/src/**'
+      - 'website/tests/**'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  FIGMA_TOKEN: ${{ secrets.FIGMA_AUTH_TOKEN }}
+  FONT_AWESOME_AUTH_TOKEN: ${{ secrets.FONT_AWESOME_AUTH_TOKEN }}
+  GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  HUSKY: 0
+  TOKENS_STUDIO_API_KEY: ${{ secrets.TOKENS_STUDIO_2_API_KEY }}
+
+jobs:
+  a11y-tests-for-changed-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref || 'main' }} --depth=1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Install Playwright browsers
+        run: yarn playwright install --with-deps
+
+      - name: Generate changed URLs
+        run: node scripts/get-changed-urls.js
+        env:
+          BASE: origin/${{ github.base_ref || 'main' }}
+
+      - name: Build website
+        run: yarn website
+
+      - name: Start server
+        run: yarn workspace @sl-design-system/website start &
+        working-directory: .
+
+      - name: Wait for server
+        run: yarn dlx wait-on --timeout 600000 --interval 1000 http://localhost:8000
+
+      - name: Run Playwright & axe-core tests
+        run: yarn playwright test --config=playwright.config.ts --project=website
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-results
+          path: reports/website

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "storybook": "wireit",
     "test": "wireit",
     "version": "wireit",
-    "website": "wireit"
+    "website": "wireit",
+    "website:a11y:test": "wireit",
+    "website:a11y:test:urls": "node scripts/run-website-a11y-test.js"
   },
   "wireit": {
     "build": {
@@ -451,15 +453,23 @@
       "dependencies": [
         "./website:build"
       ]
+    },
+    "website:a11y:test": {
+      "command": "node scripts/get-changed-urls.js && yarn exec playwright test --project=website",
+      "dependencies": [
+        "test:setup"
+      ]
     }
   },
   "devDependencies": {
     "@af-utils/scrollend-polyfill": "^0.0.14",
+    "@axe-core/playwright": "^4.11.1",
     "@changesets/cli": "^2.30.0",
     "@changesets/get-github-info": "^0.8.0",
     "@custom-elements-manifest/analyzer": "^0.11.0",
     "@faker-js/faker": "^10.3.0",
     "@lit/localize-tools": "^0.8.1",
+    "@playwright/test": "^1.58.2",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",
     "@storybook/addon-vitest": "^10.3.5",
@@ -473,6 +483,7 @@
     "@vitest/coverage-v8": "~4.1.4",
     "@vitest/ui": "~4.1.4",
     "@webcomponents/scoped-custom-element-registry": "^0.0.10",
+    "axe-html-reporter": "^2.2.11",
     "chai": "^6.2.2",
     "chai-datetime": "^1.8.1",
     "chai-dom": "^1.12.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  timeout: 30 * 1000,
+
+  projects: [
+    {
+      testDir: './tests',
+      name: 'storybook',
+      use: {
+        baseURL: 'http://localhost:6006'
+      },
+      testMatch: /storybook\/.*\.spec\.ts/
+    },
+    {
+      name: 'website',
+      testDir: './website/tests',
+      use: {
+        baseURL: 'http://localhost:8000'
+      },
+      testMatch: /website\/.*\.spec\.ts/
+    }
+  ]
+});

--- a/scripts/get-changed-urls.js
+++ b/scripts/get-changed-urls.js
@@ -1,0 +1,54 @@
+import { execSync } from 'child_process';
+import { writeFileSync } from 'fs';
+
+function normalizeUrl(url) {
+  const trimmed = url.trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  if (trimmed === '/') {
+    return '/';
+  }
+
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+
+  if (withLeadingSlash.endsWith('/') || withLeadingSlash.endsWith('.html')) {
+    return withLeadingSlash;
+  }
+
+  return `${withLeadingSlash}/`;
+}
+
+// fallback branch
+const base = process.env.BASE || 'origin/main';
+const explicitUrls = (process.env.URLS || '').split(',').map(normalizeUrl).filter(Boolean);
+
+if (explicitUrls.length > 0) {
+  writeFileSync('changed-urls.json', JSON.stringify([...new Set(explicitUrls)], null, 2));
+  process.exit(0);
+}
+
+let output;
+
+try {
+  output = execSync(`git diff --name-only ${base}...HEAD`, { encoding: 'utf-8' });
+} catch {
+  output = execSync(`git diff --name-only HEAD~1`, { encoding: 'utf-8' });
+}
+
+const files = output.split('\n').filter(Boolean);
+const mdFiles = files.filter(file => file.startsWith('website/src/') && file.endsWith('.md'));
+
+const urls = mdFiles.map(file => {
+  if (file === 'website/src/index.md') return '/';
+  if (file === 'website/src/404.md') return '/404.html';
+  return file.replace(/^website\/src\//, '').replace(/\.md$/, '/');
+});
+
+if (urls.length === 0) {
+  urls.push('/');
+}
+
+writeFileSync('changed-urls.json', JSON.stringify(urls, null, 2));

--- a/scripts/run-website-a11y-test.js
+++ b/scripts/run-website-a11y-test.js
@@ -1,0 +1,32 @@
+import { spawnSync } from 'child_process';
+
+const args = process.argv.slice(2);
+let urls;
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+
+  if (arg === '--urls') {
+    urls = args[i + 1];
+    i++;
+    continue;
+  }
+
+  if (arg.startsWith('--urls=')) {
+    urls = arg.slice('--urls='.length);
+  }
+}
+
+const result = spawnSync('yarn', ['website:a11y:test'], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    ...(urls ? { URLS: urls } : {})
+  }
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/website/tests/website_a11y.spec.ts
+++ b/website/tests/website_a11y.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { AxeResults } from 'axe-core';
+import { createHtmlReport } from 'axe-html-reporter';
+import { readFileSync } from 'node:fs';
+
+let axe: AxeBuilder;
+let results: AxeResults;
+const homePageUrl = '/';
+const domainName = 'http://localhost:8000/';
+
+function getArgumentValue(name: string): string | undefined {
+  const arg = process.argv.find(arg => arg.startsWith(`--${name}=`));
+  return arg ? arg.split('=')[1] : undefined;
+}
+
+const cliUrl = getArgumentValue('url');
+let urls: string[];
+
+if (cliUrl) {
+  urls = cliUrl.split(',');
+} else {
+  urls = JSON.parse(readFileSync(new URL('../../changed-urls.json', import.meta.url), 'utf-8')) as string[];
+}
+
+function createNumberedList<T>(items: T[]): string {
+  return items.map((item, index) => `${index + 1}. ${item}`).join('\n');
+}
+
+test.beforeEach(async ({ page }) => {
+  axe = new AxeBuilder({ page });
+});
+
+test.afterEach(async ({ page }) => {
+  if (!results || !results.violations) {
+    return;
+  }
+
+  if (results.violations.length > 0) {
+    const violationDetails = results.violations
+      .map(violation => {
+        const nodeDetails = createNumberedList(violation.nodes.flatMap(node => node.target));
+        return `${violation.id} (${violation.impact}) \n${violation.description}\n${nodeDetails} \n`;
+      })
+      .join('\n\n');
+    console.error(`Accessibility violations found for ${page.url()}:\n\n${violationDetails}`);
+
+    createHtmlReport({
+      results: {
+        violations: results.violations
+      },
+      options: {
+        outputDir: 'reports/website',
+        reportFileName: `${page.url().replace(domainName, '').replaceAll('/', '_')}a11y_report.html`
+      }
+    });
+  }
+});
+
+// Test only the homepage scanning the full page including <header> and <nav>
+test.describe('Full test for homepage', () => {
+  if (urls.includes(homePageUrl)) {
+    test('A11y test on home page', async ({ page }) => {
+      await page.goto(homePageUrl, { waitUntil: 'load' });
+      results = await axe.analyze();
+      expect(results.violations.length, 'Accessibility violations found, see details above').toBe(0);
+    });
+  }
+});
+
+// Test all other pages scanning only <main> content
+test.describe('Limited to <main> test on other pages', () => {
+  urls
+    .filter(url => url !== homePageUrl)
+    .forEach(url => {
+      test(`A11y test on ${url}`, async ({ page }) => {
+        await page.goto(url, { waitUntil: 'load' });
+        results = await axe.include('main').analyze();
+        expect(results.violations.length, 'Accessibility violations found, see details above').toBe(0);
+      });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,6 +775,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@axe-core/playwright@npm:^4.11.1":
+  version: 4.11.2
+  resolution: "@axe-core/playwright@npm:4.11.2"
+  dependencies:
+    axe-core: "npm:~4.11.3"
+  peerDependencies:
+    playwright-core: ">= 1.0.0"
+  checksum: 10c0/cb6f259c969668ae41b1c56e9fbf8d380d4b9440ef76f3037faa615fdcd36a748f53451116bb53b101dae52c6adc9183ce8de7f62819beb3866989849a9834b6
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.11, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/code-frame@npm:7.29.0"
@@ -4578,6 +4589,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.58.2":
+  version: 1.59.1
+  resolution: "@playwright/test@npm:1.59.1"
+  dependencies:
+    playwright: "npm:1.59.1"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/8c2d94a860d3c254a0b114df2f888ad0a0e9310f45b6059bd5d4da196d965cadf6922267cef0881cfa9784d4bef6d78363d2c2d94caa64be67ff644c41162137
+  languageName: node
+  linkType: hard
+
 "@polka/url@npm:^1.0.0-next.24":
   version: 1.0.0-next.29
   resolution: "@polka/url@npm:1.0.0-next.29"
@@ -5793,11 +5815,13 @@ __metadata:
   resolution: "@sl-design-system/monorepo@workspace:."
   dependencies:
     "@af-utils/scrollend-polyfill": "npm:^0.0.14"
+    "@axe-core/playwright": "npm:^4.11.1"
     "@changesets/cli": "npm:^2.30.0"
     "@changesets/get-github-info": "npm:^0.8.0"
     "@custom-elements-manifest/analyzer": "npm:^0.11.0"
     "@faker-js/faker": "npm:^10.3.0"
     "@lit/localize-tools": "npm:^0.8.1"
+    "@playwright/test": "npm:^1.58.2"
     "@storybook/addon-a11y": "npm:^10.3.5"
     "@storybook/addon-docs": "npm:^10.3.5"
     "@storybook/addon-vitest": "npm:^10.3.5"
@@ -5811,6 +5835,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:~4.1.4"
     "@vitest/ui": "npm:~4.1.4"
     "@webcomponents/scoped-custom-element-registry": "npm:^0.0.10"
+    axe-html-reporter: "npm:^2.2.11"
     chai: "npm:^6.2.2"
     chai-datetime: "npm:^1.8.1"
     chai-dom: "npm:^1.12.1"
@@ -8970,6 +8995,24 @@ __metadata:
   version: 4.10.2
   resolution: "axe-core@npm:4.10.2"
   checksum: 10c0/0e20169077de96946a547fce0df39d9aeebe0077f9d3eeff4896518b96fde857f80b98f0d4279274a7178791744dd5a54bb4f322de45b4f561ffa2586ff9a09d
+  languageName: node
+  linkType: hard
+
+"axe-core@npm:~4.11.3":
+  version: 4.11.3
+  resolution: "axe-core@npm:4.11.3"
+  checksum: 10c0/bc757775ef41396faf6470752a12e96f3972d0d97cae4ec28e99cec7bca2c5aaa6d040b97e7f0278e8d1ea354fa0b0bf7fcaa51775a725d7ed0a0834e7ea13d7
+  languageName: node
+  linkType: hard
+
+"axe-html-reporter@npm:^2.2.11":
+  version: 2.2.11
+  resolution: "axe-html-reporter@npm:2.2.11"
+  dependencies:
+    mustache: "npm:^4.0.1"
+  peerDependencies:
+    axe-core: ">=3"
+  checksum: 10c0/7f56c06e28aea591762c10f151bd48efbf7cff6a4a783a8074e779d283366a745085be64de72e6f9208006bab8dedc83681c8a9a691c9904886244d579375acd
   languageName: node
   linkType: hard
 
@@ -17788,7 +17831,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mustache@npm:^4.2.0":
+"mustache@npm:^4.0.1, mustache@npm:^4.2.0":
   version: 4.2.0
   resolution: "mustache@npm:4.2.0"
   bin:
@@ -19181,7 +19224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.59.1":
+"playwright@npm:1.59.1, playwright@npm:^1.59.1":
   version: 1.59.1
   resolution: "playwright@npm:1.59.1"
   dependencies:


### PR DESCRIPTION
Fixes #709 
Automated a11y tests for documentation website added.
Github actions check for pages (.md files) that were changed in each PR and only test affected pages. 

If home page was changed in PR whole page is being scanned including header and nav. For any other page only content in main region is being scanned to not to duplicate issues and for tests to take less time.

If a11y issues are found on page all the issues with corresponding selectors are listed on terminal and HTML report with more info is created for that page in artifacts.

Tests can be done locally with:
- `yarn website:a11y:test` - test only .md files that were in commits for current branch
- `yarn website:a11y:test:urls --urls='/urls-separated-with-comma'` - allows to test all URLs defined by user