### PR TITLE
fix(button): fix size regression

### DIFF
--- a/.changeset/shiny-goats-look.md
+++ b/.changeset/shiny-goats-look.md
@@ -1,0 +1,8 @@
+---
+'@sl-design-system/button': patch
+---
+
+Minor style fixes:
+
+- fix icon-only size regression by using `box-sizing: content-box`
+- fix `<button>` growing larger than the host `<sl-button>`

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "arrowParens": "avoid",
+  "htmlWhitespaceSensitivity": "ignore",
   "ignorePatterns": [
     "*dist",
     "*generated",

--- a/packages/components/button/src/button.scss
+++ b/packages/components/button/src/button.scss
@@ -139,7 +139,7 @@
 
 :host(:state(icon-only)) button {
   aspect-ratio: 1;
-  block-size: calc(1lh + (var(--sl-size-100) - var(--sl-size-borderWidth-action)) * 2);
+  block-size: calc(1lh + var(--sl-size-200));
   padding: 0;
 }
 
@@ -153,7 +153,7 @@
 }
 
 :host([size='sm']:state(icon-only)) button {
-  block-size: calc(1lh + (var(--sl-size-025) - var(--sl-size-borderWidth-action)) * 2);
+  block-size: calc(1lh + var(--sl-size-050));
   padding: 0;
 }
 
@@ -164,7 +164,7 @@
 }
 
 :host([size='lg']:state(icon-only)) button {
-  block-size: calc(1lh + (var(--sl-size-175) - var(--sl-size-borderWidth-action)) * 2);
+  block-size: calc(1lh + var(--sl-size-350));
   padding: 0;
 }
 
@@ -237,7 +237,6 @@ button {
   );
   border: var(--sl-size-borderWidth-action) solid var(--sl-color-border-secondary-bold);
   border-radius: var(--sl-size-borderRadius-default);
-  box-sizing: content-box;
   color: var(--sl-color-foreground-secondary-bold);
   cursor: pointer;
   display: inline-flex;

--- a/packages/components/button/src/button.scss
+++ b/packages/components/button/src/button.scss
@@ -237,6 +237,7 @@ button {
   );
   border: var(--sl-size-borderWidth-action) solid var(--sl-color-border-secondary-bold);
   border-radius: var(--sl-size-borderRadius-default);
+  box-sizing: content-box;
   color: var(--sl-color-foreground-secondary-bold);
   cursor: pointer;
   display: inline-flex;
@@ -245,6 +246,8 @@ button {
   gap: var(--sl-size-075);
   justify-content: center;
   margin: 0;
+  max-inline-size: 100%;
+  min-inline-size: 0;
   outline: transparent solid var(--sl-size-borderWidth-focusRing);
   outline-offset: var(--sl-size-outlineOffset-default);
   padding: calc(var(--sl-size-100) - var(--sl-size-borderWidth-action))

--- a/packages/components/popover/src/popover.stories.ts
+++ b/packages/components/popover/src/popover.stories.ts
@@ -134,9 +134,15 @@ export const VerticalOverflow: Story = {
   args: {
     body: () => {
       return html`
-        Lorem ipsum dolor sit amet, qui deserunt esse minim cillum nostrud exercitation veniam
-        consequat pariatur exercitation laborum nostrud culpa sunt exercitation pariatur. Nisi ipsum
-        est ullamco nostrud sit pariatur. Ex nisi ipsum et est nulla ex ex.
+        <style>
+          .wrapper {
+            background: var(--sl-color-background-accent-green-subtlest);
+            block-size: 50dvh;
+            padding-inline: var(--sl-size-200);
+            place-content: center;
+          }
+        </style>
+        <div class="wrapper">Block</div>
       `;
     }
   }

--- a/packages/components/popover/src/popover.stories.ts
+++ b/packages/components/popover/src/popover.stories.ts
@@ -85,11 +85,12 @@ export default {
         id="button"
         variant="primary"
         style=${styleMap({ 'align-self': alignSelf, 'justify-self': justifySelf })}
-        >Toggle</sl-button
       >
-      <sl-popover anchor="button" ?no-describedby=${noDescribedby} .position=${position}
-        >${typeof body === 'string' ? body : body()}</sl-popover
-      >
+        Toggle
+      </sl-button>
+      <sl-popover anchor="button" ?no-describedby=${noDescribedby} .position=${position}>
+        ${typeof body === 'string' ? body : body()}
+      </sl-popover>
     `;
   }
 } satisfies Meta<Props>;
@@ -133,43 +134,9 @@ export const VerticalOverflow: Story = {
   args: {
     body: () => {
       return html`
-        Lorem<br aria-hidden="true" />
-        ipsum<br aria-hidden="true" />
-        dolor<br aria-hidden="true" />
-        sit<br aria-hidden="true" />
-        amet,<br aria-hidden="true" />
-        qui<br aria-hidden="true" />
-        deserunt<br aria-hidden="true" />
-        esse<br aria-hidden="true" />
-        minim<br aria-hidden="true" />
-        cillum<br aria-hidden="true" />
-        nostrud<br aria-hidden="true" />
-        exercitation<br aria-hidden="true" />
-        veniam<br aria-hidden="true" />
-        consequat<br aria-hidden="true" />
-        pariatur<br aria-hidden="true" />
-        exercitation<br aria-hidden="true" />
-        laborum<br aria-hidden="true" />
-        nostrud<br aria-hidden="true" />
-        culpa<br aria-hidden="true" />
-        sunt<br aria-hidden="true" />
-        exercitation<br aria-hidden="true" />
-        pariatur.<br aria-hidden="true" />
-        Nisi<br aria-hidden="true" />
-        ipsum<br aria-hidden="true" />
-        est<br aria-hidden="true" />
-        ullamco<br aria-hidden="true" />
-        nostrud<br aria-hidden="true" />
-        sit<br aria-hidden="true" />
-        pariatur.<br aria-hidden="true" />
-        Ex<br aria-hidden="true" />
-        nisi<br aria-hidden="true" />
-        ipsum<br aria-hidden="true" />
-        et<br aria-hidden="true" />
-        est<br aria-hidden="true" />
-        nulla<br aria-hidden="true" />
-        ex<br aria-hidden="true" />
-        ex.
+        Lorem ipsum dolor sit amet, qui deserunt esse minim cillum nostrud exercitation veniam
+        consequat pariatur exercitation laborum nostrud culpa sunt exercitation pariatur. Nisi ipsum
+        est ullamco nostrud sit pariatur. Ex nisi ipsum et est nulla ex ex.
       `;
     }
   }
@@ -202,12 +169,15 @@ export const RichContent: Story = {
             Our longest serving math teacher, but also responsible for several extracurricular
             activities.
           </p>
-          <p><strong>Manager:</strong> Anna Johansson</p>
+          <p>
+            <strong>Manager:</strong>
+            Anna Johansson
+          </p>
         </section>
         <sl-button-bar align="end">
-          <sl-button @click=${onClick} size="sm" variant="primary" fill="outline"
-            >Send email</sl-button
-          >
+          <sl-button @click=${onClick} size="sm" variant="primary" fill="outline">
+            Send email
+          </sl-button>
           <sl-button @click=${onClick} size="sm" variant="primary">Send Slack message</sl-button>
         </sl-button-bar>
       `;
@@ -255,7 +225,10 @@ export const WithTooltips: Story = {
           align-items: center;
         }
       </style>
-      <p>Buttons with popovers and tooltips connected via <code>aria-labelledby</code></p>
+      <p>
+        Buttons with popovers and tooltips connected via
+        <code>aria-labelledby</code>
+      </p>
       <div class="container">
         <sl-button
           @click=${onClick}
@@ -281,7 +254,10 @@ export const WithTooltips: Story = {
         <sl-tooltip id="tooltip-edit">Edit</sl-tooltip>
       </div>
 
-      <p>Buttons with popovers and tooltips connected via <code>aria-describedby</code></p>
+      <p>
+        Buttons with popovers and tooltips connected via
+        <code>aria-describedby</code>
+      </p>
       <div class="container">
         <sl-button
           @click=${onClick}
@@ -330,54 +306,39 @@ export const All: Story = {
         }
       </style>
       <div>
-        <sl-button id="anchor" variant="primary"
-          >This is a popover anchor element (sl-button component) <br aria-hidden="true" />
-          with all top and bottom popover allowed positions shown <br aria-hidden="true" />
-          all examples at once</sl-button
-        >
+        <sl-button id="anchor" variant="primary">
+          This is a popover anchor element (sl-button component) with all top and bottom popover
+          allowed positions shown all examples at once.
+        </sl-button>
         <sl-popover anchor="anchor" popover="manual" position="top">Top</sl-popover>
         <sl-popover anchor="anchor" popover="manual" position="top-start">Top start</sl-popover>
         <sl-popover anchor="anchor" popover="manual" position="top-end">Top end</sl-popover>
         <sl-popover anchor="anchor" popover="manual" position="bottom">Bottom</sl-popover>
-        <sl-popover anchor="anchor" popover="manual" position="bottom-start"
-          >Bottom start</sl-popover
-        >
+        <sl-popover anchor="anchor" popover="manual" position="bottom-start">
+          Bottom start
+        </sl-popover>
         <sl-popover anchor="anchor" popover="manual" position="bottom-end">Bottom end</sl-popover>
       </div>
 
       <div>
-        <sl-button id="anchor2" variant="primary" style="width: 72px; padding: 24px;"
-          >This is a popover anchor element (sl-button component) with all right and left popover
-          allowed positions shown all examples at once</sl-button
-        >
-        <sl-popover anchor="anchor2" popover="manual" position="right"
-          >Right <br aria-hidden="true" />
-          example</sl-popover
-        >
-        <sl-popover anchor="anchor2" popover="manual" position="right-start"
-          >Right <br aria-hidden="true" />
-          start <br aria-hidden="true" />
-          example</sl-popover
-        >
-        <sl-popover anchor="anchor2" popover="manual" position="right-end"
-          >Right <br aria-hidden="true" />
-          end <br aria-hidden="true" />
-          example</sl-popover
-        >
-        <sl-popover anchor="anchor2" popover="manual" position="left"
-          >Left <br aria-hidden="true" />
-          example</sl-popover
-        >
-        <sl-popover anchor="anchor2" popover="manual" position="left-start"
-          >Left <br aria-hidden="true" />
-          start <br aria-hidden="true" />
-          example</sl-popover
-        >
-        <sl-popover anchor="anchor2" popover="manual" position="left-end"
-          >Left <br aria-hidden="true" />
-          end <br aria-hidden="true" />
-          example</sl-popover
-        >
+        <sl-button id="anchor2" variant="primary" style="width: 120px">
+          This is a popover anchor element (sl-button component) with all right and left popover
+          allowed positions shown all examples at once
+        </sl-button>
+        <sl-popover anchor="anchor2" popover="manual" position="right">Right example</sl-popover>
+        <sl-popover anchor="anchor2" popover="manual" position="right-start">
+          Right start example
+        </sl-popover>
+        <sl-popover anchor="anchor2" popover="manual" position="right-end">
+          Right end example
+        </sl-popover>
+        <sl-popover anchor="anchor2" popover="manual" position="left">Left example</sl-popover>
+        <sl-popover anchor="anchor2" popover="manual" position="left-start">
+          Left start example
+        </sl-popover>
+        <sl-popover anchor="anchor2" popover="manual" position="left-end">
+          Left end example
+        </sl-popover>
       </div>
     `;
   }


### PR DESCRIPTION
Fixes #3288, fixes #3290

## Changes

- Add `box-sizing: content-box` to fix icon-only button size regression
- Add `max-inline-size: 100%` and `min-inline-size: 0` to prevent `<button>` from growing larger than the host `<sl-button>`