### PR TITLE
fix(panel): Fix collapsed Panel content being exposed to screen readers

### DIFF
--- a/.changeset/stupid-drinks-refuse.md
+++ b/.changeset/stupid-drinks-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/panel': patch
+---
+
+Hide collapsed panel content from assistive technology

--- a/packages/components/panel/src/panel.spec.ts
+++ b/packages/components/panel/src/panel.spec.ts
@@ -112,6 +112,39 @@ describe('sl-panel', () => {
       expect(body).to.have.attribute('aria-labelledby', 'heading');
     });
 
+    it('should hide the body from assistive technology when collapsed', async () => {
+      const body = el.renderRoot.querySelector('[part="body"]');
+
+      expect(body).not.to.have.attribute('aria-hidden');
+      expect(body).not.to.have.attribute('inert');
+
+      el.toggle(true);
+
+      await new Promise(resolve => requestAnimationFrame(resolve));
+      await el.updateComplete;
+
+      expect(body).to.have.attribute('aria-hidden', 'true');
+      expect(body).to.have.attribute('inert');
+
+      el.toggle(false);
+
+      await new Promise(resolve => requestAnimationFrame(resolve));
+      await el.updateComplete;
+
+      expect(body).not.to.have.attribute('aria-hidden');
+      expect(body).not.to.have.attribute('inert');
+    });
+
+    it('should hide initially collapsed body from assistive technology', async () => {
+      const collapsedEl = await fixture<Panel>(
+        html`<sl-panel collapsible collapsed heading="Heading">Body content</sl-panel>`
+      );
+      const body = collapsedEl.renderRoot.querySelector('[part="body"]');
+
+      expect(body).to.have.attribute('aria-hidden', 'true');
+      expect(body).to.have.attribute('inert');
+    });
+
     it('should emit an sl-toggle event when button is clicked', async () => {
       const button = el.renderRoot.querySelector('sl-button'),
         onToggle = spy();

--- a/packages/components/panel/src/panel.ts
+++ b/packages/components/panel/src/panel.ts
@@ -182,12 +182,10 @@ export class Panel extends ScopedElementsMixin(LitElement) {
                 aria-controls="body"
                 aria-expanded=${this.collapsed ? 'false' : 'true'}
                 class="toggle"
-                fill="ghost"
-              >
+                fill="ghost">
                 <sl-icon
                   class=${!this.collapsed ? 'upside-down' : ''}
-                  name="chevron-down"
-                ></sl-icon>
+                  name="chevron-down"></sl-icon>
               </sl-button>
               <div part="wrapper">${this.#renderHeading()}</div>
             `
@@ -201,9 +199,10 @@ export class Panel extends ScopedElementsMixin(LitElement) {
       <div
         id="body"
         part="body"
+        ?inert=${this.collapsible && !!this.collapsed}
+        aria-hidden=${ifDefined(this.collapsible && this.collapsed ? 'true' : undefined)}
         aria-labelledby=${ifDefined(this.collapsible ? 'heading' : undefined)}
-        role=${ifDefined(this.collapsible ? 'region' : undefined)}
-      >
+        role=${ifDefined(this.collapsible ? 'region' : undefined)}>
         <div part="inner">
           <div part="content">
             <slot></slot>


### PR DESCRIPTION
## Summary
This PR fixes an accessibility issue in collapsible sl-panel variants where screen reader users could navigate into visually collapsed panel content.

### Changes:
- Adds aria-hidden="true" to the panel body when a collapsible panel is collapsed
- Adds inert to prevent focus/navigation into collapsed content
- Removes both attributes again when the panel is expanded
- Adds regression tests for toggled and initially collapsed panels


### BEFORE

https://github.com/user-attachments/assets/561406a8-6ceb-4158-8fba-b34c76cc5a87


### AFTER

https://github.com/user-attachments/assets/8906f657-2d0c-4840-ab39-f61f72c06089

