### PR TITLE
fix(menu-item): register click events on submenu

### DIFF
--- a/.changeset/flat-chefs-swim.md
+++ b/.changeset/flat-chefs-swim.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/menu': patch
+---
+
+Fix nested submenu item clicks being intercepted by parent menu items with submenus

--- a/packages/components/menu/src/menu-item.ts
+++ b/packages/components/menu/src/menu-item.ts
@@ -178,6 +178,10 @@ export class MenuItem extends ScopedElementsMixin(LitElement) {
   }
 
   #onClick(event: Event): void {
+    if (this.submenu && event.composedPath().includes(this.submenu)) {
+      return;
+    }
+
     if (this.#disabled) {
       event.preventDefault();
       event.stopPropagation();

--- a/packages/components/menu/src/menu.spec.ts
+++ b/packages/components/menu/src/menu.spec.ts
@@ -666,6 +666,23 @@ describe('sl-menu', () => {
 
         document.body.removeChild(outsideButton);
       });
+
+      it('should allow clicks from nested submenu items to bubble', async () => {
+        const onClickItem = spy(),
+          onClickMenu = spy(),
+          nestedItem = nestedSubmenu.querySelector('sl-menu-item')!;
+
+        nestedSubmenu.showPopover();
+        await nestedSubmenu.updateComplete;
+
+        nestedItem.addEventListener('click', onClickItem);
+        el.addEventListener('click', onClickMenu);
+
+        await userEvent.click(nestedItem);
+
+        expect(onClickItem).to.have.been.calledOnce;
+        expect(onClickMenu).to.have.been.calledOnce;
+      });
     });
   });
 

--- a/packages/components/menu/src/menu.stories.ts
+++ b/packages/components/menu/src/menu.stories.ts
@@ -268,7 +268,10 @@ const showNestedSubmenuMessage = (event: Event): void => {
     return;
   }
 
-  const message = menuItem.textContent?.trim() ?? '';
+  const clone = menuItem.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll<HTMLElement>('[slot="submenu"]').forEach(el => el.remove());
+
+  const message = clone.textContent?.trim() ?? '';
 
   if (output) {
     output.textContent = `${message} clicked`;

--- a/packages/components/menu/src/menu.stories.ts
+++ b/packages/components/menu/src/menu.stories.ts
@@ -254,6 +254,84 @@ export const Submenu: Story = {
   }
 };
 
+const showNestedSubmenuMessage = (event: Event): void => {
+  const story = (event.currentTarget as HTMLElement).closest('[data-nested-submenu-story]'),
+    output = story?.querySelector<HTMLElement>('[data-nested-submenu-message]'),
+    menuItem = event.composedPath().find((element): element is HTMLElement => {
+      return element instanceof HTMLElement && element.localName === 'sl-menu-item';
+    }),
+    menus = event.composedPath().filter((element): element is HTMLElement => {
+      return element instanceof HTMLElement && element.localName === 'sl-menu';
+    });
+
+  if (!menuItem) {
+    return;
+  }
+
+  const message = menuItem.textContent?.trim() ?? '';
+
+  if (output) {
+    output.textContent = `${message} clicked`;
+  }
+
+  setTimeout(() => menus.forEach(menu => menu.showPopover()));
+  window.alert(`${message} clicked`);
+};
+
+export const NestedSubmenu: Story = {
+  args: {
+    menuItems: () => html`
+      <sl-menu-item>
+        <sl-icon name="far-arrow-up-short-wide"></sl-icon>
+        Sort by
+        <sl-menu slot="submenu">
+          <sl-menu-item>
+            Categories
+            <sl-menu slot="submenu">
+              <sl-menu-item>Category A</sl-menu-item>
+              <sl-menu-item>Category B</sl-menu-item>
+              <sl-menu-item>Category C</sl-menu-item>
+            </sl-menu>
+          </sl-menu-item>
+          <sl-menu-item>First name (A-Z)</sl-menu-item>
+          <sl-menu-item>Last name (A-Z)</sl-menu-item>
+        </sl-menu>
+      </sl-menu-item>
+    `
+  },
+  render: ({ maxWidth, menuItems, emphasis }) => {
+    setTimeout(() =>
+      document.querySelector<HTMLElement>('[data-nested-submenu-story] sl-menu')?.showPopover()
+    );
+
+    return html`
+      <style>
+        [data-nested-submenu-story] {
+          display: grid;
+          gap: 1rem;
+          justify-items: center;
+        }
+
+        [data-nested-submenu-story] .root-menu {
+          margin: auto !important;
+          position: static !important;
+        }
+      </style>
+      <div data-nested-submenu-story>
+        <sl-menu
+          @click=${showNestedSubmenuMessage}
+          .emphasis=${emphasis}
+          class="root-menu"
+          popover="manual"
+          style="max-width: ${maxWidth}">
+          ${menuItems()}
+        </sl-menu>
+        <p aria-live="polite" data-nested-submenu-message>No item clicked yet</p>
+      </div>
+    `;
+  }
+};
+
 export const Combination: Story = {
   args: {
     menuItems: () => {


### PR DESCRIPTION
## Summary

- Fixes nested submenu item clicks being intercepted by parent `sl-menu-item` elements that also have submenus.
- Adds a regression test to ensure clicks from deeply nested submenu items can bubble correctly
- Adds a `Nested Submenu` story for manual verification with visible click feedback

### BEFORE
https://github.com/user-attachments/assets/9fc8247d-a8a3-4f30-9217-78a6d429f904

### AFTER 

https://github.com/user-attachments/assets/e95e8a83-66df-4da1-92bf-fba35a67f941