### PR TITLE
fix(dialog): improve grid bulk actions positioning in dialog

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,7 +1,8 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "arrowParens": "avoid",
-  "htmlWhitespaceSensitivity": "ignore",
+  "bracketSameLine": true,
+  "htmlWhitespaceSensitivity": "css",
   "ignorePatterns": [
     "*dist",
     "*generated",

--- a/packages/components/grid/src/grid.scss
+++ b/packages/components/grid/src/grid.scss
@@ -205,6 +205,7 @@
   }
 }
 
+/* stylelint-disable-next-line selector-attribute-operator-space-after */
 :host([striped]) tr[part~='even'] {
   --_body-cell-background: var(--sl-elevation-surface-raised-alternative);
 }

--- a/packages/components/grid/src/grid.scss
+++ b/packages/components/grid/src/grid.scss
@@ -205,7 +205,6 @@
   }
 }
 
-/* stylelint-disable-next-line selector-attribute-operator-space-after */
 :host([striped]) tr[part~='even'] {
   --_body-cell-background: var(--sl-elevation-surface-raised-alternative);
 }

--- a/packages/components/grid/src/stories/selection.stories.ts
+++ b/packages/components/grid/src/stories/selection.stories.ts
@@ -164,6 +164,10 @@ export const MultipleInDialog: Story = {
         }
       </style>
       <p>This example shows how a grid with selection behaves in a dialog.</p>
+      <p>
+        This is actually a bad idea, UX/UI wise, but we show it for demonstration/ documentation
+        purposes.
+      </p>
       <sl-button command="--show-modal" commandfor="invoker-dialog">Open dialog</sl-button>
 
       <p>
@@ -199,6 +203,15 @@ sl-grid::part(bulk-actions) {
   position-anchor: --grid-dialog;
 }</pre
       >
+
+      <p>
+        There is a known issue where the bulk actions gets placed under the dialog overlay when you
+        close and reopen the dialog. To work around this, you can deselect all rows after closing
+        the dialog.
+        <br />
+        Also, the virtual list seems to have a bit of a problem rendering the items in the dialog;
+        the placement is off by a few pixels, until you select a row.
+      </p>
       <sl-dialog id="invoker-dialog" close-button>
         <p>
           This example shows how you can select multiple rows by toggling the checkbox in the first

--- a/packages/components/grid/src/stories/selection.stories.ts
+++ b/packages/components/grid/src/stories/selection.stories.ts
@@ -8,6 +8,7 @@ import {
   isListDataSourceDataItem,
   isListDataSourceGroupItem
 } from '@sl-design-system/data-source';
+import '@sl-design-system/dialog/register.js';
 import { type Student, getStudents } from '@sl-design-system/example-data';
 import { Icon } from '@sl-design-system/icon';
 import '@sl-design-system/icon/register.js';
@@ -45,10 +46,15 @@ export const Activate: Story = {
       <p>
         This example allows you to activate a student by clicking anywhere on the row, or by using
         the keyboard to click on the button with the avatar. This behavior is enabled by setting the
-        <code>row-action</code> property to <code>activate</code>. After activation, the activated
-        student will be highlighted in the grid by setting the <code>activeRow</code> property. An
-        <code>sl-grid-active-row-change</code> event is dispatched when the active row changes,
-        which you can use to update the UI or perform other actions based on the active row.
+        <code>row-action</code>
+        property to
+        <code>activate</code>
+        . After activation, the activated student will be highlighted in the grid by setting the
+        <code>activeRow</code>
+        property. An
+        <code>sl-grid-active-row-change</code>
+        event is dispatched when the active row changes, which you can use to update the UI or
+        perform other actions based on the active row.
       </p>
       <p id="selection">You have not activated anybody yet.</p>
       <sl-grid
@@ -79,10 +85,12 @@ export const Multiple: Story = {
       <p>
         This example shows how you can select multiple rows by toggling the checkbox in the first
         column. If you add an
-        <code>sl-grid-selection-column</code> element, it will automatically enable multi selection
-        for you. When you have selected multiple rows, you can perform bulk actions on them by using
-        the floating tool-bar at the bottom of the grid. You can add bulk actions by using the
-        <code>bulk-actions</code> slot.
+        <code>sl-grid-selection-column</code>
+        element, it will automatically enable multi selection for you. When you have selected
+        multiple rows, you can perform bulk actions on them by using the floating tool-bar at the
+        bottom of the grid. You can add bulk actions by using the
+        <code>bulk-actions</code>
+        slot.
       </p>
       <sl-grid .items=${(students as Student[]).slice(0, 5)}>
         <sl-grid-selection-column ?select-all=${selectAll}></sl-grid-selection-column>
@@ -130,6 +138,125 @@ export const Multiple: Story = {
           This is another very long action button
         </sl-button>
       </sl-grid>
+    `;
+  }
+};
+
+export const MultipleInDialog: Story = {
+  args: {
+    selectAll: false
+  },
+  render: ({ selectAll }, { loaded: { students } }) => {
+    return html`
+      <style>
+        sl-dialog::part(dialog) {
+          anchor-name: --grid-dialog;
+          max-block-size: 70vh;
+        }
+        sl-dialog::part(body) {
+          display: flex;
+          flex-direction: column;
+        }
+        sl-grid::part(bulk-actions) {
+          inset-block-start: calc(anchor(bottom) - var(--sl-size-300));
+          position-anchor: --grid-dialog;
+        }
+      </style>
+      <p>This example shows how a grid with selection behaves in a dialog.</p>
+      <sl-button command="--show-modal" commandfor="invoker-dialog">Open dialog</sl-button>
+
+      <p>
+        With some extra styling it is possible to make the grid behave nicely in the dialog, with
+        the floating tool-bar anchored to the bottom of the dialog and not the viewport. This way,
+        the bulk actions are always easily accessible when you select rows, even when the dialog is
+        scrollable.
+      </p>
+      <p>
+        Also wrap the grid in a
+        <code>div</code>
+        with
+        <code>overflow: auto</code>
+        to the overflow behave better when the content exceeds the maximum height of the dialog.
+      </p>
+
+      <pre
+        style="background: var(--sl-color-background-subtle); padding: var(--sl-size-200); border-radius: var(--sl-size-borderRadius-default); overflow: auto"
+      >
+sl-dialog::part(dialog) {
+  anchor-name: --grid-dialog;
+  max-block-size: 70vh;
+}
+
+sl-dialog::part(body) {
+  display: flex;
+  flex-direction: column;
+}
+
+sl-grid::part(bulk-actions) {
+  inset-block-start: calc(anchor(bottom) - var(--sl-size-300));
+  position-anchor: --grid-dialog;
+}</pre
+      >
+      <sl-dialog id="invoker-dialog" close-button>
+        <p>
+          This example shows how you can select multiple rows by toggling the checkbox in the first
+          column. If you add an
+          <code>sl-grid-selection-column</code>
+          element, it will automatically enable multi selection for you. When you have selected
+          multiple rows, you can perform bulk actions on them by using the floating tool-bar at the
+          bottom of the grid. You can add bulk actions by using the
+          <code>bulk-actions</code>
+          slot.
+        </p>
+        <div style="flex:0; overflow: auto">
+          <sl-grid .items=${(students as Student[]).slice(0, 30)}>
+            <sl-grid-selection-column ?select-all=${selectAll}></sl-grid-selection-column>
+            <sl-grid-column
+              header="Student"
+              path="fullName"
+              .renderer=${avatarRenderer}
+              .scopedElements=${{ 'sl-avatar': Avatar }}
+            ></sl-grid-column>
+            <sl-grid-column path="email"></sl-grid-column>
+
+            <!-- These get slotted into the floating tool-bar -->
+            <sl-button fill="outline" slot="bulk-actions" variant="inverted">
+              <sl-icon name="far-copy"></sl-icon>
+              Duplicate
+            </sl-button>
+            <sl-button fill="outline" slot="bulk-actions" variant="inverted">
+              <sl-icon name="far-trash"></sl-icon>
+              Delete
+            </sl-button>
+            <sl-button disabled fill="outline" slot="bulk-actions" variant="inverted">
+              <sl-icon name="far-right-to-line"></sl-icon>
+              Action 1
+            </sl-button>
+            <sl-button
+              ${tooltip('I am a tooltip')}
+              aria-disabled="true"
+              fill="outline"
+              slot="bulk-actions"
+              variant="inverted"
+            >
+              <sl-icon name="far-right-to-line"></sl-icon>
+              Action 2
+            </sl-button>
+            <sl-button fill="outline" slot="bulk-actions" variant="inverted">
+              <sl-icon name="far-right-to-line"></sl-icon>
+              Action 3
+            </sl-button>
+            <sl-button fill="outline" slot="bulk-actions" variant="inverted">
+              <sl-icon name="far-right-to-line"></sl-icon>
+              This is a very long action button
+            </sl-button>
+            <sl-button fill="outline" slot="bulk-actions" variant="inverted">
+              <sl-icon name="far-right-to-line"></sl-icon>
+              This is another very long action button
+            </sl-button>
+          </sl-grid>
+        </div>
+      </sl-dialog>
     `;
   }
 };
@@ -264,14 +391,20 @@ export const MultipleRow: Story = {
         This example shows how you can select multiple rows at a time, but not just by toggling the
         checkbox at the start of the row, but by clicking anywhere on the row. This is done by
         setting the
-        <code>row-action</code> property to the <code>select</code> value.
+        <code>row-action</code>
+        property to the
+        <code>select</code>
+        value.
       </p>
       <p>
         This example also shows how you can perform bulk actions on the selected rows by using the
         floating tool-bar at the bottom of the grid. The actions do not create a new data source,
-        but instead update the existing data source by calling <code>setData()</code> and
-        <code>update()</code> to signal the grid the data has changed. This way, you do not lose any
-        state when the data changes.
+        but instead update the existing data source by calling
+        <code>setData()</code>
+        and
+        <code>update()</code>
+        to signal the grid the data has changed. This way, you do not lose any state when the data
+        changes.
       </p>
       <sl-grid .dataSource=${ds} row-action="select">
         <sl-grid-selection-column></sl-grid-selection-column>
@@ -284,9 +417,9 @@ export const MultipleRow: Story = {
         <sl-grid-column path="email"></sl-grid-column>
 
         <!-- These get slotted into the floating tool-bar -->
-        <sl-button @click=${onUpdate} fill="outline" slot="bulk-actions" variant="inverted"
-          >Update emails</sl-button
-        >
+        <sl-button @click=${onUpdate} fill="outline" slot="bulk-actions" variant="inverted">
+          Update emails
+        </sl-button>
         <sl-button @click=${onCopy} fill="outline" slot="bulk-actions" variant="inverted">
           <sl-icon name="far-copy"></sl-icon>
           Duplicate
@@ -420,12 +553,15 @@ export const Grouped: Story = {
     return html`
       <p>
         This example shows how selection works in combination with grouping. By adding a
-        <code>sl-grid-selection-column</code> element, the grid is automatically configured for
-        multiple selection. Since grouping is also enabled through the <code>groupBy</code> data
-        source option, the grid will automatically handle the selection of groups and items. When
-        you have selected multiple rows, you can perform bulk actions on them by using the floating
-        tool-bar at the bottom of the grid. You can add bulk actions by using the
-        <code>bulk-actions</code> slot.
+        <code>sl-grid-selection-column</code>
+        element, the grid is automatically configured for multiple selection. Since grouping is also
+        enabled through the
+        <code>groupBy</code>
+        data source option, the grid will automatically handle the selection of groups and items.
+        When you have selected multiple rows, you can perform bulk actions on them by using the
+        floating tool-bar at the bottom of the grid. You can add bulk actions by using the
+        <code>bulk-actions</code>
+        slot.
       </p>
       <sl-button-bar @click=${onClick} style="margin-block-end: var(--sl-size-200)">
         <sl-button>Get selected students</sl-button>

--- a/packages/components/grid/src/stories/selection.stories.ts
+++ b/packages/components/grid/src/stories/selection.stories.ts
@@ -46,30 +46,23 @@ export const Activate: Story = {
       <p>
         This example allows you to activate a student by clicking anywhere on the row, or by using
         the keyboard to click on the button with the avatar. This behavior is enabled by setting the
-        <code>row-action</code>
-        property to
-        <code>activate</code>
-        . After activation, the activated student will be highlighted in the grid by setting the
-        <code>activeRow</code>
-        property. An
-        <code>sl-grid-active-row-change</code>
-        event is dispatched when the active row changes, which you can use to update the UI or
-        perform other actions based on the active row.
+        <code>row-action</code> property to <code>activate</code>. After activation, the activated
+        student will be highlighted in the grid by setting the <code>activeRow</code> property. An
+        <code>sl-grid-active-row-change</code> event is dispatched when the active row changes,
+        which you can use to update the UI or perform other actions based on the active row.
       </p>
       <p id="selection">You have not activated anybody yet.</p>
       <sl-grid
         @sl-grid-active-row-change=${onActiveRowChange}
         .items=${students}
-        row-action="activate"
-      >
+        row-action="activate">
         <sl-grid-column
           grow="3"
           header="Student"
           .renderer=${(student: Student) => html`
             <sl-button fill="link" variant="primary">${avatarRenderer(student)}</sl-button>
           `}
-          .scopedElements=${{ 'sl-avatar': Avatar, 'sl-button': Button }}
-        ></sl-grid-column>
+          .scopedElements=${{ 'sl-avatar': Avatar, 'sl-button': Button }}></sl-grid-column>
         <sl-grid-column path="email"></sl-grid-column>
       </sl-grid>
     `;
@@ -84,13 +77,10 @@ export const Multiple: Story = {
     return html`
       <p>
         This example shows how you can select multiple rows by toggling the checkbox in the first
-        column. If you add an
-        <code>sl-grid-selection-column</code>
-        element, it will automatically enable multi selection for you. When you have selected
-        multiple rows, you can perform bulk actions on them by using the floating tool-bar at the
-        bottom of the grid. You can add bulk actions by using the
-        <code>bulk-actions</code>
-        slot.
+        column. If you add an <code>sl-grid-selection-column</code> element, it will automatically
+        enable multi selection for you. When you have selected multiple rows, you can perform bulk
+        actions on them by using the floating tool-bar at the bottom of the grid. You can add bulk
+        actions by using the <code>bulk-actions</code> slot.
       </p>
       <sl-grid .items=${(students as Student[]).slice(0, 5)}>
         <sl-grid-selection-column ?select-all=${selectAll}></sl-grid-selection-column>
@@ -98,8 +88,7 @@ export const Multiple: Story = {
           header="Student"
           path="fullName"
           .renderer=${avatarRenderer}
-          .scopedElements=${{ 'sl-avatar': Avatar }}
-        ></sl-grid-column>
+          .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-column>
         <sl-grid-column path="email"></sl-grid-column>
 
         <!-- These get slotted into the floating tool-bar -->
@@ -120,8 +109,7 @@ export const Multiple: Story = {
           aria-disabled="true"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           <sl-icon name="far-right-to-line"></sl-icon>
           Action 2
         </sl-button>
@@ -177,17 +165,12 @@ export const MultipleInDialog: Story = {
         scrollable.
       </p>
       <p>
-        Also wrap the grid in a
-        <code>div</code>
-        with
-        <code>overflow: auto</code>
-        to make the overflow behave better when the content exceeds the maximum height of the
-        dialog.
+        Also wrap the grid in a <code>div</code> with <code>overflow: auto</code> to make the
+        overflow behave better when the content exceeds the maximum height of the dialog.
       </p>
 
       <pre
-        style="background: var(--sl-color-background-subtle); padding: var(--sl-size-200); border-radius: var(--sl-size-borderRadius-default); overflow: auto"
-      >
+        style="background: var(--sl-color-background-subtle); padding: var(--sl-size-200); border-radius: var(--sl-size-borderRadius-default); overflow: auto">
 sl-dialog::part(dialog) {
   anchor-name: --grid-dialog;
   max-block-size: 70vh;
@@ -201,8 +184,8 @@ sl-dialog::part(body) {
 sl-grid::part(bulk-actions) {
   inset-block-start: calc(anchor(bottom) - var(--sl-size-300));
   position-anchor: --grid-dialog;
-}
-</pre>
+}</pre
+      >
 
       <p>
         There is a known issue where the bulk actions bar gets placed under the dialog overlay when
@@ -223,21 +206,19 @@ sl-grid::part(bulk-actions) {
           <code>bulk-actions</code>
           slot.
         </p>
-        <div style="flex:0; overflow: auto">
+        <div style="flex:1; overflow: auto">
           <sl-grid .items=${(students as Student[]).slice(0, 30)}>
             <sl-grid-selection-column ?select-all=${selectAll}></sl-grid-selection-column>
             <sl-grid-column
               header="Student"
               path="fullName"
               .renderer=${avatarRenderer}
-              .scopedElements=${{ 'sl-avatar': Avatar }}
-            ></sl-grid-column>
+              .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-column>
             <sl-grid-column path="email"></sl-grid-column>
 
             <!-- These get slotted into the floating tool-bar -->
             <sl-button fill="outline" slot="bulk-actions" variant="inverted">
-              <sl-icon name="far-copy"></sl-icon>
-              Duplicate
+              <sl-icon name="far-copy"></sl-icon> Duplicate
             </sl-button>
             <sl-button fill="outline" slot="bulk-actions" variant="inverted">
               <sl-icon name="far-trash"></sl-icon>
@@ -252,8 +233,7 @@ sl-grid::part(bulk-actions) {
               aria-disabled="true"
               fill="outline"
               slot="bulk-actions"
-              variant="inverted"
-            >
+              variant="inverted">
               <sl-icon name="far-right-to-line"></sl-icon>
               Action 2
             </sl-button>
@@ -293,8 +273,7 @@ export const MultipleWithMenuButton: Story = {
           header="Student"
           path="fullName"
           .renderer=${avatarRenderer}
-          .scopedElements=${{ 'sl-avatar': Avatar }}
-        ></sl-grid-column>
+          .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-column>
         <sl-grid-column path="email"></sl-grid-column>
 
         <!-- These get slotted into the floating tool-bar -->
@@ -307,8 +286,7 @@ export const MultipleWithMenuButton: Story = {
           aria-label="Visibility"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           <span slot="button">Visibility</span>
           <sl-menu-item @click=${() => alert('Hide')}>Hide</sl-menu-item>
           <sl-menu-item @click=${() => alert('Show')}>Show</sl-menu-item>
@@ -327,8 +305,7 @@ export const MultipleWithMenuButton: Story = {
           aria-disabled="true"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           <sl-icon name="far-right-to-line"></sl-icon>
           Action 2
         </sl-button>
@@ -405,11 +382,7 @@ export const MultipleRow: Story = {
       <p>
         This example shows how you can select multiple rows at a time, but not just by toggling the
         checkbox at the start of the row, but by clicking anywhere on the row. This is done by
-        setting the
-        <code>row-action</code>
-        property to the
-        <code>select</code>
-        value.
+        setting the <code>row-action</code> property to the <code>select</code> value.
       </p>
       <p>
         This example also shows how you can perform bulk actions on the selected rows by using the
@@ -427,8 +400,7 @@ export const MultipleRow: Story = {
           grow="3"
           header="Student"
           .renderer=${avatarRenderer}
-          .scopedElements=${{ 'sl-avatar': Avatar }}
-        ></sl-grid-column>
+          .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-column>
         <sl-grid-column path="email"></sl-grid-column>
 
         <!-- These get slotted into the floating tool-bar -->
@@ -461,14 +433,12 @@ export const WithFiltering: Story = {
           header="Student"
           path="fullName"
           .renderer=${avatarRenderer}
-          .scopedElements=${{ 'sl-avatar': Avatar }}
-        ></sl-grid-filter-column>
+          .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-filter-column>
         <sl-grid-filter-column
           header="School"
           label-path="school.name"
           mode="select"
-          path="school.id"
-        ></sl-grid-filter-column>
+          path="school.id"></sl-grid-filter-column>
       </sl-grid>
     `;
   }
@@ -506,8 +476,7 @@ export const WithLinks: Story = {
         @sl-grid-active-row-change=${onActiveRowChange}
         @sl-grid-selection-change=${onSelectionChange}
         .items=${students}
-        row-action="activate"
-      >
+        row-action="activate">
         <sl-grid-selection-column></sl-grid-selection-column>
         <sl-grid-column
           grow="3"
@@ -515,8 +484,7 @@ export const WithLinks: Story = {
           .renderer=${(student: Student) => html`
             <sl-button fill="link" variant="primary">${avatarRenderer(student)}</sl-button>
           `}
-          .scopedElements=${{ 'sl-avatar': Avatar, 'sl-button': Button }}
-        ></sl-grid-column>
+          .scopedElements=${{ 'sl-avatar': Avatar, 'sl-button': Button }}></sl-grid-column>
         <sl-grid-column path="email"></sl-grid-column>
 
         <!-- These get slotted into the floating tool-bar -->
@@ -588,8 +556,7 @@ export const Grouped: Story = {
           grow="3"
           header="Student"
           .renderer=${avatarRenderer}
-          .scopedElements=${{ 'sl-avatar': Avatar }}
-        ></sl-grid-column>
+          .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-column>
         <sl-grid-column path="email"></sl-grid-column>
 
         <!-- These get slotted into the floating tool-bar -->

--- a/packages/components/grid/src/stories/selection.stories.ts
+++ b/packages/components/grid/src/stories/selection.stories.ts
@@ -143,6 +143,7 @@ export const Multiple: Story = {
 };
 
 export const MultipleInDialog: Story = {
+  tags: ['!dev'], // this is a scenario that is highly questionable, so we don't want to show it in the side bar, but keep it on hand if someone needs it
   args: {
     selectAll: false
   },

--- a/packages/components/grid/src/stories/selection.stories.ts
+++ b/packages/components/grid/src/stories/selection.stories.ts
@@ -176,7 +176,8 @@ export const MultipleInDialog: Story = {
         <code>div</code>
         with
         <code>overflow: auto</code>
-        to the overflow behave better when the content exceeds the maximum height of the dialog.
+        to make the overflow behave better when the content exceeds the maximum height of the
+        dialog.
       </p>
 
       <pre

--- a/packages/components/grid/src/stories/selection.stories.ts
+++ b/packages/components/grid/src/stories/selection.stories.ts
@@ -201,13 +201,13 @@ sl-dialog::part(body) {
 sl-grid::part(bulk-actions) {
   inset-block-start: calc(anchor(bottom) - var(--sl-size-300));
   position-anchor: --grid-dialog;
-}</pre
-      >
+}
+</pre>
 
       <p>
-        There is a known issue where the bulk actions gets placed under the dialog overlay when you
-        close and reopen the dialog. To work around this, you can deselect all rows after closing
-        the dialog.
+        There is a known issue where the bulk actions bar gets placed under the dialog overlay when
+        you close and reopen the dialog. To work around this, you can deselect all rows after
+        closing the dialog.
         <br />
         Also, the virtual list seems to have a bit of a problem rendering the items in the dialog;
         the placement is off by a few pixels, until you select a row.


### PR DESCRIPTION
This pull request updates the `selection.stories.ts` file to improve the documentation and add a new example for using the grid selection feature inside a dialog. The main changes include adding a new story, clarifying and formatting documentation, and making minor code improvements.

**New Story Example:**

* Added a `MultipleInDialog` story to demonstrate how the grid selection feature behaves inside a dialog, including custom styling to anchor the bulk actions toolbar to the dialog instead of the viewport. This example is hidden from the sidebar but available for reference.

**Documentation and Formatting Improvements:**

* Reformatted and clarified the documentation in the `Activate`, `Multiple`, `MultipleRow`, and `Grouped` stories for better readability and consistency, especially around code references and explanations. [[1]](diffhunk://#diff-29d20bf14ce78b5b4ab8a139e5516168667c8f0c811401e2ea8bcb284f1cae9bL48-R57) [[2]](diffhunk://#diff-29d20bf14ce78b5b4ab8a139e5516168667c8f0c811401e2ea8bcb284f1cae9bL82-R93) [[3]](diffhunk://#diff-29d20bf14ce78b5b4ab8a139e5516168667c8f0c811401e2ea8bcb284f1cae9bL267-R422) [[4]](diffhunk://#diff-29d20bf14ce78b5b4ab8a139e5516168667c8f0c811401e2ea8bcb284f1cae9bL423-R579)

**Code and Dependency Updates:**

* Imported the dialog component registration (`@sl-design-system/dialog/register.js`) to support the new dialog story.
* Improved the formatting of bulk action buttons in the `MultipleRow` story for consistency.