### PR TITLE
fix(tool-bar): forward overflow submenu item clicks to original menu items

### DIFF
--- a/.changeset/vast-months-tickle.md
+++ b/.changeset/vast-months-tickle.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/tool-bar': patch
+---
+
+Fix a bug where `sl-menu-item` click handlers did not fire from the toolbar overflow menu.
+
+When a toolbar was collapsed, submenu actions originating from `sl-menu-button` were rendered in overflow but did not forward clicks to the original menu items. This change adds click proxying so selecting an overflow submenu item triggers the original item's click handler, restoring expected behavior in components such as Grid bulk actions.

--- a/packages/components/grid/src/stories/selection.stories.ts
+++ b/packages/components/grid/src/stories/selection.stories.ts
@@ -11,6 +11,7 @@ import {
 import { type Student, getStudents } from '@sl-design-system/example-data';
 import { Icon } from '@sl-design-system/icon';
 import '@sl-design-system/icon/register.js';
+import '@sl-design-system/menu/register.js';
 import { tooltip } from '@sl-design-system/tooltip';
 import '@sl-design-system/tooltip/register.js';
 import { type StoryObj } from '@storybook/web-components-vite';
@@ -127,6 +128,71 @@ export const Multiple: Story = {
         <sl-button fill="outline" slot="bulk-actions" variant="inverted">
           <sl-icon name="far-right-to-line"></sl-icon>
           This is another very long action button
+        </sl-button>
+      </sl-grid>
+    `;
+  }
+};
+
+export const MultipleWithMenuButton: Story = {
+  args: {
+    selectAll: false
+  },
+  render: ({ selectAll }, { loaded: { students } }) => {
+    return html`
+      <p>
+        This example validates click events for menu items in bulk actions when the floating
+        tool-bar is collapsed. Reduce the viewport width, select rows, open "Visibility" and click
+        "Hide" or "Show".
+      </p>
+      <sl-grid .items=${(students as Student[]).slice(0, 5)}>
+        <sl-grid-selection-column ?select-all=${selectAll}></sl-grid-selection-column>
+        <sl-grid-column
+          header="Student"
+          path="fullName"
+          .renderer=${avatarRenderer}
+          .scopedElements=${{ 'sl-avatar': Avatar }}
+        ></sl-grid-column>
+        <sl-grid-column path="email"></sl-grid-column>
+
+        <!-- These get slotted into the floating tool-bar -->
+        <sl-button fill="outline" slot="bulk-actions" variant="inverted">
+          <sl-icon name="far-copy"></sl-icon>
+          Duplicate
+        </sl-button>
+
+        <sl-menu-button
+          aria-label="Visibility"
+          fill="outline"
+          slot="bulk-actions"
+          variant="inverted"
+        >
+          <span slot="button">Visibility</span>
+          <sl-menu-item @click=${() => alert('Hide')}>Hide</sl-menu-item>
+          <sl-menu-item @click=${() => alert('Show')}>Show</sl-menu-item>
+        </sl-menu-button>
+
+        <sl-button fill="outline" slot="bulk-actions" variant="inverted">
+          <sl-icon name="far-trash"></sl-icon>
+          Delete
+        </sl-button>
+        <sl-button disabled fill="outline" slot="bulk-actions" variant="inverted">
+          <sl-icon name="far-right-to-line"></sl-icon>
+          Action 1
+        </sl-button>
+        <sl-button
+          ${tooltip('I am a tooltip')}
+          aria-disabled="true"
+          fill="outline"
+          slot="bulk-actions"
+          variant="inverted"
+        >
+          <sl-icon name="far-right-to-line"></sl-icon>
+          Action 2
+        </sl-button>
+        <sl-button fill="outline" slot="bulk-actions" variant="inverted">
+          <sl-icon name="far-right-to-line"></sl-icon>
+          Action 3
         </sl-button>
       </sl-grid>
     `;

--- a/packages/components/tool-bar/src/mapping.spec.ts
+++ b/packages/components/tool-bar/src/mapping.spec.ts
@@ -161,6 +161,13 @@ describe('mapMenuItemToItem', () => {
 
     expect(item.icon).to.equal('far-pen');
   });
+
+  it('should provide a click handler', async () => {
+    const el = await fixture<MenuItem>(html`<sl-menu-item>Rename...</sl-menu-item>`),
+      item = mapMenuItemToItem(el);
+
+    expect(item.click).to.be.a('function');
+  });
 });
 
 describe('mapElementsToItems', () => {

--- a/packages/components/tool-bar/src/mapping.ts
+++ b/packages/components/tool-bar/src/mapping.ts
@@ -93,7 +93,8 @@ export function mapMenuItemToItem(menuItem: MenuItem): ToolBarItemButton {
     disabled: menuItem.hasAttribute('disabled'),
     icon: menuItem.querySelector('sl-icon')?.getAttribute('name'),
     label: menuItem.textContent?.trim() || undefined,
-    visible: true
+    visible: true,
+    click: () => menuItem.click()
   };
 }
 

--- a/packages/components/tool-bar/src/overflow.spec.ts
+++ b/packages/components/tool-bar/src/overflow.spec.ts
@@ -276,6 +276,20 @@ describe('overflow (integration)', () => {
 
       expect(onClick).to.have.been.calledOnce;
     });
+
+    it('should proxy clicks on overflow submenu items to the original menu items', () => {
+      const originalMenuItem = el.querySelector('sl-menu-button sl-menu-item'),
+        onClick = spy(),
+        overflowSubmenuItem = el.renderRoot.querySelector('sl-menu[slot="submenu"] sl-menu-item');
+
+      originalMenuItem?.addEventListener('click', onClick);
+
+      if (overflowSubmenuItem instanceof HTMLElement) {
+        overflowSubmenuItem.click();
+      }
+
+      expect(onClick).to.have.been.calledOnce;
+    });
   });
 });
 

--- a/packages/components/tool-bar/src/overflow.spec.ts
+++ b/packages/components/tool-bar/src/overflow.spec.ts
@@ -286,6 +286,9 @@ describe('overflow (integration)', () => {
       expect(overflowSubmenuItem, 'expected overflow submenu item to exist').to.exist;
 
       (originalMenuItem as MenuItem).addEventListener('click', onClick);
+      // Use a non-bubbling click here to assert proxying behavior only.
+      // A real bubbling click can trigger the parent submenu path (with delayed showPopover),
+      // which causes teardown-related InvalidStateError noise in this test environment.
       (overflowSubmenuItem as MenuItem).dispatchEvent(
         new MouseEvent('click', { bubbles: false, composed: false })
       );

--- a/packages/components/tool-bar/src/overflow.spec.ts
+++ b/packages/components/tool-bar/src/overflow.spec.ts
@@ -282,11 +282,11 @@ describe('overflow (integration)', () => {
         onClick = spy(),
         overflowSubmenuItem = el.renderRoot.querySelector('sl-menu[slot="submenu"] sl-menu-item');
 
-      originalMenuItem?.addEventListener('click', onClick);
+      expect(originalMenuItem, 'expected original menu item to exist').to.exist;
+      expect(overflowSubmenuItem, 'expected overflow submenu item to exist').to.exist;
 
-      if (overflowSubmenuItem instanceof HTMLElement) {
-        overflowSubmenuItem.click();
-      }
+      (originalMenuItem as MenuItem).addEventListener('click', onClick);
+      (overflowSubmenuItem as MenuItem).click();
 
       expect(onClick).to.have.been.calledOnce;
     });

--- a/packages/components/tool-bar/src/overflow.spec.ts
+++ b/packages/components/tool-bar/src/overflow.spec.ts
@@ -286,7 +286,9 @@ describe('overflow (integration)', () => {
       expect(overflowSubmenuItem, 'expected overflow submenu item to exist').to.exist;
 
       (originalMenuItem as MenuItem).addEventListener('click', onClick);
-      (overflowSubmenuItem as MenuItem).click();
+      (overflowSubmenuItem as MenuItem).dispatchEvent(
+        new MouseEvent('click', { bubbles: false, composed: false })
+      );
 
       expect(onClick).to.have.been.calledOnce;
     });

--- a/packages/components/tool-bar/src/tool-bar.stories.ts
+++ b/packages/components/tool-bar/src/tool-bar.stories.ts
@@ -385,6 +385,62 @@ export const ClickEvents: Story = {
   }
 };
 
+export const OverflowMenuItemClicks: Story = {
+  args: {
+    width: '160px',
+    enableLogging: true,
+    description:
+      'This example reproduces click handling for menu items when a menu-button is moved into the overflow menu. Open the overflow menu (ellipsis), open "Visibility", then click "Hide" or "Show".',
+    items: () => {
+      const handleClick = (event: Event, actionName: string) => {
+        console.log(`${actionName} clicked`, event);
+        const logging = document.getElementById('logging');
+        if (logging) {
+          const logEntry = document.createElement('div');
+          logEntry.textContent = `${actionName} clicked`;
+          logging.prepend(logEntry);
+          announce(`${actionName} clicked`);
+        }
+      };
+
+      return html`
+        <sl-button @click=${(e: Event) => handleClick(e, 'Duplicate')} fill="outline">
+          <sl-icon name="far-copy"></sl-icon>
+          Duplicate
+        </sl-button>
+        <sl-menu-button
+          aria-label="Visibility"
+          fill="outline"
+          @click=${(e: Event) => handleClick(e, 'Visibility button')}
+        >
+          <sl-icon name="far-gear" slot="button"></sl-icon>
+          <span slot="button">Visibility</span>
+          <sl-menu-item @click=${(e: Event) => handleClick(e, 'Hide')}>
+            <sl-icon name="far-bars-filter"></sl-icon>
+            Hide
+          </sl-menu-item>
+          <sl-menu-item @click=${(e: Event) => handleClick(e, 'Show')}>
+            <sl-icon name="far-universal-access"></sl-icon>
+            Show
+          </sl-menu-item>
+        </sl-menu-button>
+        <sl-button @click=${(e: Event) => handleClick(e, 'Delete')} fill="outline">
+          <sl-icon name="far-trash"></sl-icon>
+          Delete
+        </sl-button>
+        <sl-button @click=${(e: Event) => handleClick(e, 'Action 1')} fill="outline">
+          <sl-icon name="far-arrow-down-to-line"></sl-icon>
+          Action 1
+        </sl-button>
+        <sl-button @click=${(e: Event) => handleClick(e, 'Action 2')} fill="outline">
+          <sl-icon name="far-arrow-up-from-bracket"></sl-icon>
+          Action 2
+        </sl-button>
+      `;
+    }
+  }
+};
+
 export const Overflow: Story = {
   args: {
     ...Basic.args,

--- a/packages/components/tool-bar/src/tool-bar.stories.ts
+++ b/packages/components/tool-bar/src/tool-bar.stories.ts
@@ -385,62 +385,6 @@ export const ClickEvents: Story = {
   }
 };
 
-export const OverflowMenuItemClicks: Story = {
-  args: {
-    width: '160px',
-    enableLogging: true,
-    description:
-      'This example reproduces click handling for menu items when a menu-button is moved into the overflow menu. Open the overflow menu (ellipsis), open "Visibility", then click "Hide" or "Show".',
-    items: () => {
-      const handleClick = (event: Event, actionName: string) => {
-        console.log(`${actionName} clicked`, event);
-        const logging = document.getElementById('logging');
-        if (logging) {
-          const logEntry = document.createElement('div');
-          logEntry.textContent = `${actionName} clicked`;
-          logging.prepend(logEntry);
-          announce(`${actionName} clicked`);
-        }
-      };
-
-      return html`
-        <sl-button @click=${(e: Event) => handleClick(e, 'Duplicate')} fill="outline">
-          <sl-icon name="far-copy"></sl-icon>
-          Duplicate
-        </sl-button>
-        <sl-menu-button
-          aria-label="Visibility"
-          fill="outline"
-          @click=${(e: Event) => handleClick(e, 'Visibility button')}
-        >
-          <sl-icon name="far-gear" slot="button"></sl-icon>
-          <span slot="button">Visibility</span>
-          <sl-menu-item @click=${(e: Event) => handleClick(e, 'Hide')}>
-            <sl-icon name="far-bars-filter"></sl-icon>
-            Hide
-          </sl-menu-item>
-          <sl-menu-item @click=${(e: Event) => handleClick(e, 'Show')}>
-            <sl-icon name="far-universal-access"></sl-icon>
-            Show
-          </sl-menu-item>
-        </sl-menu-button>
-        <sl-button @click=${(e: Event) => handleClick(e, 'Delete')} fill="outline">
-          <sl-icon name="far-trash"></sl-icon>
-          Delete
-        </sl-button>
-        <sl-button @click=${(e: Event) => handleClick(e, 'Action 1')} fill="outline">
-          <sl-icon name="far-arrow-down-to-line"></sl-icon>
-          Action 1
-        </sl-button>
-        <sl-button @click=${(e: Event) => handleClick(e, 'Action 2')} fill="outline">
-          <sl-icon name="far-arrow-up-from-bracket"></sl-icon>
-          Action 2
-        </sl-button>
-      `;
-    }
-  }
-};
-
 export const Overflow: Story = {
   args: {
     ...Basic.args,


### PR DESCRIPTION
## Summary

Fixes a bug where `sl-menu-item` click handlers did not fire when a toolbar was collapsed and actions were rendered in the overflow menu (e.g. Grid bulk actions).


### BEFORE

https://github.com/user-attachments/assets/aff390da-deff-48b8-b7d2-a47b9514280a

### AFTER

https://github.com/user-attachments/assets/23e133b4-9fc4-4120-99e9-aef9b26c50c7

