### PR TITLE
Fix/3263 line height token has px bug

### DIFF
--- a/.changeset/cool-walls-spend.md
+++ b/.changeset/cool-walls-spend.md
@@ -1,0 +1,20 @@
+---
+'@sl-design-system/bingel-dc': patch
+'@sl-design-system/bingel-int': patch
+'@sl-design-system/clickedu': patch
+'@sl-design-system/editorial-suite': patch
+'@sl-design-system/itslearning': patch
+'@sl-design-system/kampus': patch
+'@sl-design-system/magister': patch
+'@sl-design-system/max': patch
+'@sl-design-system/my-digital-book': patch
+'@sl-design-system/myvanin': patch
+'@sl-design-system/neon': patch
+'@sl-design-system/sanoma-learning': patch
+'@sl-design-system/sanoma-pro': patch
+'@sl-design-system/sanoma-utbildning': patch
+'@sl-design-system/teas': patch
+'@sl-design-system/tig': patch
+---
+
+Fixes an issue where line-height variables had a duplicate unit (pxpx)

--- a/scripts/build-themes.js
+++ b/scripts/build-themes.js
@@ -146,7 +146,7 @@ StyleDictionary.registerTransform({
   transitive: true,
   filter: token => token.$type === 'lineHeight',
   transform: token => {
-    const value = token.$value.replace;
+    const value = token.$value;
 
     return value?.endsWith('%')
       ? transformLineHeight(value)

--- a/scripts/build-themes.js
+++ b/scripts/build-themes.js
@@ -146,9 +146,13 @@ StyleDictionary.registerTransform({
   transitive: true,
   filter: token => token.$type === 'lineHeight',
   transform: token => {
-    const value = token.$value;
+    const value = token.$value.replace;
 
-    return value?.endsWith('%') ? transformLineHeight(value) : `${value}px`;
+    return value?.endsWith('%')
+      ? transformLineHeight(value)
+      : value?.endsWith('px')
+        ? value
+        : `${value}px`;
   }
 });
 

--- a/website/.stylelintrc
+++ b/website/.stylelintrc
@@ -1,10 +1,6 @@
 {
   "extends": "../.stylelintrc.mjs",
-  "plugins": [
-    "stylelint-prettier"
-  ],
   "rules": {
-    "prettier/prettier": true,
     "selector-class-pattern": [
       "^(?:(?:o|c|u|t|s|is|has|_|js|qa)-)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:\\[.+\\])?$",
       {


### PR DESCRIPTION
This pull request addresses a bug with line-height variables resulting in duplicate units (e.g., `pxpx`) and makes minor configuration updates to the stylelint setup for the website. The most important changes are summarized below.

### Bug Fixes

* Fixed an issue in the `StyleDictionary` transform logic to prevent appending an extra `px` unit if the value already ends with `px`. This ensures line-height variables are formatted correctly and do not end up with duplicate units (e.g., `pxpx`).

### Tooling/Configuration

* Removed the `stylelint-prettier` plugin and its associated rule from the website’s `.stylelintrc` configuration, simplifying the stylelint setup.


## Before:
<img width="889" height="893" alt="image" src="https://github.com/user-attachments/assets/9c4b6315-56aa-4d8e-b48f-13db8b502f93" />

## After:
<img width="908" height="1059" alt="image" src="https://github.com/user-attachments/assets/1e10ccbe-a7dc-4ea4-9070-7e139324ae7e" />
