### PR TITLE
fix(combobox): reset filtered results on blur when no option is selected

### DIFF
--- a/.changeset/soft-rocks-dig.md
+++ b/.changeset/soft-rocks-dig.md
@@ -1,0 +1,10 @@
+---
+'@sl-design-system/combobox': patch
+---
+
+Fix `filter-results` behavior in `sl-combobox` when leaving the field without selecting an option.
+
+Previously, typing a search value and blurring the component could clear the input while keeping the internal filtered state, so reopening the list showed only stale filtered results.
+Now, when focus leaves the component, filtered option visibility is reset to match the restored input value.
+
+Also adds a regression test for the flow: type search text -> leave combobox (click/Tab) -> return to combobox.

--- a/.changeset/soft-rocks-dig.md
+++ b/.changeset/soft-rocks-dig.md
@@ -6,5 +6,3 @@ Fix `filter-results` behavior in `sl-combobox` when leaving the field without se
 
 Previously, typing a search value and blurring the component could clear the input while keeping the internal filtered state, so reopening the list showed only stale filtered results.
 Now, when focus leaves the component, filtered option visibility is reset to match the restored input value.
-
-Also adds a regression test for the flow: type search text -> leave combobox (click/Tab) -> return to combobox.

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -736,6 +736,25 @@ describe('sl-combobox', () => {
         expect(options[1]).to.be.displayed;
         expect(options[2]).to.be.displayed;
       });
+
+      it('should reset the results when focus leaves the component without selecting an option', async () => {
+        input.focus();
+        await userEvent.keyboard('Ip');
+
+        const options = Array.from(el.querySelectorAll('sl-option'));
+
+        expect(options[0]).not.to.be.displayed;
+        expect(options[1]).to.be.displayed;
+        expect(options[2]).to.be.displayed;
+
+        await userEvent.click(document.body);
+        await el.updateComplete;
+
+        expect(input.value).to.equal('');
+        expect(options[0]).to.be.displayed;
+        expect(options[1]).to.be.displayed;
+        expect(options[2]).to.be.displayed;
+      });
     });
   });
 

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -614,6 +614,7 @@ export class Combobox<T = any, U = T> extends FormControlMixin(ScopedElementsMix
       // If we are leaving the component, make sure the input value reflects the selected items
       this.#updateCreateCustomOption();
       this.#updateTextFieldValue();
+      this.#updateFilteredOptions();
       this.updateValidity();
     }
   }


### PR DESCRIPTION
## Summary
This PR fixes a bug in `sl-combobox` (`filter-results`) where filtering state could persist after the user leaves the field without selecting an option.

## Problem
When a user typed a search value, did not select anything, and moved focus away (click or Tab), the visible input could be reset but the options list remained filtered internally.  
After returning to the combobox, the list showed only results from the previous search although the field looked empty.

## Root Cause
On `focusout`, the component restored the text-field value but did not reset filtered option visibility.


### BEFORE

https://github.com/user-attachments/assets/c05f98fb-256a-40e5-862f-d88e5e0b7195


### AFTER

https://github.com/user-attachments/assets/8d67f603-0bef-41c4-a81c-d739d0345ec7


