### PR TITLE
fix(tag-list): Fix listitem role on stacked tag list counter

### DIFF
--- a/.changeset/great-owls-mix.md
+++ b/.changeset/great-owls-mix.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/tag': patch
+---
+
+Fixed stacked tag lists so the generated stack counter tag has `role="listitem"`, matching the slotted tags and satisfying ARIA list semantics

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -144,6 +144,12 @@ describe('sl-tag-list', () => {
       expect(tag).to.have.trimmed.text('+7');
     });
 
+    it('should give the stack tag a listitem role', () => {
+      const tag = el.renderRoot.querySelector('sl-tag');
+
+      expect(tag).to.have.attribute('role', 'listitem');
+    });
+
     it('should have hidden tags with tabindex -1', async () => {
       // Give some time to updateVisibility
       await new Promise(resolve => setTimeout(resolve, 60));

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -248,6 +248,7 @@ export class TagList extends ScopedElementsMixin(LitElement) {
               <sl-tag
                 aria-labelledby="tooltip"
                 ?disabled=${this.disabled}
+                role="listitem"
                 size=${ifDefined(this.size)}
                 variant=${ifDefined(this.variant)}>
                 +${this.stackSize}


### PR DESCRIPTION
## Summary

- Adds `role="listitem"` to the generated stack counter tag in `sl-tag-list`
- Adds a regression test for the stacked tag list counter role


### BEFORE
<img width="1213" height="735" alt="Screenshot 2026-06-02 at 12 23 58" src="https://github.com/user-attachments/assets/e619f5a1-36af-4e86-83b1-53e979e665c5" />


### AFTER
<img width="1220" height="877" alt="Screenshot 2026-06-02 at 12 23 22" src="https://github.com/user-attachments/assets/f0cfe219-a394-4602-acba-02895106a05a" />
