### PR TITLE
fix(paginator): Fix xs paginator page numbers wrapping

### DIFF
--- a/.changeset/silent-actors-laugh.md
+++ b/.changeset/silent-actors-laugh.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/paginator': patch
+---
+
+Prevent page numbers from wrapping in the extra small paginator page select

--- a/packages/components/paginator/src/paginator.scss
+++ b/packages/components/paginator/src/paginator.scss
@@ -27,11 +27,14 @@
   sl-select {
     min-inline-size: var(--sl-size-1000);
   }
+
+  sl-option::part(wrapper) {
+    white-space: nowrap;
+  }
 }
 
 .page {
   box-sizing: border-box;
-  color: var(--sl-color-foreground-neutral-bold);
   flex-shrink: 0;
   inline-size: calc(1lh + (var(--sl-size-100) * 2));
   padding-inline: 0;

--- a/packages/components/paginator/src/paginator.spec.ts
+++ b/packages/components/paginator/src/paginator.spec.ts
@@ -1,6 +1,7 @@
 import { Button } from '@sl-design-system/button';
 import '@sl-design-system/button/register.js';
 import { ArrayListDataSource, type ListDataSource } from '@sl-design-system/data-source';
+import { type Option } from '@sl-design-system/listbox';
 import '@sl-design-system/select/register.js';
 import {
   getForwardedAccessibleName,
@@ -441,6 +442,16 @@ describe('sl-paginator', () => {
         );
 
         expect(buttons).to.have.lengthOf(0);
+      });
+
+      it('should not wrap page numbers in select options when the width is xs', async () => {
+        el.width = 'xs';
+        await el.updateComplete;
+
+        const option = el.renderRoot.querySelector<Option>('sl-option:nth-of-type(10)')!,
+          wrapper = option.renderRoot.querySelector('[part="wrapper"]')!;
+
+        expect(getComputedStyle(wrapper).whiteSpace).to.equal('nowrap');
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes the extra small paginator page select so two-digit page numbers stay on one line in macOS browsers


### BEFORE
<img width="379" height="539" alt="Screenshot 2026-05-22 at 17 28 11" src="https://github.com/user-attachments/assets/10c2536b-0f36-4c19-9b8e-e433bb8b52c9" />


### AFTER
<img width="394" height="523" alt="Screenshot 2026-05-22 at 17 27 37" src="https://github.com/user-attachments/assets/8a37165b-99f8-4875-997e-384f6f8614a2" />
