### PR TITLE
fix(button): layout issues in Safari and expose internal button part

### DIFF
--- a/.changeset/sour-colts-obey.md
+++ b/.changeset/sour-colts-obey.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/button': minor
+---
+
+Add `button` part to the internal `<button>`

--- a/.changeset/thin-parents-search.md
+++ b/.changeset/thin-parents-search.md
@@ -1,0 +1,8 @@
+---
+'@sl-design-system/button': patch
+---
+
+Styling fixes:
+
+- Fix WebKit bug where the aspect-ratio of the inner button is ignored
+- Fix bug where the inner button doesn't grow with the host element

--- a/packages/components/button/src/button.scss
+++ b/packages/components/button/src/button.scss
@@ -240,12 +240,12 @@ button {
   color: var(--sl-color-foreground-secondary-bold);
   cursor: pointer;
   display: inline-flex;
+  flex: 1;
   font: inherit;
   font-weight: var(--sl-text-new-typeset-fontWeight-semiBold);
   gap: var(--sl-size-075);
   justify-content: center;
   margin: 0;
-  max-inline-size: 100%;
   min-inline-size: 0;
   outline: transparent solid var(--sl-size-borderWidth-focusRing);
   outline-offset: var(--sl-size-outlineOffset-default);

--- a/packages/components/button/src/button.spec.ts
+++ b/packages/components/button/src/button.spec.ts
@@ -28,6 +28,10 @@ describe('sl-button', () => {
       expect(button).to.have.attribute('type', 'button');
     });
 
+    it('should have a "button" CSS part on the inner button', () => {
+      expect(button).to.have.attribute('part', 'button');
+    });
+
     it('should not be disabled', () => {
       expect(button).not.to.have.attribute('disabled');
       expect(el).not.to.have.attribute('disabled');

--- a/packages/components/button/src/button.ts
+++ b/packages/components/button/src/button.ts
@@ -42,6 +42,8 @@ export type ButtonVariant =
  * ```
  *
  * @slot default - Text label of the button. Optionally an <code>sl-icon</code> can be added
+ *
+ * @csspart button - The internal <code>&lt;button&gt;</code> element.
  */
 export class Button extends ForwardAriaMixin(LitElement) {
   /** @internal */
@@ -181,8 +183,8 @@ export class Button extends ForwardAriaMixin(LitElement) {
         command=${ifDefined(this.command)}
         .commandForElement=${target}
         ?disabled=${this.disabled}
-        type="button"
-      >
+        part="button"
+        type="button">
         <slot></slot>
       </button>
     `;


### PR DESCRIPTION
Fixes several button-related issues in Safari and adds a missing CSS part.

## Changes

- Fix icon-only buttons in Safari being stacked on top of each other in the toolbar (#3356)
- Fix dialog close button ('X') being positioned too far to the right in Safari (#3353)
- Expose the internal `<button>` element via `part="button"` so consumers can style it externally using `::part(button)` (#3357)

## Issues

Fixes #3356
Fixes #3353
Fixes #3357