### PR TITLE
fix(combobox): Fix combobox selection with numeric option values

### DIFF
--- a/.changeset/icy-worlds-do.md
+++ b/.changeset/icy-worlds-do.md
@@ -1,0 +1,7 @@
+---
+'@sl-design-system/combobox': patch
+---
+
+Fix combobox selection matching when option values and the combobox value use different primitive types.
+
+The combobox now treats primitive values such as `1` and `"1"` as equivalent when resolving selected options. This prevents the selected option from being cleared when a value is provided as a string while the matching `sl-option` value is a number

--- a/.changeset/icy-worlds-do.md
+++ b/.changeset/icy-worlds-do.md
@@ -4,4 +4,4 @@
 
 Fix combobox selection matching when option values and the combobox value use different primitive types.
 
-The combobox now treats primitive values such as `1` and `"1"` as equivalent when resolving selected options. This prevents the selected option from being cleared when a value is provided as a string while the matching `sl-option` value is a number
+The combobox now treats primitive values such as `1` and "1" as equivalent when resolving selected options. This prevents the selected option from being cleared when a value is provided as a string while the matching `sl-option` value is a number.

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -722,6 +722,23 @@ describe('sl-combobox', () => {
         expect(input.value).to.equal('Lorem');
         expect(onChange).not.to.have.been.called;
       });
+
+      it('should prefer a strict value match over a string-coerced match', async () => {
+        el = await fixture(html`
+          <sl-combobox>
+            <sl-listbox>
+              <sl-option .value=${1}>Number</sl-option>
+              <sl-option .value=${'1'}>String</sl-option>
+            </sl-listbox>
+          </sl-combobox>
+        `);
+        input = el.querySelector<HTMLInputElement>('input[slot="input"]')!;
+
+        el.value = '1';
+        await el.updateComplete;
+
+        expect(input.value).to.equal('String');
+      });
     });
 
     describe('allow custom values', () => {
@@ -992,6 +1009,22 @@ describe('sl-combobox', () => {
 
         expect(onChange).to.have.been.calledOnce;
         expect(onChange.lastCall.args[0]).to.deep.equal(['Lorem']);
+      });
+
+      it('should select only the strict value match when coercible option values also match', async () => {
+        el = await fixture(html`
+          <sl-combobox multiple>
+            <sl-listbox>
+              <sl-option .value=${1}>Number</sl-option>
+              <sl-option .value=${'1'}>String</sl-option>
+            </sl-listbox>
+          </sl-combobox>
+        `);
+
+        el.value = ['1'];
+        await el.updateComplete;
+
+        expect(el.selectedItems.map(item => item.label)).to.deep.equal(['String']);
       });
 
       it('should select and deselect the current option with Space when select-only', async () => {

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -696,6 +696,32 @@ describe('sl-combobox', () => {
         expect(el.value).to.equal('1');
         expect(input.value).to.equal('Lorem');
       });
+
+      it('should select an option when the value matches after string coercion', async () => {
+        const onChange = spy();
+
+        el = await fixture(html`
+          <sl-combobox @sl-change=${onChange}>
+            <sl-listbox>
+              <sl-option .value=${1}>Lorem</sl-option>
+              <sl-option .value=${2}>Ipsum</sl-option>
+            </sl-listbox>
+          </sl-combobox>
+          <input />
+        `);
+        input = el.querySelector<HTMLInputElement>('input[slot="input"]')!;
+
+        el.value = '1';
+        await el.updateComplete;
+
+        input.focus();
+        await userEvent.keyboard('{Tab}');
+        await el.updateComplete;
+
+        expect(el.value).to.equal('1');
+        expect(input.value).to.equal('Lorem');
+        expect(onChange).not.to.have.been.called;
+      });
     });
 
     describe('allow custom values', () => {
@@ -1467,6 +1493,15 @@ describe('sl-combobox', () => {
           selectedGroup.querySelectorAll('sl-combobox-grouped-option')
         ).map(o => o.innerText);
         expect(options).to.deep.equal(['Option 1', 'Option 2']);
+      });
+
+      it('should expose the selected state for grouped options', () => {
+        const options = Array.from(selectedGroup.querySelectorAll('sl-combobox-grouped-option'));
+
+        expect(options.map(option => option.getAttribute('aria-selected'))).to.deep.equal([
+          'true',
+          'true'
+        ]);
       });
 
       it('should have group headers for both the selected and unselected options', () => {

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -1254,7 +1254,15 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   }
 
   #isStringCoercibleValue(value: unknown): value is string | number | boolean | bigint {
-    return ['bigint', 'boolean', 'number', 'string'].includes(typeof value);
+    switch (typeof value) {
+      case 'bigint':
+      case 'boolean':
+      case 'number':
+      case 'string':
+        return true;
+      default:
+        return false;
+    }
   }
 
   #prepareOptions(options: T[]): Array<ComboboxItem<T, U>> {

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -663,7 +663,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         this.input.setSelectionRange(value.length, item.label.length);
       }
     } else {
-      item = this.items.find(option => this.#isEqualValue(option.value, value as U));
+      item = this.#findItemByValue(value as U);
     }
 
     if (this.allowCustomValues && !item) {
@@ -1069,6 +1069,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       el.id = groupedItem.id;
       el.innerText = groupedItem.label;
       el.selected = true;
+      el.setAttribute('aria-selected', 'true');
 
       if (!el.parentElement) {
         this.#selectedGroup?.append(el);
@@ -1263,6 +1264,16 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       default:
         return false;
     }
+  }
+
+  #findItemByValue(
+    value: U | undefined,
+    predicate: (item: ComboboxItem<T, U>) => boolean = () => true
+  ): ComboboxItem<T, U> | undefined {
+    return (
+      this.items.find(item => predicate(item) && item.value === value) ??
+      this.items.find(item => predicate(item) && this.#isEqualValue(item.value, value))
+    );
   }
 
   #prepareOptions(options: T[]): Array<ComboboxItem<T, U>> {
@@ -1484,17 +1495,28 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     this.selectedItems.forEach(item => this.#removeSelectedOption(item));
     this.selectedItems = [];
 
-    this.items.forEach(item => {
-      if (
-        this.multiple &&
-        Array.isArray(this.value) &&
-        this.value.some(value => this.#isEqualValue(value, item.value))
-      ) {
-        this.#addSelectedOption(item);
-      } else if (this.#isEqualValue(item.value, this.value as U | undefined)) {
+    if (this.multiple) {
+      if (!Array.isArray(this.value)) {
+        return;
+      }
+
+      const selectedItems = new Set<ComboboxItem<T, U>>();
+      this.value.forEach(value => {
+        const item = this.#findItemByValue(value, item => !selectedItems.has(item));
+
+        if (item) {
+          selectedItems.add(item);
+        }
+      });
+
+      selectedItems.forEach(item => this.#addSelectedOption(item));
+    } else {
+      const item = this.#findItemByValue(this.value as U | undefined);
+
+      if (item) {
         this.#addSelectedOption(item);
       }
-    });
+    }
   }
 
   /** Update the value in the text field. */

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -1271,8 +1271,10 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     predicate: (item: ComboboxItem<T, U>) => boolean = () => true
   ): ComboboxItem<T, U> | undefined {
     return (
-      this.items.find(item => predicate(item) && item.value === value) ??
-      this.items.find(item => predicate(item) && this.#isEqualValue(item.value, value))
+      this.items.find(item => item.type === 'option' && predicate(item) && item.value === value) ??
+      this.items.find(
+        item => item.type === 'option' && predicate(item) && this.#isEqualValue(item.value, value)
+      )
     );
   }
 

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -663,7 +663,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         this.input.setSelectionRange(value.length, item.label.length);
       }
     } else {
-      item = this.items.find(option => option.value === value);
+      item = this.items.find(option => this.#isEqualValue(option.value, value as U));
     }
 
     if (this.allowCustomValues && !item) {
@@ -1241,6 +1241,22 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     return [];
   }
 
+  #isEqualValue(a: U | undefined, b: U | undefined): boolean {
+    if (a === b) {
+      return true;
+    }
+
+    if (this.#isStringCoercibleValue(a) && this.#isStringCoercibleValue(b)) {
+      return a.toString() === b.toString();
+    }
+
+    return false;
+  }
+
+  #isStringCoercibleValue(value: unknown): value is string | number | boolean | bigint {
+    return ['bigint', 'boolean', 'number', 'string'].includes(typeof value);
+  }
+
   #prepareOptions(options: T[]): Array<ComboboxItem<T, U>> {
     if (this.optionGroupPath) {
       const groups = Object.groupBy(options, option =>
@@ -1461,9 +1477,13 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     this.selectedItems = [];
 
     this.items.forEach(item => {
-      if (this.multiple && (this.value as U[])?.includes(item.value!)) {
+      if (
+        this.multiple &&
+        Array.isArray(this.value) &&
+        this.value.some(value => this.#isEqualValue(value, item.value))
+      ) {
         this.#addSelectedOption(item);
-      } else if (item.value === this.value) {
+      } else if (this.#isEqualValue(item.value, this.value as U | undefined)) {
         this.#addSelectedOption(item);
       }
     });
@@ -1493,8 +1513,8 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     const isValueEqual = this.multiple
       ? Array.isArray(this.value) &&
         this.value.length === values.length &&
-        values.every(v => (this.value as U[]).includes(v))
-      : this.value === values[0];
+        values.every(v => (this.value as U[]).some(value => this.#isEqualValue(value, v)))
+      : this.#isEqualValue(this.value as U | undefined, values[0]);
 
     // Do nothing if the value hasn't changed
     if (isValueEqual) {

--- a/packages/components/combobox/src/single.stories.ts
+++ b/packages/components/combobox/src/single.stories.ts
@@ -208,6 +208,18 @@ export const Value: Story = {
   }
 };
 
+export const NumericOptionValues: Story = {
+  args: {
+    label: 'Chapter',
+    options: () => html`
+      <sl-option .value=${1}>Chapter 1</sl-option>
+      <sl-option .value=${2}>Chapter 2</sl-option>
+      <sl-option .value=${3}>Chapter 3</sl-option>
+    `,
+    value: '1'
+  }
+};
+
 export const VirtualList: Story = {
   args: {
     optionLabelPath: 'label',


### PR DESCRIPTION
## Summary

Fixes an issue where `sl-combobox` failed to resolve the selected option when the combobox value and option value represented the same primitive value but had different types, for example `"1"` and `1`.

Previously, selection matching used strict equality, so a string value passed to the combobox did not match a numeric `sl-option.value`. As a result, the combobox could appear empty and reset its input when focus left the component

## Changes

- Compare primitive combobox values using string coercion when resolving selected options.
- Preserve strict matching for objects to avoid accidental matches such as `[object Object]`.
- Add a regression test for string combobox value matching numeric option values.
- Add a Storybook example showing numeric option values.


### BEFORE

https://github.com/user-attachments/assets/0467045f-e26c-4076-b448-0b2cd49c7ae6

### AFTER

https://github.com/user-attachments/assets/69df8fcd-4b53-47c3-a4bd-1e1a73ce6fcb

