### PR TITLE
fix(panel): correct Toggle Externally announcer messages for expand/collapse

### DIFF
--- a/packages/components/panel/src/panel.stories.ts
+++ b/packages/components/panel/src/panel.stories.ts
@@ -477,7 +477,7 @@ export const ToggleExternally: Story = {
 
           togglePanel() {
             this.renderRoot.querySelector('sl-panel')?.toggle();
-            announce(`Panel ${this.collapsed ? 'collapsing' : 'expanding'}`);
+            announce(`Panel ${this.collapsed ? 'expanding' : 'collapsing'}`);
             this.requestUpdate();
           }
 


### PR DESCRIPTION
Summary
Fixes incorrect screen reader announcements in the Panel story variant Toggle Externally.

Previously, the announcer text was reversed:

collapsing announced as "Panel expanding"
expanding announced as "Panel collapsing"