### PR TITLE
fix(grid): Fix Grid aria-rowindex to start at 1

### DIFF
--- a/.changeset/four-dingos-know.md
+++ b/.changeset/four-dingos-know.md
@@ -2,4 +2,4 @@
 '@sl-design-system/grid': patch
 ---
 
-Fixed Grid row accessibility by rendering `aria-rowindex` as a 1-based value instead of using the internal zero-based virtualizer index
+Fixed Grid row accessibility by rendering `aria-rowindex` as a 1-based value for both data rows and group rows instead of using the internal zero-based virtualizer index

--- a/.changeset/four-dingos-know.md
+++ b/.changeset/four-dingos-know.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Fixed Grid row accessibility by rendering `aria-rowindex` as a 1-based value instead of using the internal zero-based virtualizer index

--- a/packages/components/grid/src/grid.spec.ts
+++ b/packages/components/grid/src/grid.spec.ts
@@ -55,8 +55,7 @@ describe('sl-grid', () => {
           .items=${[
             { firstName: 'John', lastName: 'Doe' },
             { firstName: 'Jane', lastName: 'Smith' }
-          ]}
-        >
+          ]}>
           <sl-grid-column path="firstName"></sl-grid-column>
           <sl-grid-column path="lastName"></sl-grid-column>
         </sl-grid>
@@ -95,6 +94,14 @@ describe('sl-grid', () => {
         ['John', 'Doe'],
         ['Jane', 'Smith']
       ]);
+    });
+
+    it('should render aria-rowindex values starting at 1', () => {
+      const rowIndices = Array.from(el.renderRoot.querySelectorAll('tbody tr')).map(row =>
+        row.getAttribute('aria-rowindex')
+      );
+
+      expect(rowIndices).to.deep.equal(['1', '2']);
     });
   });
 
@@ -195,8 +202,7 @@ describe('sl-grid', () => {
           aria-disabled="true"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           Action 2
         </sl-button>
       `);
@@ -228,8 +234,7 @@ describe('sl-grid', () => {
           aria-describedby="bulk-action-tooltip"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           Action 2
         </sl-button>
       `);
@@ -270,8 +275,7 @@ describe('sl-grid', () => {
           aria-describedby="bulk-action-tooltip"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           Action 2
         </sl-button>
       `);
@@ -305,8 +309,7 @@ describe('sl-grid', () => {
           aria-disabled="true"
           fill="outline"
           slot="bulk-actions"
-          variant="inverted"
-        >
+          variant="inverted">
           Action 2
         </sl-button>
       `);
@@ -360,8 +363,7 @@ describe('sl-grid', () => {
             { firstName: 'Alice', lastName: 'Johnson' }
           ]}
           selects="single"
-          row-action="select"
-        >
+          row-action="select">
           <sl-grid-column path="firstName"></sl-grid-column>
           <sl-grid-column path="lastName"></sl-grid-column>
         </sl-grid>
@@ -484,8 +486,7 @@ describe('sl-grid', () => {
             { firstName: 'John', lastName: 'Doe' },
             { firstName: 'Jane', lastName: 'Smith' }
           ]}
-          row-action="activate"
-        >
+          row-action="activate">
           <sl-grid-column path="firstName"></sl-grid-column>
           <sl-grid-column path="lastName"></sl-grid-column>
         </sl-grid>
@@ -553,8 +554,7 @@ describe('sl-grid', () => {
             { firstName: 'John', lastName: 'Doe' },
             { firstName: 'Jane', lastName: 'Smith' }
           ]}
-          row-action="select"
-        >
+          row-action="select">
           <sl-grid-selection-column></sl-grid-selection-column>
           <sl-grid-column path="firstName"></sl-grid-column>
           <sl-grid-column path="lastName"></sl-grid-column>
@@ -651,8 +651,7 @@ describe('sl-grid', () => {
             { firstName: 'Sophie', lastName: 'Müller', email: 'sophie.muller@school1.edu' },
             { firstName: 'Luca', lastName: 'van Dijk', email: 'luca.vandijk@school4.edu' },
             { firstName: 'Clara', lastName: 'de Vries', email: 'clara.devries@school4.edu' }
-          ]}
-        >
+          ]}>
           <sl-grid-selection-column></sl-grid-selection-column>
           <sl-grid-column path="firstName"></sl-grid-column>
           <sl-grid-column path="email"></sl-grid-column>

--- a/packages/components/grid/src/grid.spec.ts
+++ b/packages/components/grid/src/grid.spec.ts
@@ -1,4 +1,5 @@
 import '@sl-design-system/button/register.js';
+import { ArrayListDataSource } from '@sl-design-system/data-source';
 import '@sl-design-system/menu/register.js';
 import { isPopoverOpen } from '@sl-design-system/shared';
 import { type ToolBar } from '@sl-design-system/tool-bar';
@@ -14,6 +15,7 @@ import { type Grid, type SlActiveRowChangeEvent } from './grid.js';
 import { waitForGridToRenderData } from './utils.js';
 
 type Person = { firstName: string; lastName: string; email?: string };
+type Student = Person & { school: { id: number; name: string } };
 
 describe('sl-grid', () => {
   let el: Grid<Person>;
@@ -183,6 +185,45 @@ describe('sl-grid', () => {
       await el.updateComplete;
 
       expect(el.dataSource?.selects).to.equal('multiple');
+    });
+  });
+
+  describe('grouping', () => {
+    beforeEach(async () => {
+      el = await fixture(html`
+        <sl-grid
+          .dataSource=${new ArrayListDataSource<Student>(
+            [
+              {
+                firstName: 'John',
+                lastName: 'Doe',
+                school: { id: 1, name: 'School A' }
+              },
+              {
+                firstName: 'Jane',
+                lastName: 'Smith',
+                school: { id: 2, name: 'School B' }
+              }
+            ],
+            {
+              groupBy: 'school.id',
+              groupLabelPath: 'school.name'
+            }
+          )}>
+          <sl-grid-column path="firstName"></sl-grid-column>
+          <sl-grid-column path="lastName"></sl-grid-column>
+        </sl-grid>
+      `);
+
+      await waitForGridToRenderData(el);
+    });
+
+    it('should render aria-rowindex values for group and data rows', () => {
+      const rowIndices = Array.from(el.renderRoot.querySelectorAll('tbody tr')).map(row =>
+        row.getAttribute('aria-rowindex')
+      );
+
+      expect(rowIndices).to.deep.equal(['1', '2', '3', '4']);
     });
   });
 

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -630,7 +630,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
       );
 
     return html`
-      <tr part="group" index=${index}>
+      <tr aria-rowindex=${index + 1} part="group" index=${index}>
         <td part="group-header">
           <sl-grid-group-header
             @sl-select=${(event: SlSelectEvent<boolean>) => this.#onGroupSelect(event, item)}

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -449,8 +449,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
       <slot
         @sl-column-update=${this.#onColumnUpdate}
         @slotchange=${this.#onSlotChange}
-        style="display:none"
-      ></slot>
+        style="display:none"></slot>
       <style>
         ${this.renderStyles()}
       </style>
@@ -461,8 +460,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
               href="#table-end"
               class="skip-link-start"
               @click=${(e: Event & { target: HTMLSlotElement }) => this.#onSkipTo(e, 'end')}
-              @focus=${(e: Event & { target: HTMLSlotElement }) => this.#onSkipToFocus(e, 'top')}
-            >
+              @focus=${(e: Event & { target: HTMLSlotElement }) => this.#onSkipToFocus(e, 'top')}>
               ${msg('Skip to end of table', { id: 'sl.grid.skipToEndOfTable' })}
             </a>
           `
@@ -474,8 +472,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
           @sl-filter-register=${this.#onFilterRegister}
           @sl-sorter-change=${this.#onSorterChange}
           @sl-sorter-register=${this.#onSorterRegister}
-          part="thead"
-        >
+          part="thead">
           ${this.#headerRows.map(row => this.renderHeaderRow(row))}
         </thead>
         <tbody id="tbody" part="tbody">
@@ -510,8 +507,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
           @click=${this.#onCancelSelection}
           aria-describedby="tooltip"
           fill="ghost"
-          variant="inverted"
-        >
+          variant="inverted">
           <sl-icon name="xmark"></sl-icon>
         </sl-button>
         <sl-tooltip id="tooltip">
@@ -616,10 +612,9 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
         @dragover=${(event: DragEvent) => this.#onDragOver(event, item)}
         @dragend=${(event: DragEvent) => this.#onDragEnd(event, item)}
         @drop=${(event: DragEvent) => this.#onDrop(event, item)}
-        aria-rowindex=${index}
+        aria-rowindex=${index + 1}
         index=${index}
-        part=${parts.join(' ')}
-      >
+        part=${parts.join(' ')}>
         ${rows[rows.length - 1].map(col => col.renderData(item))}
       </tr>
     `;
@@ -643,8 +638,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
             ?collapsed=${collapsed}
             ?drag-handle=${draggable}
             ?selectable=${selectable}
-            .selected=${item.selected ?? 'none'}
-          >
+            .selected=${item.selected ?? 'none'}>
             ${this.groupHeaderRenderer?.(item) ??
             html`
               <span slot="group-heading">


### PR DESCRIPTION
## Summary:

Fixed an accessibility issue in Grid where row `aria-rowindex` values were based on the internal zero-based virtualizer index. Grid rows now render 1-based `aria-rowindex` values, including both data rows and group rows. Added regression tests for regular and grouped rows


### BEFORE
<img width="1216" height="852" alt="Screenshot 2026-05-22 at 17 10 19" src="https://github.com/user-attachments/assets/833fac01-c022-4861-8568-d6ddcff79791" />

### AFTER

<img width="1212" height="968" alt="Screenshot 2026-05-22 at 17 11 05" src="https://github.com/user-attachments/assets/dadbf10a-102b-4ba1-98e5-ece3ce6070db" />



