### PR TITLE
fix(menu tooolbar): Fix disabled toolbar overflow menu items a11y

### DIFF
--- a/.changeset/plain-times-beam.md
+++ b/.changeset/plain-times-beam.md
@@ -1,6 +1,7 @@
 ---
 '@sl-design-system/menu': patch
+'@sl-design-system/shared': patch
 '@sl-design-system/tool-bar': patch
 ---
 
-Expose `aria-disabled="true"` on disabled menu items so assistive technologies announce them as unavailable. Toolbar overflow menu items now preserve disabled semantics with `aria-disabled` instead of rendering hard-disabled menu items, keeping them reachable while preventing activation.
+Expose `aria-disabled="true"` on disabled menu items so assistive technologies announce them as unavailable. Toolbar overflow menu items now preserve disabled semantics with `aria-disabled` instead of rendering hard-disabled menu items, keeping them reachable while preventing activation. Forwarded `ariaDisabled` now clears correctly through nested proxy targets

--- a/.changeset/plain-times-beam.md
+++ b/.changeset/plain-times-beam.md
@@ -1,0 +1,6 @@
+---
+'@sl-design-system/menu': patch
+'@sl-design-system/tool-bar': patch
+---
+
+Expose `aria-disabled="true"` on disabled menu items so assistive technologies announce them as unavailable. Toolbar overflow menu items now preserve disabled semantics with `aria-disabled` instead of rendering hard-disabled menu items, keeping them reachable while preventing activation.

--- a/packages/components/menu/src/menu-item.scss
+++ b/packages/components/menu/src/menu-item.scss
@@ -62,15 +62,16 @@
   --_bg-color: var(--sl-color-background-negative-subtle);
 }
 
-:host([emphasis='bold'][variant='danger']:not([disabled]):hover),
-:host([emphasis='bold'][variant='danger'][selected]:not([disabled])) {
+:host([emphasis='bold'][variant='danger']:not([disabled], [aria-disabled='true']):hover),
+:host([emphasis='bold'][variant='danger'][selected]:not([disabled], [aria-disabled='true'])) {
   --_bg-color: var(--sl-color-background-negative-bold);
   --_bg-mix-color: var(--sl-color-background-negative-interactive-bold);
 
   color: var(--sl-color-foreground-negative-onBold);
 }
 
-:host([disabled]) {
+:host([disabled]),
+:host([aria-disabled='true']) {
   color: var(--sl-color-foreground-disabled);
   pointer-events: none;
 

--- a/packages/components/menu/src/menu-item.spec.ts
+++ b/packages/components/menu/src/menu-item.spec.ts
@@ -32,6 +32,7 @@ describe('sl-menu-item', () => {
 
     it('should not be disabled', () => {
       expect(el).not.to.have.attribute('disabled');
+      expect(el).not.to.have.attribute('aria-disabled');
       expect(el.disabled).not.to.be.true;
     });
 
@@ -40,7 +41,31 @@ describe('sl-menu-item', () => {
       await el.updateComplete;
 
       expect(el).to.have.attribute('disabled');
+      expect(el).to.have.attribute('aria-disabled', 'true');
       expect(el.disabled).to.be.true;
+    });
+
+    it('should remove aria-disabled when re-enabled', async () => {
+      el.disabled = true;
+      await el.updateComplete;
+
+      el.disabled = false;
+      await el.updateComplete;
+
+      expect(el).not.to.have.attribute('aria-disabled');
+      expect(el).to.have.attribute('tabindex', '0');
+    });
+
+    it('should preserve aria-disabled when re-enabled if it was set explicitly', async () => {
+      el.setAttribute('aria-disabled', 'true');
+      el.disabled = true;
+      await el.updateComplete;
+
+      el.disabled = false;
+      await el.updateComplete;
+
+      expect(el).to.have.attribute('aria-disabled', 'true');
+      expect(el).to.have.attribute('tabindex', '0');
     });
 
     it('should not be selectable', () => {
@@ -165,6 +190,38 @@ describe('sl-menu-item', () => {
       el = await fixture(html`<sl-menu-item selected>Item 1</sl-menu-item>`);
 
       expect(el.renderRoot.querySelector('sl-icon[name="check"]')).not.to.exist;
+    });
+  });
+
+  describe('aria-disabled', () => {
+    it('should remain focusable when aria-disabled', async () => {
+      el = await fixture(html`<sl-menu-item aria-disabled="true">Item 1</sl-menu-item>`);
+
+      expect(el).to.have.attribute('tabindex', '0');
+      expect(el).not.to.have.attribute('disabled');
+    });
+
+    it('should not toggle selected when clicked', async () => {
+      el = await fixture(html`
+        <sl-menu-item aria-disabled="true" selectable selected>Item 1</sl-menu-item>
+      `);
+
+      el.click();
+      await el.updateComplete;
+
+      expect(el.selected).to.be.true;
+    });
+
+    it('should not toggle selected when pressing enter', async () => {
+      el = await fixture(html`
+        <sl-menu-item aria-disabled="true" selectable selected>Item 1</sl-menu-item>
+      `);
+
+      el.focus();
+      await userEvent.keyboard('{Enter}');
+      await el.updateComplete;
+
+      expect(el.selected).to.be.true;
     });
   });
 

--- a/packages/components/menu/src/menu-item.ts
+++ b/packages/components/menu/src/menu-item.ts
@@ -65,6 +65,9 @@ export class MenuItem extends ScopedElementsMixin(LitElement) {
   /** Shortcut controller. */
   #shortcut = new ShortcutController(this);
 
+  // Tracks whether aria-disabled was added internally so explicit user-provided values survive.
+  #ariaDisabledFromDisabled = false;
+
   /** Whether this menu item is disabled. */
   @property({ type: Boolean, reflect: true }) disabled?: boolean;
 
@@ -92,6 +95,10 @@ export class MenuItem extends ScopedElementsMixin(LitElement) {
   /** The variant of the menu item. */
   @property({ reflect: true }) variant?: MenuItemVariant;
 
+  get #disabled(): boolean {
+    return this.disabled || this.ariaDisabled === 'true';
+  }
+
   override connectedCallback(): void {
     super.connectedCallback();
 
@@ -104,6 +111,15 @@ export class MenuItem extends ScopedElementsMixin(LitElement) {
 
     if (changes.has('disabled')) {
       this.setAttribute('tabindex', this.disabled ? '-1' : '0');
+      if (this.disabled) {
+        if (this.ariaDisabled !== 'true') {
+          this.setAttribute('aria-disabled', 'true');
+          this.#ariaDisabledFromDisabled = true;
+        }
+      } else if (this.#ariaDisabledFromDisabled) {
+        this.removeAttribute('aria-disabled');
+        this.#ariaDisabledFromDisabled = false;
+      }
     }
 
     if (changes.has('shortcut')) {
@@ -162,7 +178,7 @@ export class MenuItem extends ScopedElementsMixin(LitElement) {
   }
 
   #onClick(event: Event): void {
-    if (this.disabled) {
+    if (this.#disabled) {
       event.preventDefault();
       event.stopPropagation();
 
@@ -191,7 +207,7 @@ export class MenuItem extends ScopedElementsMixin(LitElement) {
   }
 
   #onKeydown(event: KeyboardEvent): void {
-    if (this.disabled) {
+    if (this.#disabled) {
       return;
     }
 
@@ -213,6 +229,10 @@ export class MenuItem extends ScopedElementsMixin(LitElement) {
   }
 
   #onPointerenter(): void {
+    if (this.#disabled) {
+      return;
+    }
+
     this.#showSubMenu();
   }
 
@@ -227,7 +247,7 @@ export class MenuItem extends ScopedElementsMixin(LitElement) {
   }
 
   #onShortcut(event: KeyboardEvent): void {
-    if (this.disabled) {
+    if (this.#disabled) {
       return;
     }
 

--- a/packages/components/menu/src/menu.spec.ts
+++ b/packages/components/menu/src/menu.spec.ts
@@ -202,6 +202,24 @@ describe('sl-menu', () => {
 
       expect(document.activeElement).to.equal(thirdItem);
     });
+
+    it('should focus aria-disabled menu items', async () => {
+      el = await fixture(html`
+        <sl-menu>
+          <sl-menu-item aria-disabled="true">Item 1</sl-menu-item>
+          <sl-menu-item>Item 2</sl-menu-item>
+        </sl-menu>
+      `);
+
+      el.showPopover();
+      await el.updateComplete;
+
+      el.focus();
+
+      const firstItem = el.querySelector('sl-menu-item');
+
+      expect(document.activeElement).to.equal(firstItem);
+    });
   });
 
   describe('focusout handling', () => {

--- a/packages/components/shared/src/mixins/forward-aria-mixin.spec.ts
+++ b/packages/components/shared/src/mixins/forward-aria-mixin.spec.ts
@@ -28,6 +28,22 @@ try {
   // Element may already be defined in watch / repeated test runs
 }
 
+class NestedAriaDisabledElement extends ForwardAriaMixin(LitElement, ['aria-disabled']) {
+  override render() {
+    return html`<forward-aria-test>Click me</forward-aria-test>`;
+  }
+
+  override firstUpdated(): void {
+    this.setProxyTarget(this.renderRoot.querySelector('forward-aria-test')!);
+  }
+}
+
+try {
+  customElements.define('forward-aria-nested-disabled-test', NestedAriaDisabledElement);
+} catch {
+  // Element may already be defined in watch / repeated test runs
+}
+
 describe('ForwardAriaMixin', () => {
   let el: TestElement, button: HTMLButtonElement;
 
@@ -176,6 +192,22 @@ describe('ForwardAriaMixin', () => {
       expect(btn).to.have.attribute('aria-disabled', 'true');
 
       deferredEl.remove();
+    });
+
+    it('should clear aria-disabled from a nested proxy target', async () => {
+      const nestedEl = await fixture<NestedAriaDisabledElement>(
+          html`<forward-aria-nested-disabled-test></forward-aria-nested-disabled-test>`
+        ),
+        innerEl = nestedEl.renderRoot.querySelector<TestElement>('forward-aria-test')!,
+        innerButton = innerEl.renderRoot.querySelector('button')!;
+
+      nestedEl.ariaDisabled = 'true';
+
+      expect(innerButton).to.have.attribute('aria-disabled', 'true');
+
+      nestedEl.ariaDisabled = null;
+
+      expect(innerButton).not.to.have.attribute('aria-disabled');
     });
   });
 

--- a/packages/components/shared/src/mixins/forward-aria-mixin.ts
+++ b/packages/components/shared/src/mixins/forward-aria-mixin.ts
@@ -15,6 +15,10 @@ const ELEMENT_REFERENCES: Record<string, keyof ARIAMixin> = {
   'aria-owns': 'ariaOwnsElements'
 };
 
+function setAriaDisabled(target: HTMLElement, value: string | null): void {
+  target.ariaDisabled = value === 'true' ? 'true' : null;
+}
+
 /**
  * Mixin that forwards ARIA attributes from a custom element host to a target element inside its
  * shadow DOM. This is necessary because screen readers cannot pierce the shadow boundary, so ARIA
@@ -104,11 +108,7 @@ export function ForwardAriaMixin<
       // Forward ariaDisabled if it was set via property before the target was available
       if (ariaDisabledStorage.has(this)) {
         const value = ariaDisabledStorage.get(this) ?? null;
-        if (value === 'true') {
-          target.setAttribute('aria-disabled', 'true');
-        } else {
-          target.removeAttribute('aria-disabled');
-        }
+        setAriaDisabled(target, value);
       }
 
       // Forward any attributes that were set before the target was available
@@ -221,11 +221,7 @@ export function ForwardAriaMixin<
 
       const target = targetElements.get(this);
       if (target) {
-        if (value === 'true') {
-          target.setAttribute('aria-disabled', 'true');
-        } else {
-          target.removeAttribute('aria-disabled');
-        }
+        setAriaDisabled(target, value);
       }
     }
   });

--- a/packages/components/tool-bar/src/tool-bar.spec.ts
+++ b/packages/components/tool-bar/src/tool-bar.spec.ts
@@ -4,6 +4,7 @@ import { Button } from '@sl-design-system/button';
 import '@sl-design-system/button/register.js';
 import { Icon } from '@sl-design-system/icon';
 import '@sl-design-system/icon/register.js';
+import { type MenuButton } from '@sl-design-system/menu';
 import '@sl-design-system/menu/register.js';
 import { closestElementComposed } from '@sl-design-system/shared';
 import { fixture } from '@sl-design-system/vitest-browser-lit';
@@ -317,6 +318,53 @@ describe('sl-tool-bar', () => {
       await el.updateComplete;
 
       expect(document.activeElement).to.exist;
+    });
+
+    it('should keep aria-disabled overflow menu items reachable', async () => {
+      const toolbar = await fixture<ToolBar>(html`
+        <sl-tool-bar style="inline-size: 48px">
+          <sl-button>Cut</sl-button>
+          <sl-button aria-disabled="true">Copy</sl-button>
+          <sl-button>Paste</sl-button>
+        </sl-tool-bar>
+      `);
+      await new Promise(resolve => setTimeout(resolve, 150));
+      await toolbar.updateComplete;
+
+      const menuButton = toolbar.shadowRoot?.querySelector<MenuButton>('sl-menu-button'),
+        items = Array.from(toolbar.shadowRoot?.querySelectorAll('sl-menu-item') ?? []),
+        copy = items.find(item => item.textContent?.trim() === 'Copy');
+
+      expect(copy).to.exist;
+      expect(copy).to.have.attribute('aria-disabled', 'true');
+      expect(copy).not.to.have.attribute('disabled');
+
+      menuButton?.menu.showPopover();
+      items[0].focus();
+      await toolbar.updateComplete;
+
+      await userEvent.keyboard('{ArrowDown}');
+      await toolbar.updateComplete;
+
+      expect(toolbar.shadowRoot?.activeElement).to.equal(copy);
+    });
+
+    it('should not activate aria-disabled overflow menu items', async () => {
+      let clicked = false;
+
+      const toolbar = await fixture<ToolBar>(html`
+        <sl-tool-bar style="inline-size: 48px">
+          <sl-button @click=${() => (clicked = true)} aria-disabled="true">Copy</sl-button>
+        </sl-tool-bar>
+      `);
+      await new Promise(resolve => setTimeout(resolve, 150));
+      await toolbar.updateComplete;
+
+      const copy = toolbar.shadowRoot?.querySelector('sl-menu-item');
+
+      copy?.click();
+
+      expect(clicked).to.be.false;
     });
 
     it('should wrap focus from last to first item', async () => {

--- a/packages/components/tool-bar/src/tool-bar.spec.ts
+++ b/packages/components/tool-bar/src/tool-bar.spec.ts
@@ -120,6 +120,29 @@ describe('sl-tool-bar', () => {
       expect(children.item(3)).to.have.attribute('data-toolbar-disabled');
     });
 
+    it('should clear aria-disabled from the overflow menu button when re-enabled', async () => {
+      const toolbar = await fixture<ToolBar>(html`
+        <sl-tool-bar disabled style="inline-size: 48px">
+          <sl-button>Button 1</sl-button>
+          <sl-button>Button 2</sl-button>
+        </sl-tool-bar>
+      `);
+      await new Promise(resolve => setTimeout(resolve, 150));
+      await toolbar.updateComplete;
+
+      const menuButton = toolbar.shadowRoot?.querySelector<MenuButton>('sl-menu-button'),
+        internalButton = menuButton?.renderRoot.querySelector('sl-button'),
+        nativeButton = internalButton?.renderRoot.querySelector('button');
+
+      expect(nativeButton).to.have.attribute('aria-disabled', 'true');
+
+      toolbar.disabled = false;
+      await toolbar.updateComplete;
+      await internalButton?.updateComplete;
+
+      expect(nativeButton).not.to.have.attribute('aria-disabled');
+    });
+
     it('should have made all slotted elements visible', () => {
       // When all items fit, visibility is set to 'visible' by the resize observer
       // Check that no items are hidden

--- a/packages/components/tool-bar/src/tool-bar.ts
+++ b/packages/components/tool-bar/src/tool-bar.ts
@@ -270,8 +270,7 @@ export class ToolBar extends ScopedElementsMixin(LitElement) {
         aria-label=${msg('Show more', { id: 'sl.toolBar.showMore' })}
         fill=${ifDefined(this.fill)}
         ?hidden=${this.menuItems.length === 0}
-        variant=${ifDefined(this.inverted ? 'inverted' : undefined)}
-      >
+        variant=${ifDefined(this.inverted ? 'inverted' : undefined)}>
         <sl-icon name="ellipsis-vertical" slot="button"></sl-icon>
         ${this.menuItems.map(item => this.renderMenuItem(item))}
       </sl-menu-button>
@@ -294,9 +293,8 @@ export class ToolBar extends ScopedElementsMixin(LitElement) {
       return html`
         <sl-menu-item
           @click=${isDisabled ? undefined : () => item.click?.()}
-          ?disabled=${isDisabled}
-          ?selectable=${item.selectable}
-        >
+          aria-disabled=${ifDefined(isDisabled ? 'true' : undefined)}
+          ?selectable=${item.selectable}>
           ${item.icon ? html`<sl-icon .name=${item.icon}></sl-icon>` : nothing} ${item.label}
         </sl-menu-item>
       `;
@@ -304,7 +302,7 @@ export class ToolBar extends ScopedElementsMixin(LitElement) {
       const isDisabled = item.disabled || item.ariaDisabled;
 
       return html`
-        <sl-menu-item ?disabled=${isDisabled}>
+        <sl-menu-item aria-disabled=${ifDefined(isDisabled ? 'true' : undefined)}>
           ${item.icon ? html`<sl-icon .name=${item.icon}></sl-icon>` : nothing} ${item.label}
           <sl-menu slot="submenu"
             >${item.menuItems.map(menuItem => this.renderMenuItem(menuItem))}</sl-menu

--- a/packages/components/tool-bar/src/tool-bar.ts
+++ b/packages/components/tool-bar/src/tool-bar.ts
@@ -266,7 +266,7 @@ export class ToolBar extends ScopedElementsMixin(LitElement) {
       </div>
 
       <sl-menu-button
-        aria-disabled=${ifDefined(this.disabled ? 'true' : undefined)}
+        .ariaDisabled=${this.disabled ? 'true' : null}
         aria-label=${msg('Show more', { id: 'sl.toolBar.showMore' })}
         fill=${ifDefined(this.fill)}
         ?hidden=${this.menuItems.length === 0}


### PR DESCRIPTION
### Summary
This PR fixes disabled menu item accessibility and toolbar overflow behavior

### Changes:

- Disabled sl-menu-item now exposes aria-disabled="true" so assistive technologies can announce it as unavailable.
- Toolbar overflow items now use aria-disabled instead of hard disabled, keeping unavailable items reachable in menu keyboard navigation while still preventing activation.
- Disabled styling now also applies to sl-menu-item[aria-disabled="true"].
- ForwardAriaMixin now clears forwarded ariaDisabled correctly through nested proxy targets, preventing stale aria-disabled on internal buttons.
Added regression coverage for menu focus behavior, toolbar overflow disabled items, and nested ARIA forwarding cleanup


### BEFORE

https://github.com/user-attachments/assets/a817dc40-42ff-4eae-b940-a09bc8f2ca84

### AFTER

https://github.com/user-attachments/assets/c5bd2ec6-44ba-4e5f-be52-20b193a6f8e2


