### PR TITLE
fix(tool-bar): preserve overflow label for menu buttons mapped before aria forwarding

### DIFF
--- a/.changeset/puny-streets-cheat.md
+++ b/.changeset/puny-streets-cheat.md
@@ -1,0 +1,7 @@
+---
+"@sl-design-system/tool-bar": patch
+---
+
+Fix missing labels for `sl-menu-button` items rendered in the tool-bar overflow menu when mapping happens before ARIA forwarding is ready (e.g. nested slot scenarios such as Grid bulk actions).
+
+The overflow mapping now falls back from forwarded ARIA name/description to host `aria-labelledby` / `aria-label`, and finally to `slot="button"` text content, ensuring labels remain visible

--- a/packages/components/tool-bar/src/mapping.spec.ts
+++ b/packages/components/tool-bar/src/mapping.spec.ts
@@ -133,6 +133,39 @@ describe('mapMenuButtonToItem', () => {
     expect(item.disabled).to.equal(false);
     expect(item.ariaDisabled).to.equal(true);
   });
+
+  it('should map label from button slot content before first render update', () => {
+    const el = document.createElement('sl-menu-button') as MenuButton;
+    el.innerHTML = `
+      <span slot="button"><sl-icon name="far-ban"></sl-icon> Block</span>
+      <sl-menu-item>Item 1</sl-menu-item>
+    `;
+
+    const item = mapMenuButtonToItem(el);
+
+    expect(item.label).to.equal('Block');
+  });
+
+  it('should map label from host aria-labelledby before first render update', () => {
+    const container = document.createElement('div'),
+      label = document.createElement('span'),
+      el = document.createElement('sl-menu-button') as MenuButton;
+
+    label.id = 'menu-label';
+    label.textContent = 'Visibility';
+    container.append(label, el);
+    document.body.append(container);
+
+    el.setAttribute('aria-labelledby', 'menu-label');
+    el.innerHTML = '<sl-menu-item>Item 1</sl-menu-item>';
+
+    try {
+      const item = mapMenuButtonToItem(el);
+      expect(item.label).to.equal('Visibility');
+    } finally {
+      container.remove();
+    }
+  });
 });
 
 describe('mapMenuItemToItem', () => {

--- a/packages/components/tool-bar/src/mapping.spec.ts
+++ b/packages/components/tool-bar/src/mapping.spec.ts
@@ -135,7 +135,7 @@ describe('mapMenuButtonToItem', () => {
   });
 
   it('should map label from button slot content before first render update', () => {
-    const el = document.createElement('sl-menu-button') as MenuButton;
+    const el = document.createElement('sl-menu-button');
     el.innerHTML = `
       <span slot="button"><sl-icon name="far-ban"></sl-icon> Block</span>
       <sl-menu-item>Item 1</sl-menu-item>
@@ -149,7 +149,7 @@ describe('mapMenuButtonToItem', () => {
   it('should map label from host aria-labelledby before first render update', () => {
     const container = document.createElement('div'),
       label = document.createElement('span'),
-      el = document.createElement('sl-menu-button') as MenuButton;
+      el = document.createElement('sl-menu-button');
 
     label.id = 'menu-label';
     label.textContent = 'Visibility';
@@ -165,6 +165,17 @@ describe('mapMenuButtonToItem', () => {
     } finally {
       container.remove();
     }
+  });
+
+  it('should map label from host aria-label before first render update', () => {
+    const el = document.createElement('sl-menu-button');
+
+    el.setAttribute('aria-label', 'Visibility');
+    el.innerHTML = '<sl-menu-item>Item 1</sl-menu-item>';
+
+    const item = mapMenuButtonToItem(el);
+
+    expect(item.label).to.equal('Visibility');
   });
 });
 

--- a/packages/components/tool-bar/src/mapping.ts
+++ b/packages/components/tool-bar/src/mapping.ts
@@ -50,6 +50,59 @@ export type ToolBarItem =
   | ToolBarItemGroup
   | ToolBarItemMenu;
 
+function getLabelFromAriaLabelledBy(host: HTMLElement): string {
+  const labelledBy = host.ariaLabelledByElements ?? [];
+
+  if (labelledBy.length) {
+    return labelledBy
+      .map(el => el.textContent?.trim())
+      .filter(Boolean)
+      .join(' ');
+  }
+
+  const labelledByIds = host.getAttribute('aria-labelledby');
+
+  if (!labelledByIds) {
+    return '';
+  }
+
+  const root = host.getRootNode(),
+    getElementById =
+      root instanceof Document || root instanceof ShadowRoot
+        ? root.getElementById.bind(root)
+        : undefined;
+
+  return labelledByIds
+    .split(/\s+/)
+    .map(id => getElementById?.(id)?.textContent?.trim())
+    .filter(Boolean)
+    .join(' ');
+}
+
+function getMenuButtonLabel(menuButton: MenuButton): string {
+  const fromForwardedAria =
+    getForwardedAccessibleName(menuButton) || getForwardedDescription(menuButton);
+
+  if (fromForwardedAria) {
+    return fromForwardedAria;
+  }
+
+  const fromHostAria =
+    getLabelFromAriaLabelledBy(menuButton) || menuButton.getAttribute('aria-label') || '';
+
+  if (fromHostAria) {
+    return fromHostAria;
+  }
+
+  return Array.from(menuButton.children)
+    .filter(
+      (el): el is HTMLElement => el instanceof HTMLElement && el.slot === 'button'
+    )
+    .map(el => el.textContent?.trim())
+    .filter(Boolean)
+    .join(' ');
+}
+
 export function mapButtonToItem(button: Button): ToolBarItemButton {
   const label = getForwardedAccessibleName(button) || getForwardedDescription(button),
     disabled = isForwardedDisabled(button);
@@ -68,7 +121,7 @@ export function mapButtonToItem(button: Button): ToolBarItemButton {
 }
 
 export function mapMenuButtonToItem(menuButton: MenuButton): ToolBarItemMenu {
-  const label = getForwardedAccessibleName(menuButton) || getForwardedDescription(menuButton),
+  const label = getMenuButtonLabel(menuButton),
     menuItems = Array.from(menuButton.querySelectorAll('sl-menu-item')).map(el =>
       mapMenuItemToItem(el)
     ),

--- a/packages/components/tool-bar/src/mapping.ts
+++ b/packages/components/tool-bar/src/mapping.ts
@@ -67,14 +67,14 @@ function getLabelFromAriaLabelledBy(host: HTMLElement): string {
   }
 
   const root = host.getRootNode(),
-    getElementById =
+    getLabelledByElement =
       root instanceof Document || root instanceof ShadowRoot
-        ? root.getElementById.bind(root)
+        ? (id: string) => root.querySelector<HTMLElement>(`#${CSS.escape(id)}`)
         : undefined;
 
   return labelledByIds
     .split(/\s+/)
-    .map(id => getElementById?.(id)?.textContent?.trim())
+    .map(id => getLabelledByElement?.(id)?.textContent?.trim())
     .filter(Boolean)
     .join(' ');
 }
@@ -95,9 +95,7 @@ function getMenuButtonLabel(menuButton: MenuButton): string {
   }
 
   return Array.from(menuButton.children)
-    .filter(
-      (el): el is HTMLElement => el instanceof HTMLElement && el.slot === 'button'
-    )
+    .filter((el): el is HTMLElement => el instanceof HTMLElement && el.slot === 'button')
     .map(el => el.textContent?.trim())
     .filter(Boolean)
     .join(' ');


### PR DESCRIPTION
## Summary
This PR fixes a bug where sl-menu-button labels could disappear in the tool-bar overflow menu (notably in Grid bulk-actions with nested slots).

In some render timings, `mapMenuButtonToItem()` runs before `sl-menu-button` finishes ARIA forwarding.
When that happened, the mapping could produce an empty label, so overflow items rendered icon-only textless entries.


### BEFORE
https://github.com/user-attachments/assets/7ba9fab9-cde9-4bb8-9609-d0997cfe576e


### AFTER
https://github.com/user-attachments/assets/1ce7fc79-6a1c-401e-a21b-e7d8487d4517

