### PR TITLE
fix(calendar): accidental registering of sl-tooltip in global scope

### DIFF
--- a/.changeset/spicy-icons-count.md
+++ b/.changeset/spicy-icons-count.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/calendar': patch
+---
+
+Fix accidental global `<sl-tooltip>` register

--- a/packages/components/calendar/src/month-view.ts
+++ b/packages/components/calendar/src/month-view.ts
@@ -11,7 +11,6 @@ import { isDateInList, isSameDate } from '@sl-design-system/shared/date.js';
 import { type SlChangeEvent, type SlSelectEvent } from '@sl-design-system/shared/events.js';
 import { LocaleMixin } from '@sl-design-system/shared/mixins.js';
 import { Tooltip } from '@sl-design-system/tooltip';
-import '@sl-design-system/tooltip/register.js';
 import {
   type CSSResultGroup,
   LitElement,
@@ -282,8 +281,7 @@ export class MonthView extends LocaleMixin(ScopedElementsMixin(LitElement)) {
           str`Days of ${format(this.month ?? new Date(), this.locale, { month: 'long', year: 'numeric' })}`,
           { id: 'sl.calendar.daysLabel' }
         )}
-        role="grid"
-      >
+        role="grid">
         ${this.renderHeader()}
         <tbody>
           ${this.calendar?.weeks.map(
@@ -294,8 +292,7 @@ export class MonthView extends LocaleMixin(ScopedElementsMixin(LitElement)) {
                       <td
                         aria-label=${msg(str`Week ${week.number}`, { id: 'sl.monthView.week' })}
                         part="week-number"
-                        role="rowheader"
-                      >
+                        role="rowheader">
                         ${week.number}
                       </td>
                     `
@@ -362,8 +359,7 @@ export class MonthView extends LocaleMixin(ScopedElementsMixin(LitElement)) {
                 )}
                 aria-label=${this.getDayLabel(day)}
                 aria-pressed=${selected.toString()}
-                part=${parts.join(' ')}
-              >
+                part=${parts.join(' ')}>
                 <span>${day.date.getDate()}</span>
               </button>
               ${day.indicator?.label


### PR DESCRIPTION
Removes the accidental global `sl-tooltip` custom element registration from `month-view.ts` in the calendar component.

## Problem

Calendar was importing `@sl-design-system/tooltip/register.js` directly in `month-view.ts`, causing `sl-tooltip` to be registered globally. When multiple micro-frontends using `sl-date-field` were loaded in the same page (e.g. switching between SCS's in Magister), the second one would throw:

> `DOMException: Failed to execute 'define' on 'CustomElementRegistry': the name "sl-tooltip" has already been used with this registry`

## Fix

Removed the `import '@sl-design-system/tooltip/register.js'` line from `month-view.ts`.

Closes #3355