### PR TITLE
fix(toggle-button): Add accessible names to toggle buttons in documentation

### DIFF
--- a/website/src/categories/components/toggle-button/code.md
+++ b/website/src/categories/components/toggle-button/code.md
@@ -10,11 +10,11 @@ eleventyNavigation:
 <section class="no-heading">
 <div class="ds-example">
   <div class="ds-example__code-wrapper">
-    <sl-toggle-button>
+    <sl-toggle-button aria-label="Show settings">
       <sl-icon name="far-gear" slot="default"></sl-icon>
       <sl-icon name="fas-gear" slot="pressed"></sl-icon>
     </sl-toggle-button>
-    <sl-toggle-button fill="outline" pressed>
+    <sl-toggle-button fill="outline" aria-label="Show settings" pressed>
       <sl-icon name="far-gear" slot="default"></sl-icon>
       <sl-icon name="fas-gear" slot="pressed"></sl-icon>
     </sl-toggle-button>
@@ -24,12 +24,12 @@ eleventyNavigation:
 <div class="ds-code">
 
   ```html
-  <sl-toggle-button>
+  <sl-toggle-button aria-label="Show settings">
     <sl-icon name="far-gear" slot="default"></sl-icon>
     <sl-icon name="fas-gear" slot="pressed"></sl-icon>
   </sl-toggle-button>
 
-  <sl-toggle-button fill="outline" pressed>
+  <sl-toggle-button fill="outline" aria-label="Show settings" pressed>
     <sl-icon name="far-gear" slot="default"></sl-icon>
     <sl-icon name="fas-gear" slot="pressed"></sl-icon>
   </sl-toggle-button>

--- a/website/src/categories/components/toggle-button/usage.md
+++ b/website/src/categories/components/toggle-button/usage.md
@@ -9,7 +9,7 @@ eleventyNavigation:
 <section>
 
 <div class="ds-example">
-  <sl-toggle-button fill="outline">
+  <sl-toggle-button fill="outline" aria-label="Show settings">
     <sl-icon name="far-gear" slot="default"></sl-icon>
     <sl-icon name="fas-gear" slot="pressed"></sl-icon>
   </sl-toggle-button>
@@ -18,7 +18,7 @@ eleventyNavigation:
 <div class="ds-code">
 
   ```html
-    <sl-toggle-button fill="outline">
+    <sl-toggle-button fill="outline" aria-label="Show settings">
       <sl-icon name="far-gear" slot="default"></sl-icon>
       <sl-icon name="fas-gear" slot="pressed"></sl-icon>
     </sl-toggle-button>


### PR DESCRIPTION
This pull request updates the accessibility of the `sl-toggle-button` component examples and code snippets in the documentation by adding the `aria-label` attribute. This ensures that assistive technologies can properly describe the button's purpose to users.

**Accessibility improvements:**

* Added `aria-label="Show settings"` to all `sl-toggle-button` examples and code snippets in `code.md` and `usage.md` to improve screen reader support. [[1]](diffhunk://#diff-053b3d7a9042333914add888443a7f39b0b290934e609492b0afb9ce599b219fL13-R17) [[2]](diffhunk://#diff-053b3d7a9042333914add888443a7f39b0b290934e609492b0afb9ce599b219fL27-R32) [[3]](diffhunk://#diff-b0cdfc77f182e0948177765429b2446d049623084c284c7ff121d5bbdf0df6cdL12-R12) [[4]](diffhunk://#diff-b0cdfc77f182e0948177765429b2446d049623084c284c7ff121d5bbdf0df6cdL21-R21)