### PR TITLE
fix(grid): Fix transparent sticky grid columns with row activation

### DIFF
--- a/.changeset/orange-bottles-arrive.md
+++ b/.changeset/orange-bottles-arrive.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Fixed sticky grid columns becoming transparent when using `row-action="activate"`

--- a/packages/components/grid/src/grid.scss
+++ b/packages/components/grid/src/grid.scss
@@ -1,6 +1,7 @@
 // stylelint-disable color-no-hex
 :host {
   --_body-cell-background: var(--sl-elevation-surface-raised-default);
+  --_body-cell-background-interactive: linear-gradient(transparent, transparent);
   --_body-cell-padding-block: var(--sl-size-125);
   --_body-cell-padding-inline: var(--sl-size-150);
   --_head-cell-background: var(--sl-elevation-surface-raised-alternative);
@@ -46,23 +47,31 @@
 
 :host([row-action]) {
   [part~='row'] {
-    --_bg-color: transparent;
-    --_bg-mix-color: var(--sl-color-background-input-interactive);
-    --_bg-opacity: var(--sl-opacity-interactive-plain-idle);
-    --_body-cell-background: color-mix(
-      in srgb,
-      var(--_bg-color),
-      var(--_bg-mix-color) calc(100% * var(--_bg-opacity))
+    --_body-cell-background-interactive: linear-gradient(
+      color-mix(
+        in srgb,
+        transparent,
+        var(--_body-cell-background-interactive-color)
+          calc(100% * var(--_body-cell-background-interactive-opacity))
+      ),
+      color-mix(
+        in srgb,
+        transparent,
+        var(--_body-cell-background-interactive-color)
+          calc(100% * var(--_body-cell-background-interactive-opacity))
+      )
     );
+    --_body-cell-background-interactive-color: var(--sl-color-background-input-interactive);
+    --_body-cell-background-interactive-opacity: var(--sl-opacity-interactive-plain-idle);
 
     cursor: pointer;
 
     &:hover {
-      --_bg-opacity: var(--sl-opacity-interactive-plain-hover);
+      --_body-cell-background-interactive-opacity: var(--sl-opacity-interactive-plain-hover);
     }
 
     &:active {
-      --_bg-opacity: var(--sl-opacity-interactive-plain-active);
+      --_body-cell-background-interactive-opacity: var(--sl-opacity-interactive-plain-active);
     }
   }
 
@@ -76,8 +85,9 @@
 
   tr[part~='active'],
   tr[part~='selected'] {
-    --_bg-color: var(--sl-color-background-selected-subtlest);
-    --_bg-mix-color: var(--sl-color-background-selected-interactive-plain);
+    --_body-cell-background-interactive-color: var(
+      --sl-color-background-selected-interactive-plain
+    );
   }
 }
 
@@ -98,10 +108,12 @@
   }
 
   td {
-    background: var(--_vertical-border), var(--_body-cell-background);
+    background:
+      var(--_vertical-border), var(--_body-cell-background-interactive),
+      var(--_body-cell-background);
 
     &:first-of-type {
-      background: var(--_body-cell-background);
+      background: var(--_body-cell-background-interactive), var(--_body-cell-background);
     }
   }
 }
@@ -133,7 +145,9 @@
   }
 
   td.sticky-start-last {
-    background: var(--_vertical-border-end), var(--_body-cell-background);
+    background:
+      var(--_vertical-border-end), var(--_body-cell-background-interactive),
+      var(--_body-cell-background);
   }
 
   th.sticky-start-last {
@@ -182,7 +196,9 @@
   }
 
   td.sticky-end-first {
-    background: var(--_vertical-border), var(--_body-cell-background);
+    background:
+      var(--_vertical-border), var(--_body-cell-background-interactive),
+      var(--_body-cell-background);
   }
 
   th.sticky-end-first {
@@ -401,7 +417,7 @@ th[part~='selection'] {
 }
 
 td {
-  background: var(--_body-cell-background);
+  background: var(--_body-cell-background-interactive), var(--_body-cell-background);
   border-block-end: var(--_border);
   justify-content: start;
   padding: var(--_body-cell-padding-block) var(--_body-cell-padding-inline);

--- a/packages/components/grid/src/grid.scss
+++ b/packages/components/grid/src/grid.scss
@@ -1,7 +1,24 @@
 // stylelint-disable color-no-hex
+@property --_body-cell-background-interactive-opacity {
+  inherits: true;
+  initial-value: 0;
+  syntax: '<number>';
+}
+
 :host {
   --_body-cell-background: var(--sl-elevation-surface-raised-default);
-  --_body-cell-background-interactive: linear-gradient(transparent, transparent);
+  --_body-cell-background-interactive: linear-gradient(
+    var(--_body-cell-background-interactive-mix),
+    var(--_body-cell-background-interactive-mix)
+  );
+  --_body-cell-background-interactive-color: transparent;
+  --_body-cell-background-interactive-mix: color-mix(
+    in srgb,
+    transparent,
+    var(--_body-cell-background-interactive-color)
+      calc(100% * var(--_body-cell-background-interactive-opacity))
+  );
+  --_body-cell-background-interactive-opacity: 0;
   --_body-cell-padding-block: var(--sl-size-125);
   --_body-cell-padding-inline: var(--sl-size-150);
   --_head-cell-background: var(--sl-elevation-surface-raised-alternative);
@@ -47,20 +64,6 @@
 
 :host([row-action]) {
   [part~='row'] {
-    --_body-cell-background-interactive: linear-gradient(
-      color-mix(
-        in srgb,
-        transparent,
-        var(--_body-cell-background-interactive-color)
-          calc(100% * var(--_body-cell-background-interactive-opacity))
-      ),
-      color-mix(
-        in srgb,
-        transparent,
-        var(--_body-cell-background-interactive-color)
-          calc(100% * var(--_body-cell-background-interactive-opacity))
-      )
-    );
     --_body-cell-background-interactive-color: var(--sl-color-background-input-interactive);
     --_body-cell-background-interactive-opacity: var(--sl-opacity-interactive-plain-idle);
 
@@ -423,7 +426,7 @@ td {
   padding: var(--_body-cell-padding-block) var(--_body-cell-padding-inline);
 
   @media (prefers-reduced-motion: no-preference) {
-    transition: background-color 0.2s ease-in-out;
+    transition: --_body-cell-background-interactive-opacity 0.2s ease-in-out;
   }
 
   &:has(> :not(sl-ellipsize-text)) {

--- a/packages/components/grid/src/grid.scss
+++ b/packages/components/grid/src/grid.scss
@@ -426,7 +426,9 @@ td {
   padding: var(--_body-cell-padding-block) var(--_body-cell-padding-inline);
 
   @media (prefers-reduced-motion: no-preference) {
-    transition: --_body-cell-background-interactive-opacity 0.2s ease-in-out;
+    transition:
+      background-color 0.2s ease-in-out,
+      --_body-cell-background-interactive-opacity 0.2s ease-in-out;
   }
 
   &:has(> :not(sl-ellipsize-text)) {

--- a/packages/components/grid/src/grid.spec.ts
+++ b/packages/components/grid/src/grid.spec.ts
@@ -55,8 +55,7 @@ describe('sl-grid', () => {
           .items=${[
             { firstName: 'John', lastName: 'Doe' },
             { firstName: 'Jane', lastName: 'Smith' }
-          ]}
-        >
+          ]}>
           <sl-grid-column path="firstName"></sl-grid-column>
           <sl-grid-column path="lastName"></sl-grid-column>
         </sl-grid>
@@ -195,8 +194,7 @@ describe('sl-grid', () => {
           aria-disabled="true"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           Action 2
         </sl-button>
       `);
@@ -228,8 +226,7 @@ describe('sl-grid', () => {
           aria-describedby="bulk-action-tooltip"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           Action 2
         </sl-button>
       `);
@@ -270,8 +267,7 @@ describe('sl-grid', () => {
           aria-describedby="bulk-action-tooltip"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           Action 2
         </sl-button>
       `);
@@ -305,8 +301,7 @@ describe('sl-grid', () => {
           aria-disabled="true"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           Action 2
         </sl-button>
       `);
@@ -360,8 +355,7 @@ describe('sl-grid', () => {
             { firstName: 'Alice', lastName: 'Johnson' }
           ]}
           selects="single"
-          row-action="select"
-        >
+          row-action="select">
           <sl-grid-column path="firstName"></sl-grid-column>
           <sl-grid-column path="lastName"></sl-grid-column>
         </sl-grid>
@@ -484,8 +478,7 @@ describe('sl-grid', () => {
             { firstName: 'John', lastName: 'Doe' },
             { firstName: 'Jane', lastName: 'Smith' }
           ]}
-          row-action="activate"
-        >
+          row-action="activate">
           <sl-grid-column path="firstName"></sl-grid-column>
           <sl-grid-column path="lastName"></sl-grid-column>
         </sl-grid>
@@ -543,6 +536,41 @@ describe('sl-grid', () => {
       expect(onActiveRowChange).to.have.been.calledOnce;
       expect(onActiveRowChange.firstCall.args[0].detail).to.deep.equal(el.items!.at(1));
     });
+
+    it('should keep sticky active row cells opaque', async () => {
+      el = await fixture(html`
+        <sl-grid
+          .items=${[
+            { firstName: 'John', lastName: 'Doe' },
+            { firstName: 'Jane', lastName: 'Smith' }
+          ]}
+          row-action="activate"
+          style="
+            --sl-elevation-surface-raised-default: rgb(255 255 255);
+            --sl-color-background-input-interactive: rgb(0 0 0);
+            --sl-color-background-selected-interactive-plain: rgb(0 80 160);
+            --sl-color-background-selected-subtlest: transparent;
+            --sl-opacity-interactive-plain-idle: 0.1;
+          ">
+          <sl-grid-column path="firstName" sticky></sl-grid-column>
+          <sl-grid-column path="lastName"></sl-grid-column>
+        </sl-grid>
+      `);
+
+      await waitForGridToRenderData(el);
+
+      el.activeRow = el.items!.at(0);
+      await el.updateComplete;
+
+      const cell = el.renderRoot.querySelector<HTMLTableCellElement>(
+        'tbody tr:first-of-type td.sticky-start-first'
+      );
+
+      const style = getComputedStyle(cell!);
+
+      expect(style.backgroundColor).to.equal('rgb(255, 255, 255)');
+      expect(style.backgroundImage).to.contain('linear-gradient');
+    });
   });
 
   describe('row action select', () => {
@@ -553,8 +581,7 @@ describe('sl-grid', () => {
             { firstName: 'John', lastName: 'Doe' },
             { firstName: 'Jane', lastName: 'Smith' }
           ]}
-          row-action="select"
-        >
+          row-action="select">
           <sl-grid-selection-column></sl-grid-selection-column>
           <sl-grid-column path="firstName"></sl-grid-column>
           <sl-grid-column path="lastName"></sl-grid-column>
@@ -651,8 +678,7 @@ describe('sl-grid', () => {
             { firstName: 'Sophie', lastName: 'Müller', email: 'sophie.muller@school1.edu' },
             { firstName: 'Luca', lastName: 'van Dijk', email: 'luca.vandijk@school4.edu' },
             { firstName: 'Clara', lastName: 'de Vries', email: 'clara.devries@school4.edu' }
-          ]}
-        >
+          ]}>
           <sl-grid-selection-column></sl-grid-selection-column>
           <sl-grid-column path="firstName"></sl-grid-column>
           <sl-grid-column path="email"></sl-grid-column>

--- a/packages/components/grid/src/grid.spec.ts
+++ b/packages/components/grid/src/grid.spec.ts
@@ -566,6 +566,8 @@ describe('sl-grid', () => {
         'tbody tr:first-of-type td.sticky-start-first'
       );
 
+      expect(cell).to.exist;
+
       const style = getComputedStyle(cell!);
 
       expect(style.backgroundColor).to.equal('rgb(255, 255, 255)');

--- a/packages/components/grid/src/stories/scrolling.stories.ts
+++ b/packages/components/grid/src/stories/scrolling.stories.ts
@@ -31,8 +31,7 @@ export const Vertical: Story = {
         header="Student"
         path="fullName"
         .renderer=${avatarRenderer}
-        .scopedElements=${{ 'sl-avatar': Avatar }}
-      ></sl-grid-column>
+        .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-column>
       <sl-grid-column path="email"></sl-grid-column>
     </sl-grid>
   `
@@ -63,8 +62,7 @@ export const VerticalOverflow: Story = {
         header="Student"
         path="fullName"
         .renderer=${avatarRenderer}
-        .scopedElements=${{ 'sl-avatar': Avatar }}
-      ></sl-grid-column>
+        .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-column>
       <sl-grid-column path="email"></sl-grid-column>
     </sl-grid>
   `
@@ -142,8 +140,7 @@ export const Both: Story = {
         <sl-grid-column
           header="Student"
           .renderer=${avatarRenderer}
-          .scopedElements=${{ 'sl-avatar': Avatar }}
-        ></sl-grid-column>
+          .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-column>
         ${columns.map(c => html`<sl-grid-column path=${c}></sl-grid-column>`)}
       </sl-grid>
     `;
@@ -181,7 +178,7 @@ export const BothSticky: Story = {
       or end of the grid. You cannot have sticky columns in the middle of the grid.
     </p>
     <div class="cover"></div>
-    <sl-grid .items=${students}>
+    <sl-grid .items=${students} row-action="activate">
       <sl-grid-selection-column sticky></sl-grid-selection-column>
       <sl-grid-column grow="0" header="Nr." path="studentNumber" sticky></sl-grid-column>
       <sl-grid-column path="group.name" sticky></sl-grid-column>
@@ -190,8 +187,7 @@ export const BothSticky: Story = {
         header="Student"
         path="fullName"
         .renderer=${avatarRenderer}
-        .scopedElements=${{ 'sl-avatar': Avatar }}
-      ></sl-grid-column>
+        .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-column>
       <sl-grid-column path="email"></sl-grid-column>
       <sl-grid-column path="school.name"></sl-grid-column>
       <sl-grid-column path="school.address"></sl-grid-column>
@@ -221,8 +217,7 @@ export const Horizontal: Story = {
         header="Student"
         path="fullName"
         .renderer=${avatarRenderer}
-        .scopedElements=${{ 'sl-avatar': Avatar }}
-      ></sl-grid-column>
+        .scopedElements=${{ 'sl-avatar': Avatar }}></sl-grid-column>
       <sl-grid-column path="email"></sl-grid-column>
       <sl-grid-column path="group.name"></sl-grid-column>
       <sl-grid-column path="school.name"></sl-grid-column>

--- a/packages/components/grid/src/stories/scrolling.stories.ts
+++ b/packages/components/grid/src/stories/scrolling.stories.ts
@@ -173,9 +173,10 @@ export const BothSticky: Story = {
     </style>
     <p>
       This example shows a large grid where you can both scroll horizontally as well as vertically.
-      It also has both a sticky header as well as sticky columns. You can make a column sticky by
-      adding the <code>sticky</code> attribute. Note that this only works for columns at the start
-      or end of the grid. You cannot have sticky columns in the middle of the grid.
+      It also has both a sticky header as well as sticky columns, and activates rows when you click
+      them. You can make a column sticky by adding the <code>sticky</code> attribute. Note that this
+      only works for columns at the start or end of the grid. You cannot have sticky columns in the
+      middle of the grid.
     </p>
     <div class="cover"></div>
     <sl-grid .items=${students} row-action="activate">


### PR DESCRIPTION
## Summary:

Sticky grid columns now keep an opaque cell background when row-action="activate" is used, preventing scrolled content from showing through active or interactive rows


### BEFORE

https://github.com/user-attachments/assets/1e17e9b1-03eb-4b26-9c6e-b918ebf7b1b6

### AFTER

https://github.com/user-attachments/assets/9410e9ec-b79d-4a8a-addc-ed072658711f

