### PR TITLE
fix(grid): Add visually hidden text for drag handle column reorder functionality

### DIFF
--- a/.changeset/few-walls-yell.md
+++ b/.changeset/few-walls-yell.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/locales': patch
+---
+
+Add translations for `sl.grid.reorder` in Dutch, Italian, Polish and Spanish.

--- a/.changeset/nine-months-ring.md
+++ b/.changeset/nine-months-ring.md
@@ -2,4 +2,4 @@
 '@sl-design-system/grid': patch
 ---
 
-Add a localized, visually hidden label to the drag handle column header so screen readers can announce the column's purpose properly. Please also remember to update `locales` package to include the new label key `sl.grid.reorder` with an appropriate value for each supported language.
+Add a localized, visually hidden label to the drag handle column header so screen readers can announce the column's purpose properly (includes the new `sl.grid.reorder` locale key).

--- a/.changeset/nine-months-ring.md
+++ b/.changeset/nine-months-ring.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Add a localized, visually hidden label to the drag handle column header so screen readers can announce the column's purpose properly. Please also remember to update `locales` package to include the new label key `sl.grid.reorder` with an appropriate value for each supported language.

--- a/packages/components/grid/src/drag-handle-column.spec.ts
+++ b/packages/components/grid/src/drag-handle-column.spec.ts
@@ -19,8 +19,7 @@ describe('sl-grid-drag-handle-column', () => {
           .items=${[
             { id: 1, name: 'Item 1' },
             { id: 2, name: 'Item 2' }
-          ]}
-        >
+          ]}>
           <sl-grid-drag-handle-column></sl-grid-drag-handle-column>
           <sl-grid-column path="name"></sl-grid-column>
         </sl-grid>
@@ -43,12 +42,15 @@ describe('sl-grid-drag-handle-column', () => {
       expect(el.draggableRows).to.equal('between');
     });
 
-    it('should render an empty header', () => {
+    it('should render a header with a visually hidden label', () => {
       const header = el.renderRoot.querySelector('th[part*="drag-handle"]');
 
       expect(header).to.exist;
-      expect(header).to.have.trimmed.text('');
       expect(header).to.have.attribute('role', 'columnheader');
+
+      const span = header!.querySelector('span.visually-hidden');
+      expect(span).to.exist;
+      expect(span).to.have.trimmed.text('Reorder');
     });
 
     it('should render draggable cells with grip icon', () => {
@@ -74,8 +76,7 @@ describe('sl-grid-drag-handle-column', () => {
             { id: 1, name: 'Draggable Item', draggable: true },
             { id: 2, name: 'Fixed Item', draggable: false },
             { id: 3, name: 'No draggable property' }
-          ]}
-        >
+          ]}>
           <sl-grid-drag-handle-column path="draggable"></sl-grid-drag-handle-column>
           <sl-grid-column path="name"></sl-grid-column>
         </sl-grid>
@@ -126,8 +127,7 @@ describe('sl-grid-drag-handle-column', () => {
           .items=${[
             { id: 1, name: 'Item 1' },
             { id: 2, name: 'Item 2' }
-          ]}
-        >
+          ]}>
           <sl-grid-drag-handle-column></sl-grid-drag-handle-column>
           <sl-grid-column path="name"></sl-grid-column>
         </sl-grid>
@@ -168,8 +168,7 @@ describe('sl-grid-drag-handle-column', () => {
           .items=${[
             { id: 1, name: 'Draggable Item', draggable: true },
             { id: 2, name: 'Fixed Item', draggable: false }
-          ]}
-        >
+          ]}>
           <sl-grid-drag-handle-column path="draggable"></sl-grid-drag-handle-column>
           <sl-grid-column path="name"></sl-grid-column>
         </sl-grid>

--- a/packages/components/grid/src/drag-handle-column.ts
+++ b/packages/components/grid/src/drag-handle-column.ts
@@ -1,3 +1,4 @@
+import { msg } from '@lit/localize';
 import { type ListDataSourceDataItem } from '@sl-design-system/data-source';
 import { Icon } from '@sl-design-system/icon';
 import { getValueByPath } from '@sl-design-system/shared';
@@ -39,7 +40,11 @@ export class GridDragHandleColumn<T = any> extends GridColumn<T> {
   }
 
   override renderHeaderRow(): TemplateResult {
-    return html`<th part="header drag-handle" role="columnheader"></th>`;
+    return html`
+      <th part="header drag-handle" role="columnheader">
+        <span class="visually-hidden">${msg('Reorder', { id: 'sl.grid.reorder' })}</span>
+      </th>
+    `;
   }
 
   override renderData(item: ListDataSourceDataItem<T>): TemplateResult {
@@ -57,8 +62,7 @@ export class GridDragHandleColumn<T = any> extends GridColumn<T> {
           this.#onStartDrag(event, item.data)}
         @touchstart=${(event: Event & { target: HTMLElement }) =>
           this.#onStartDrag(event, item.data)}
-        part="data drag-handle ${draggable ? '' : 'fixed'}"
-      >
+        part="data drag-handle ${draggable ? '' : 'fixed'}">
         ${draggable ? html`<sl-icon name="grip-lines"></sl-icon>` : nothing}
       </td>
     `;

--- a/packages/components/grid/src/grid.scss
+++ b/packages/components/grid/src/grid.scss
@@ -376,6 +376,16 @@ th {
 th[part~='drag-handle'] {
   inline-size: var(--sl-size-600);
   padding-inline: 0;
+
+  .visually-hidden {
+    block-size: 1px;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    inline-size: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+  }
 }
 
 th[part~='filter'],

--- a/packages/components/grid/src/grid.scss
+++ b/packages/components/grid/src/grid.scss
@@ -379,10 +379,13 @@ th[part~='drag-handle'] {
 
   .visually-hidden {
     block-size: 1px;
+    border: 0;
     clip: rect(0 0 0 0);
     clip-path: inset(50%);
     inline-size: 1px;
+    margin: 0;
     overflow: hidden;
+    padding: 0;
     position: absolute;
     white-space: nowrap;
   }

--- a/packages/locales/src/es-ES.ts
+++ b/packages/locales/src/es-ES.ts
@@ -57,6 +57,7 @@ export const templates = {
   'sl.grid.cancelSelection': 'Cancelar selección',
   'sl.grid.filterByValue': str`Filtrar por ${0}`,
   'sl.grid.removeSort': 'Quitar orden',
+  'sl.grid.reorder': 'Reordenar',
   'sl.grid.selectAllRows': 'Seleccionar todas las filas',
   'sl.grid.selectionStatusMessage': str`${0} de ${1} seleccionados`,
   'sl.grid.selectRow': 'Seleccionar fila',

--- a/packages/locales/src/es-ES.xlf
+++ b/packages/locales/src/es-ES.xlf
@@ -138,6 +138,10 @@
   <source>Remove sort</source>
   <target>Quitar orden</target>
 </trans-unit>
+<trans-unit id="sl.grid.reorder">
+  <source>Reorder</source>
+  <target>Reordenar</target>
+</trans-unit>
 <trans-unit id="sl.grid.sortAscending">
   <source>Sort ascending</source>
   <target>Orden ascendente</target>

--- a/packages/locales/src/it.ts
+++ b/packages/locales/src/it.ts
@@ -57,6 +57,7 @@ export const templates = {
   'sl.grid.cancelSelection': 'Annulla selezione',
   'sl.grid.filterByValue': str`Filtra per ${0}`,
   'sl.grid.removeSort': 'Rimuovi ordinamento',
+  'sl.grid.reorder': 'Riordinare',
   'sl.grid.selectAllRows': 'Seleziona tutte le righe',
   'sl.grid.selectionStatusMessage': str`${0} di ${1} selezionati`,
   'sl.grid.selectRow': 'Seleziona riga',

--- a/packages/locales/src/it.xlf
+++ b/packages/locales/src/it.xlf
@@ -138,6 +138,10 @@
   <source>Remove sort</source>
   <target>Rimuovi ordinamento</target>
 </trans-unit>
+<trans-unit id="sl.grid.reorder">
+  <source>Reorder</source>
+  <target>Riordinare</target>
+</trans-unit>
 <trans-unit id="sl.grid.sortAscending">
   <source>Sort ascending</source>
   <target>Ordina crescente</target>

--- a/packages/locales/src/nl.ts
+++ b/packages/locales/src/nl.ts
@@ -57,6 +57,7 @@ export const templates = {
   'sl.grid.cancelSelection': 'Annuleer selectie',
   'sl.grid.filterByValue': str`Filter op ${0}`,
   'sl.grid.removeSort': 'Verwijder sortering',
+  'sl.grid.reorder': 'Herschikken',
   'sl.grid.selectAllRows': 'Selecteer alle rijen',
   'sl.grid.selectionStatusMessage': str`${0} van ${1} geselecteerd`,
   'sl.grid.selectRow': 'Selecteer rij',

--- a/packages/locales/src/nl.xlf
+++ b/packages/locales/src/nl.xlf
@@ -138,6 +138,10 @@
   <source>Remove sort</source>
   <target>Verwijder sortering</target>
 </trans-unit>
+<trans-unit id="sl.grid.reorder">
+  <source>Reorder</source>
+  <target>Herschikken</target>
+</trans-unit>
 <trans-unit id="sl.grid.sortAscending">
   <source>Sort ascending</source>
   <target>Sorteer oplopend</target>

--- a/packages/locales/src/pl.ts
+++ b/packages/locales/src/pl.ts
@@ -57,6 +57,7 @@ export const templates = {
   'sl.grid.cancelSelection': 'Anuluj wybór',
   'sl.grid.filterByValue': str`Filtruj według ${0}`,
   'sl.grid.removeSort': 'Usuń sortowanie',
+  'sl.grid.reorder': 'Zmień kolejność',
   'sl.grid.selectAllRows': 'Zaznacz wszystkie wiersze',
   'sl.grid.selectionStatusMessage': str`${0} z ${1} wybranych`,
   'sl.grid.selectRow': 'Zaznacz wiersz',

--- a/packages/locales/src/pl.xlf
+++ b/packages/locales/src/pl.xlf
@@ -138,6 +138,10 @@
   <source>Remove sort</source>
   <target>Usuń sortowanie</target>
 </trans-unit>
+<trans-unit id="sl.grid.reorder">
+  <source>Reorder</source>
+  <target>Zmień kolejność</target>
+</trans-unit>
 <trans-unit id="sl.grid.sortAscending">
   <source>Sort ascending</source>
   <target>Sortuj rosnąco</target>


### PR DESCRIPTION
This pull request improves accessibility for the grid's drag handle column by adding a localized, visually hidden label for screen readers, and updates the localization files to support this new label in Dutch, Italian, Polish, and Spanish.

**Accessibility improvements:**

* Added a visually hidden `<span>` with a localized label to the drag handle column header in `GridDragHandleColumn`, allowing screen readers to announce the column's purpose. (`sl.grid.reorder`) [[1]](diffhunk://#diff-7dd3cf50a62de86e20006dcd23cc62a5368ec1d15abe08f343c3625e2f8fc040R1-R5) [[2]](diffhunk://#diff-577105a918abc53c02f0a0211e1bf9db9410779002466cdb369b097f5bf8db76L42-R47)
* Updated the grid's SCSS to style the `.visually-hidden` class, ensuring the label is accessible to screen readers but hidden visually.

**Localization updates:**

* Added the `sl.grid.reorder` translation key to the `locales` package and provided translations in Dutch (`Herschikken`), Italian (`Riordinare`), Polish (`Zmień kolejność`), and Spanish (`Reordenar`). [[1]](diffhunk://#diff-d98f4160a2998ac39c2f25457958b409c05846e35839bd2d316c6737b7756e55R1-R5) [[2]](diffhunk://#diff-2e2d9f21689c17236e5f6b8b95506585db7db225de8c4d0cf093b6d1ffc905c6R60) [[3]](diffhunk://#diff-7bd0d83324072da1a9ae84a28e1b06df2c2fea86239355abeec0cc4991b1701cR141-R144) [[4]](diffhunk://#diff-735eab81ae3c1580b94d3275fe0556214f636d1b0511a5e84cbf724f35d214d4R60) [[5]](diffhunk://#diff-d9c3c091bda33302c68d8db9048b9547a7ba2fa58076c7521245ff342ab8336dR141-R144) [[6]](diffhunk://#diff-dce4a86fee183acfa6822d46a61eae19ad41d9896074ada4051fd2f8fe7474f8R60) [[7]](diffhunk://#diff-ce8ab9252b62ce1b3573243a413c23fa094b7f8d7bda448a65819555ea5c8c56R141-R144) [[8]](diffhunk://#diff-86205577e211d47bd6b1bb3a1acd64fa76c4f070dd3718eb123d26455bd7623fR60) [[9]](diffhunk://#diff-0a25aeae0ba3383b91079779739506c8b266cd5354ca58f0f3d71e0ec130567dR141-R144)
