### PR TITLE
fix(tool-bar): Add extra padding to prevent focus outline clipping inverted bg

### DIFF
--- a/packages/components/tool-bar/src/tool-bar.stories.ts
+++ b/packages/components/tool-bar/src/tool-bar.stories.ts
@@ -780,22 +780,25 @@ export const Examples: Story = {
             ${filteringAndSorting}
           </sl-tool-bar>
 
-          <sl-tool-bar
-            aria-label="Filtering and sorting"
-            inverted
-            fill="ghost"
-            style="inline-size: fit-content; padding: var(--sl-size-100)">
-            ${filteringAndSorting}
-          </sl-tool-bar>
+          <div
+            style="background: var(--sl-elevation-surface-raised-primary);  padding: var(--sl-size-100); inline-size: fit-content;">
+            <sl-tool-bar
+              aria-label="Filtering and sorting"
+              inverted
+              fill="ghost"
+              style="inline-size: fit-content;">
+              ${filteringAndSorting}
+            </sl-tool-bar>
+          </div>
         </div>
         <p>
-          This last example has been given extra padding for demonstration purposes. This prevents
-          the white focus outline from being invisible on the white background.
+          This last example has put in a div with extra padding for demonstration purposes. This
+          prevents the white focus outline that overflows the toolbar from being invisible on the
+          white background.
         </p>
         <p>
-          If you use the toolbar as part of a larger UI with a non-white background, you typically
-          won't need this extra padding, as the focus outline will be visible against the
-          background.
+          Make sure that a toolbar with the inverted variant is on a dark background, because
+          otherwise the focus outline will not be sufficiently visible against the background.
         </p>
       </div>
     `;

--- a/packages/components/tool-bar/src/tool-bar.stories.ts
+++ b/packages/components/tool-bar/src/tool-bar.stories.ts
@@ -784,9 +784,16 @@ export const Examples: Story = {
             aria-label="Filtering and sorting"
             inverted
             fill="ghost"
-            style="inline-size: fit-content">
+            style="inline-size: fit-content; padding: var(--sl-size-100)">
             ${filteringAndSorting}
           </sl-tool-bar>
+          <p>
+            This last example has been given extra padding for demonstration purposes. This prevents
+            the white focus outline from being invisible on the white background.<br />
+            If you use the toolbar as part of a larger UI with a non-white background, you typically
+            won't need this extra padding, as the focus outline will be visible against the
+            background.
+          </p>
         </div>
       </div>
     `;

--- a/packages/components/tool-bar/src/tool-bar.stories.ts
+++ b/packages/components/tool-bar/src/tool-bar.stories.ts
@@ -787,14 +787,16 @@ export const Examples: Story = {
             style="inline-size: fit-content; padding: var(--sl-size-100)">
             ${filteringAndSorting}
           </sl-tool-bar>
-          <p>
-            This last example has been given extra padding for demonstration purposes. This prevents
-            the white focus outline from being invisible on the white background.<br />
-            If you use the toolbar as part of a larger UI with a non-white background, you typically
-            won't need this extra padding, as the focus outline will be visible against the
-            background.
-          </p>
         </div>
+        <p>
+          This last example has been given extra padding for demonstration purposes. This prevents
+          the white focus outline from being invisible on the white background.
+        </p>
+        <p>
+          If you use the toolbar as part of a larger UI with a non-white background, you typically
+          won't need this extra padding, as the focus outline will be visible against the
+          background.
+        </p>
       </div>
     `;
   }


### PR DESCRIPTION
This pull request makes a small UI improvement to the `Examples` story for the toolbar component. The main change is the addition of extra padding and a descriptive note to demonstrate how to ensure the focus outline is visible against a white background in the Storybook example.

UI demonstration improvements:

* Added inline padding to the toolbar in the example and included a note explaining the reason for the extra padding, which is to make the white focus outline visible on a white background.