### PR TITLE
fix(combobox): Fix Space key selection for select-only comboboxes

### DIFF
--- a/.changeset/quiet-spaces-select.md
+++ b/.changeset/quiet-spaces-select.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/combobox': patch
+---
+
+Fixed select-only comboboxes so keyboard users can select and deselect the current option with Space while editable comboboxes still insert spaces in the input field

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -622,6 +622,53 @@ describe('sl-combobox', () => {
         expect(onChange).to.have.been.calledOnce;
         expect(onChange.lastCall.args[0]).to.equal('Lorem');
       });
+
+      it('should insert spaces in the input', async () => {
+        input.focus();
+        await userEvent.keyboard('Foo{Space}Bar');
+        await el.updateComplete;
+
+        expect(input.value).to.equal('Foo Bar');
+      });
+    });
+
+    describe('select only', () => {
+      beforeEach(async () => {
+        el = await fixture(html`
+          <sl-combobox select-only>
+            <sl-listbox>
+              <sl-option>Lorem</sl-option>
+              <sl-option>Ipsum</sl-option>
+              <sl-option>Ipsom</sl-option>
+            </sl-listbox>
+          </sl-combobox>
+        `);
+        input = el.querySelector<HTMLInputElement>('input[slot="input"]')!;
+      });
+
+      it('should select the current option when pressing Space', async () => {
+        input.focus();
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.keyboard('{Space}');
+        await el.updateComplete;
+
+        expect(el.value).to.equal('Lorem');
+        expect(input.value).to.equal('Lorem');
+      });
+
+      it('should deselect the current option when pressing Space', async () => {
+        el.value = 'Lorem';
+        await el.updateComplete;
+
+        input.focus();
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.keyboard('{Space}');
+        await el.updateComplete;
+
+        expect(el.value).to.be.undefined;
+        expect(input.value).to.equal('');
+      });
     });
 
     describe('options with values', () => {
@@ -919,6 +966,24 @@ describe('sl-combobox', () => {
 
         expect(onChange).to.have.been.calledOnce;
         expect(onChange.lastCall.args[0]).to.deep.equal(['Lorem']);
+      });
+
+      it('should select and deselect the current option with Space when select-only', async () => {
+        el.selectOnly = true;
+        await el.updateComplete;
+
+        input.focus();
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.keyboard('{Space}');
+        await el.updateComplete;
+
+        expect(el.value).to.deep.equal(['Lorem']);
+
+        await userEvent.keyboard('{Space}');
+        await el.updateComplete;
+
+        expect(el.value).to.deep.equal([]);
       });
 
       it('should not have has-selected-items attribute when interacting with a combobox with no selected items', async () => {

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -683,7 +683,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   }
 
   #onKeydown(event: KeyboardEvent): void {
-    const isSelectOnlySpace = !!this.selectOnly && (event.key === ' ' || event.key === 'Spacebar');
+    const isSelectOnlySpace = !!this.selectOnly && event.key === ' ';
 
     if ((event.key === 'Enter' || isSelectOnlySpace) && !this.focusedTag) {
       if (isSelectOnlySpace) {

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -683,7 +683,13 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   }
 
   #onKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Enter' && !this.focusedTag) {
+    const isSelectOnlySpace = this.selectOnly && (event.key === ' ' || event.key === 'Spacebar');
+
+    if ((event.key === 'Enter' || isSelectOnlySpace) && !this.focusedTag) {
+      if (isSelectOnlySpace) {
+        event.preventDefault();
+      }
+
       if (this.allowCustomValues && this.currentItem === this.createCustomOption) {
         this.#addCustomOption(this.input.value);
       } else if (this.currentItem?.custom && this.currentItem?.option) {

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -683,7 +683,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   }
 
   #onKeydown(event: KeyboardEvent): void {
-    const isSelectOnlySpace = this.selectOnly && (event.key === ' ' || event.key === 'Spacebar');
+    const isSelectOnlySpace = !!this.selectOnly && (event.key === ' ' || event.key === 'Spacebar');
 
     if ((event.key === 'Enter' || isSelectOnlySpace) && !this.focusedTag) {
       if (isSelectOnlySpace) {


### PR DESCRIPTION
## Summary

- Allow select-only comboboxes to select and deselect the current option with the Space key
- Keep existing editable combobox behavior unchanged, so Space still inserts a space in the input field
- Add regression tests for single-select, multi-select, and editable combobox behavior


### BEFORE

https://github.com/user-attachments/assets/2eba7e99-46ba-43e2-9a96-cd734c81025a

### AFTER

https://github.com/user-attachments/assets/f1f71d90-c3ef-4f9b-bad2-f7520ad5cfb1


