### PR TITLE
chore(docs): Document Angular dialog services

### DIFF
--- a/website/src/categories/components/dialog/code.md
+++ b/website/src/categories/components/dialog/code.md
@@ -52,6 +52,14 @@ magna duis. Voluptate tempor amet cupidatat officia labore ipsum ad do.
 
 <section>
 
+## Angular service
+
+Angular applications can use the `DialogService` to open and manage dialogs programmatically. See the [Dialog Service documentation in Storybook](https://storybook.sanomalearning.design/?path=/docs/angular_components-dialog-service--documentation) for Angular examples and API details.
+
+</section>
+
+<section>
+
 ## Responsive behavior
 
 The button-bar component in the footer will automatically stack the buttons vertically when the viewport is smaller than 600px. This behavior is enabled by default.

--- a/website/src/categories/components/message-dialog/code.md
+++ b/website/src/categories/components/message-dialog/code.md
@@ -52,6 +52,13 @@ eleventyNavigation:
 <ds-install-info link-in-navigation package="message-dialog"></ds-install-info>
 <section>
 
+## Angular service
+
+Angular applications can use the `MessageDialogService` to open and manage message dialogs programmatically. See the [Message Dialog Service documentation in Storybook](https://storybook.sanomalearning.design/?path=/docs/angular_components-message-dialog-service--documentation) for Angular examples and API details.
+
+</section>
+<section>
+
 ## Alert
 
 The `MessageDialog.alert()` API is used to show a message dialog with a single "OK" button. Use this for informing the user about something important. Do not use this just for anything, as you are interrupting the workflow of the user.


### PR DESCRIPTION
## Summary

Adds documentation notes for the Angular DialogService and MessageDialogService on the Dialog and Message dialog code pages, including links to their Storybook documentation