### PR TITLE
feat(listbox): Add scroll button to center option in listbox

### DIFF
--- a/packages/components/listbox/src/listbox.stories.ts
+++ b/packages/components/listbox/src/listbox.stories.ts
@@ -50,6 +50,9 @@ export default {
         sl-listbox {
           border: var(--sl-color-border-plain) solid var(--sl-size-borderWidth-subtle);
           border-radius: var(--sl-size-borderRadius-default);
+          max-block-size: calc(100dvh - 4rem);
+        }
+        sl-button + sl-listbox {
           margin-block-start: 1rem;
           max-block-size: calc(100dvh - 7rem);
         }

--- a/packages/components/listbox/src/listbox.stories.ts
+++ b/packages/components/listbox/src/listbox.stories.ts
@@ -1,6 +1,7 @@
 import '@sl-design-system/badge/register.js';
+import '@sl-design-system/button/register.js';
 import { type Meta, type StoryObj } from '@storybook/web-components-vite';
-import { type TemplateResult, html } from 'lit';
+import { type TemplateResult, html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import '../register.js';
 import { type Listbox } from './listbox.js';
@@ -41,14 +42,25 @@ export default {
     optionValuePath,
     slot
   }) => {
+    const scrollTo = (index: number): void => {
+      document.querySelector('sl-listbox')?.scrollToIndex(index);
+    };
     return html`
       <style>
         sl-listbox {
           border: var(--sl-color-border-plain) solid var(--sl-size-borderWidth-subtle);
           border-radius: var(--sl-size-borderRadius-default);
-          max-block-size: calc(100dvh - 3rem);
+          margin-block-start: 1rem;
+          max-block-size: calc(100dvh - 7rem);
         }
       </style>
+      ${options
+        ? html`
+            <sl-button @click=${() => scrollTo(Math.floor(options.length / 2) - 1)}
+              >Scroll to ${Math.floor(options.length / 2)}</sl-button
+            >
+          `
+        : nothing}
       <sl-listbox
         .options=${options}
         .optionGroupPath=${optionGroupPath}


### PR DESCRIPTION
This pull request updates the Listbox story in Storybook to improve usability and demonstrate new functionality. The main change is the addition of a button that allows users to scroll the listbox to the middle item, making it easier to test and showcase the `scrollToIndex` method.

**Storybook improvements:**

* Added an `sl-button` to the Listbox story that, when clicked, scrolls the listbox to the middle option using the new `scrollTo` helper function.
* Updated the listbox's styling by increasing the top margin and adjusting the maximum block size for better layout in Storybook.

**Code and dependency updates:**

* Imported the `@sl-design-system/button/register.js` module to enable use of the `sl-button` component in stories.
* Imported `nothing` from `lit` to conditionally render the scroll button only when options are present.