### PR TITLE
[3256] fix(accessibility): Improve screen reader support for combobox and listbox components

### DIFF
--- a/.changeset/calm-rivers-sync.md
+++ b/.changeset/calm-rivers-sync.md
@@ -1,0 +1,13 @@
+---
+'@sl-design-system/combobox': patch
+'@sl-design-system/listbox': patch
+---
+
+Accessibility improvements: improve screen reader support for combobox and listbox components
+
+- Set `aria-activedescendant` when the popover opens so screen readers announce the current option immediately
+- Set `aria-activedescendant` on mouse-open so AT context is maintained without applying a visual highlight
+- Remove non-standard `aria-owns` attribute from the combobox input
+- Always set `aria-selected` on options, including grouped options in the selected group
+- Set correct `aria-posinset` and `aria-setsize` on virtualized options, excluding group headers from the count
+- Add group label context to the accessible name of grouped options for Safari/VoiceOver compatibility

--- a/.changeset/calm-rivers-sync.md
+++ b/.changeset/calm-rivers-sync.md
@@ -1,13 +1,10 @@
 ---
 '@sl-design-system/combobox': patch
-'@sl-design-system/listbox': patch
 ---
 
-Accessibility improvements: improve screen reader support for combobox and listbox components
+Accessibility improvements for combobox screen reader support
 
 - Set `aria-activedescendant` when the popover opens so screen readers announce the current option immediately
 - Set `aria-activedescendant` on mouse-open so AT context is maintained without applying a visual highlight
-- Remove non-standard `aria-owns` attribute from the combobox input
-- Always set `aria-selected` on options, including grouped options in the selected group
-- Set correct `aria-posinset` and `aria-setsize` on virtualized options, excluding group headers from the count
-- Add group label context to the accessible name of grouped options for Safari/VoiceOver compatibility
+- Remove `aria-owns` from the combobox input because it is not needed for this implementation
+- Fixes issue where you can select an option multiple times when the "group selected" option is true

--- a/.changeset/pretty-brooms-invent.md
+++ b/.changeset/pretty-brooms-invent.md
@@ -1,0 +1,12 @@
+---
+'@sl-design-system/select': patch
+---
+
+Accessibility improvements for select screen reader support
+
+- Set `aria-activedescendant` when the popover opens so screen readers announce the current option immediately
+- Set `aria-activedescendant` on mouse-open so AT context is maintained without applying a visual highlight
+- Remove `aria-owns` from the select trigger/input because it is not needed for this implementation
+- Always set `aria-selected` on options, including grouped options in the selected group
+- Set correct `aria-posinset` and `aria-setsize` on virtualized options, excluding group headers from the count
+- Add group label context to the accessible name of grouped options for Safari/VoiceOver compatibility

--- a/.changeset/witty-cameras-smile.md
+++ b/.changeset/witty-cameras-smile.md
@@ -1,0 +1,9 @@
+---
+'@sl-design-system/listbox': patch
+---
+
+Accessibility improvements for listbox screen reader support
+
+- Always set `aria-selected` on options, including grouped options in the selected group
+- Set correct `aria-posinset` and `aria-setsize` on virtualized options, excluding group headers from the count
+- Add group label context to the accessible name of grouped options for Safari/VoiceOver compatibility

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -14,6 +14,18 @@ import { type SelectedGroup } from './selected-group.js';
 
 describe('sl-combobox', () => {
   let el: Combobox, input: HTMLInputElement;
+
+  const waitForNextMacrotask = async (): Promise<void> => {
+    if (vi.isFakeTimers()) {
+      vi.advanceTimersByTime(0);
+      await Promise.resolve();
+
+      return;
+    }
+
+    await new Promise<void>(resolve => setTimeout(resolve));
+  };
+
   const waitForNextFrame = async (): Promise<void> => {
     if (vi.isFakeTimers()) {
       vi.advanceTimersToNextFrame();
@@ -1499,7 +1511,7 @@ describe('sl-combobox', () => {
         input.focus();
         await el.updateComplete;
         await waitForNextFrame();
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await waitForNextMacrotask();
       });
 
       it('should not have role="group" on group wrappers', () => {
@@ -1509,27 +1521,46 @@ describe('sl-combobox', () => {
         expect(groups).to.have.lengthOf(0);
       });
 
-      it('should have aria-hidden="true" on group headers', () => {
-        // The items should include group headers
-        expect(el.items).to.exist;
-        const groupHeaders = el.items.filter(item => item.type === 'group');
-        expect(groupHeaders.length).to.equal(2);
+      it('should have aria-hidden="true" on group headers', async () => {
+        await userEvent.click(input);
+        await el.updateComplete;
+        await waitForNextFrame();
+        await waitForNextMacrotask();
 
-        // Check that group headers will be rendered with aria-hidden
-        // (actual rendering verified by visual/manual testing with virtualizer)
+        const listbox = el.querySelector('sl-listbox');
+        const headers = el.items
+          .filter(item => item.type === 'group')
+          .map(item => item.element)
+          .filter((header): header is HTMLElement => header instanceof HTMLElement)
+          .filter(header => header.closest('sl-listbox') === listbox);
+
+        expect(headers).to.have.lengthOf(2);
+
+        headers.forEach(header => {
+          expect(header).to.have.attribute('aria-hidden', 'true');
+        });
       });
 
-      it('should have flattened aria-posinset and aria-setsize across all options', () => {
-        // Verify the items structure has correct data
-        const options = el.items.filter(item => 'option' in item);
+      it('should have flattened aria-posinset and aria-setsize across all options', async () => {
+        await userEvent.click(input);
+        await el.updateComplete;
+        await waitForNextFrame();
+        await waitForNextMacrotask();
+
+        const listbox = el.querySelector('sl-listbox');
+        const options = el.items
+          .filter(item => 'option' in item)
+          .map(item => item.element)
+          .filter((option): option is HTMLElement => option instanceof HTMLElement)
+          .filter(option => option.tagName === 'SL-OPTION')
+          .filter(option => option.closest('sl-listbox') === listbox);
+
         expect(options).to.have.lengthOf(4);
 
-        // The aria attributes are set in #renderItem when the virtualizer renders each item
-        // We can verify the logic by checking that items are structured correctly
-        expect(options[0].label).to.equal('Apple');
-        expect(options[1].label).to.equal('Banana');
-        expect(options[2].label).to.equal('Carrot');
-        expect(options[3].label).to.equal('Potato');
+        options.forEach((option, index) => {
+          expect(option).to.have.attribute('aria-posinset', (index + 1).toString());
+          expect(option).to.have.attribute('aria-setsize', '4');
+        });
       });
 
       it('should include group context in option accessible names', () => {
@@ -1593,7 +1624,8 @@ describe('sl-combobox', () => {
         input = el.querySelector<HTMLInputElement>('input[slot="input"]')!;
 
         // Give time for options to be processed
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await waitForNextFrame();
+        await waitForNextMacrotask();
       });
 
       it('should not have role="group" on option-group elements', () => {
@@ -1617,7 +1649,8 @@ describe('sl-combobox', () => {
         // Trigger options processing
         input.focus();
         await el.updateComplete;
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await waitForNextFrame();
+        await waitForNextMacrotask();
 
         const options = el.querySelectorAll('sl-option');
 
@@ -1633,7 +1666,8 @@ describe('sl-combobox', () => {
         // Trigger options processing
         input.focus();
         await el.updateComplete;
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await waitForNextFrame();
+        await waitForNextMacrotask();
 
         const options = el.querySelectorAll('sl-option');
 
@@ -1727,7 +1761,8 @@ describe('sl-combobox', () => {
         `);
 
       await el.updateComplete;
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await waitForNextFrame();
+      await waitForNextMacrotask();
 
       expect(el.value).to.equal('Option 1');
       expect(changeSpy).not.to.have.been.called;
@@ -1943,7 +1978,6 @@ describe('sl-combobox', () => {
       expect(input).to.have.attribute('aria-expanded', 'false');
       expect(input).to.have.attribute('aria-haspopup', 'listbox');
       expect(input).to.have.attribute('aria-controls', listbox.id);
-      expect(input).to.have.attribute('aria-owns', listbox.id);
     });
   });
 });

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -10,6 +10,7 @@ import { userEvent } from 'vitest/browser';
 import '../register.js';
 import { type Combobox } from './combobox.js';
 import { type CustomOption } from './custom-option.js';
+import { type GroupedOption } from './grouped-option.js';
 import { type SelectedGroup } from './selected-group.js';
 
 describe('sl-combobox', () => {
@@ -1473,6 +1474,17 @@ describe('sl-combobox', () => {
         expect(el.groupSelected).to.be.true;
       });
 
+      it('should prepend the selected group as the first child in the listbox', () => {
+        const listbox = el.querySelector('sl-listbox');
+
+        expect(listbox?.firstElementChild).to.equal(selectedGroup);
+      });
+
+      it('should set has-groups to false when source options are not grouped', () => {
+        expect(selectedGroup.hasGroups).to.be.false;
+        expect(selectedGroup).not.to.have.attribute('has-groups');
+      });
+
       it('should group the selected options', () => {
         expect(selectedGroup).to.exist;
         // Note: aria-label is no longer set since we removed role="group" for Safari/VoiceOver compatibility
@@ -1489,6 +1501,56 @@ describe('sl-combobox', () => {
         expect(headers).to.have.lengthOf(2);
         expect(headers.item(0)).to.have.trimmed.text('Selected');
         expect(headers.item(1)).to.have.trimmed.text('All options');
+      });
+
+      it('should remove the selected group when all selections are cleared', async () => {
+        el.value = [];
+        await el.updateComplete;
+
+        expect(el.querySelector('sl-combobox-selected-group')).not.to.exist;
+      });
+
+      describe('with grouped source options', () => {
+        beforeEach(async () => {
+          el = await fixture(html`
+            <sl-combobox group-selected multiple .value=${['Option 1', 'Option 3']}>
+              <sl-listbox>
+                <sl-option-group label="Group 1">
+                  <sl-option>Option 1</sl-option>
+                  <sl-option>Option 2</sl-option>
+                </sl-option-group>
+                <sl-option-group label="Group 2">
+                  <sl-option>Option 3</sl-option>
+                  <sl-option>Option 4</sl-option>
+                </sl-option-group>
+              </sl-listbox>
+            </sl-combobox>
+          `);
+
+          selectedGroup = el.querySelector('sl-combobox-selected-group')!;
+        });
+
+        it('should set has-groups to true when source options are grouped', () => {
+          expect(selectedGroup.hasGroups).to.be.true;
+          expect(selectedGroup).to.have.attribute('has-groups');
+        });
+
+        it('should render only the selected header when has-groups is true', () => {
+          const headers = selectedGroup.renderRoot.querySelectorAll('sl-option-group-header');
+
+          expect(headers).to.have.lengthOf(1);
+          expect(headers.item(0)).to.have.trimmed.text('Selected');
+        });
+
+        it('should preserve original group labels on grouped selected options', () => {
+          const options = Array.from(
+            selectedGroup.querySelectorAll<GroupedOption>('sl-combobox-grouped-option')
+          );
+
+          expect(options).to.have.lengthOf(2);
+          expect(options[0].group).to.equal('Group 1');
+          expect(options[1].group).to.equal('Group 2');
+        });
       });
     });
 
@@ -1585,7 +1647,7 @@ describe('sl-combobox', () => {
         });
       });
 
-      it('should include group context in option accessible names', () => {
+      it('should have set the group name in the option items', () => {
         // Verify that items have group information
         const options = el.items.filter(item => 'option' in item);
 

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1533,8 +1533,18 @@ describe('sl-combobox', () => {
         const headers = el.items
           .filter(item => item.type === 'group')
           .map(item => item.element)
-          .filter((header): header is HTMLElement => header instanceof HTMLElement)
-          .filter(header => header.closest('sl-listbox') === listbox);
+          .filter(
+            (header): header is NonNullable<Combobox['items'][number]['element']> =>
+              header !== undefined
+          )
+          .filter(header => {
+            const root = header.getRootNode();
+
+            return (
+              header.closest('sl-listbox') === listbox ||
+              (root instanceof ShadowRoot && root.host.hasAttribute('data-virtual-list'))
+            );
+          });
 
         expect(headers).to.have.lengthOf(2);
 
@@ -1553,9 +1563,19 @@ describe('sl-combobox', () => {
         const options = el.items
           .filter(item => 'option' in item)
           .map(item => item.element)
-          .filter((option): option is HTMLElement => option instanceof HTMLElement)
-          .filter(option => option.tagName === 'SL-OPTION')
-          .filter(option => option.closest('sl-listbox') === listbox);
+          .filter(
+            (option): option is NonNullable<Combobox['items'][number]['element']> =>
+              option !== undefined
+          )
+          .filter(option => option.getAttribute('role') === 'option')
+          .filter(option => {
+            const root = option.getRootNode();
+
+            return (
+              option.closest('sl-listbox') === listbox ||
+              (root instanceof ShadowRoot && root.host.hasAttribute('data-virtual-list'))
+            );
+          });
 
         expect(options).to.have.lengthOf(4);
 

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1461,7 +1461,7 @@ describe('sl-combobox', () => {
 
       it('should group the selected options', () => {
         expect(selectedGroup).to.exist;
-        expect(selectedGroup).to.have.attribute('aria-label', 'Selected');
+        // Note: aria-label is no longer set since we removed role="group" for Safari/VoiceOver compatibility
 
         const options = Array.from(
           selectedGroup.querySelectorAll('sl-combobox-grouped-option')
@@ -1475,6 +1475,172 @@ describe('sl-combobox', () => {
         expect(headers).to.have.lengthOf(2);
         expect(headers.item(0)).to.have.trimmed.text('Selected');
         expect(headers.item(1)).to.have.trimmed.text('All options');
+      });
+    });
+
+    describe('grouped options accessibility', () => {
+      beforeEach(async () => {
+        el = await fixture(html`
+          <sl-combobox
+            .options=${[
+              { label: 'Apple', value: 'apple', group: 'Fruits' },
+              { label: 'Banana', value: 'banana', group: 'Fruits' },
+              { label: 'Carrot', value: 'carrot', group: 'Vegetables' },
+              { label: 'Potato', value: 'potato', group: 'Vegetables' }
+            ]}
+            option-group-path="group"
+            option-label-path="label"
+            option-value-path="value">
+          </sl-combobox>
+        `);
+        input = el.querySelector<HTMLInputElement>('input[slot="input"]')!;
+
+        // Open the listbox to render options
+        input.focus();
+        await el.updateComplete;
+        await waitForNextFrame();
+        await new Promise(resolve => setTimeout(resolve, 100));
+      });
+
+      it('should not have role="group" on group wrappers', () => {
+        const listbox = el.querySelector('sl-listbox');
+        const groups = listbox?.shadowRoot?.querySelectorAll('[role="group"]');
+
+        expect(groups).to.have.lengthOf(0);
+      });
+
+      it('should have aria-hidden="true" on group headers', () => {
+        // The items should include group headers
+        expect(el.items).to.exist;
+        const groupHeaders = el.items.filter(item => item.type === 'group');
+        expect(groupHeaders.length).to.equal(2);
+
+        // Check that group headers will be rendered with aria-hidden
+        // (actual rendering verified by visual/manual testing with virtualizer)
+      });
+
+      it('should have flattened aria-posinset and aria-setsize across all options', () => {
+        // Verify the items structure has correct data
+        const options = el.items.filter(item => 'option' in item);
+        expect(options).to.have.lengthOf(4);
+
+        // The aria attributes are set in #renderItem when the virtualizer renders each item
+        // We can verify the logic by checking that items are structured correctly
+        expect(options[0].label).to.equal('Apple');
+        expect(options[1].label).to.equal('Banana');
+        expect(options[2].label).to.equal('Carrot');
+        expect(options[3].label).to.equal('Potato');
+      });
+
+      it('should include group context in option accessible names', () => {
+        // Verify that items have group information
+        const options = el.items.filter(item => 'option' in item);
+
+        expect(options[0].group).to.equal('Fruits');
+        expect(options[1].group).to.equal('Fruits');
+        expect(options[2].group).to.equal('Vegetables');
+        expect(options[3].group).to.equal('Vegetables');
+
+        // The aria-label with group context is set in #renderItem when virtualizer renders
+      });
+
+      it('should have aria-selected on all options', () => {
+        // Verify that items are structured correctly for aria-selected
+        const options = el.items.filter(item => 'option' in item);
+
+        options.forEach(option => {
+          expect(option.selected).to.be.oneOf([true, false, undefined]);
+        });
+      });
+
+      it('should update aria-activedescendant to point to current option', async () => {
+        // Ensure the popover is open
+        await userEvent.click(input);
+        await el.updateComplete;
+        await waitForNextFrame();
+
+        // Navigate to first option
+        await userEvent.keyboard('{ArrowDown}');
+        await el.updateComplete;
+        await waitForNextFrame();
+
+        // The current item should be set and aria-activedescendant should point to it
+        if (el.currentItem) {
+          expect(input).to.have.attribute('aria-activedescendant', el.currentItem.id);
+        } else {
+          // If currentItem is not set, that's also acceptable for initial state
+          expect(el.currentItem).to.be.undefined;
+        }
+      });
+    });
+
+    describe('grouped options in light DOM', () => {
+      beforeEach(async () => {
+        el = await fixture(html`
+          <sl-combobox>
+            <sl-listbox>
+              <sl-option-group label="Group 1">
+                <sl-option value="1">Option 1</sl-option>
+                <sl-option value="2">Option 2</sl-option>
+              </sl-option-group>
+              <sl-option-group label="Group 2">
+                <sl-option value="3">Option 3</sl-option>
+                <sl-option value="4">Option 4</sl-option>
+              </sl-option-group>
+            </sl-listbox>
+          </sl-combobox>
+        `);
+        input = el.querySelector<HTMLInputElement>('input[slot="input"]')!;
+
+        // Give time for options to be processed
+        await new Promise(resolve => setTimeout(resolve, 100));
+      });
+
+      it('should not have role="group" on option-group elements', () => {
+        const groups = el.querySelectorAll('sl-option-group');
+
+        groups.forEach(group => {
+          expect(group).not.to.have.attribute('role', 'group');
+        });
+      });
+
+      it('should have aria-hidden="true" on group headers', () => {
+        const groups = el.querySelectorAll('sl-option-group');
+
+        groups.forEach(group => {
+          const header = group.shadowRoot?.querySelector('sl-option-group-header');
+          expect(header).to.have.attribute('aria-hidden', 'true');
+        });
+      });
+
+      it('should have flattened aria-posinset and aria-setsize across all options', async () => {
+        // Trigger options processing
+        input.focus();
+        await el.updateComplete;
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const options = el.querySelectorAll('sl-option');
+
+        expect(options).to.have.lengthOf(4);
+
+        options.forEach((option, index) => {
+          expect(option).to.have.attribute('aria-posinset', (index + 1).toString());
+          expect(option).to.have.attribute('aria-setsize', '4');
+        });
+      });
+
+      it('should include group context in option accessible names', async () => {
+        // Trigger options processing
+        input.focus();
+        await el.updateComplete;
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const options = el.querySelectorAll('sl-option');
+
+        expect(options[0]).to.have.attribute('aria-label', 'Group 1, Option 1');
+        expect(options[1]).to.have.attribute('aria-label', 'Group 1, Option 2');
+        expect(options[2]).to.have.attribute('aria-label', 'Group 2, Option 3');
+        expect(options[3]).to.have.attribute('aria-label', 'Group 2, Option 4');
       });
     });
 

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1515,8 +1515,8 @@ describe('sl-combobox', () => {
       });
 
       it('should not have role="group" on group wrappers', () => {
-        const listbox = el.querySelector('sl-listbox');
-        const groups = listbox?.shadowRoot?.querySelectorAll('[role="group"]');
+        // sl-option-group elements are in the light DOM, not the listbox shadow root
+        const groups = el.querySelectorAll('sl-option-group[role="group"]');
 
         expect(groups).to.have.lengthOf(0);
       });

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1578,6 +1578,44 @@ describe('sl-combobox', () => {
         expect(el.querySelector('sl-combobox-selected-group')).not.to.exist;
       });
 
+      it('should move current to the grouped option so Enter toggles it off instead of selecting it twice', async () => {
+        input.focus();
+        await userEvent.keyboard('Option 3');
+        await el.updateComplete;
+        await waitForNextFrame();
+
+        await userEvent.keyboard('{Enter}');
+        await el.updateComplete;
+        await waitForNextFrame();
+        await waitForNextMacrotask();
+
+        const currentGroupedOption = selectedGroup.querySelector(
+          'sl-combobox-grouped-option[current]'
+        );
+        const groupedLabelsAfterFirstEnter = Array.from(
+          selectedGroup.querySelectorAll('sl-combobox-grouped-option')
+        ).map(option => option.textContent?.trim());
+
+        expect(currentGroupedOption).to.exist;
+        expect(currentGroupedOption).to.have.trimmed.text('Option 3');
+        expect(groupedLabelsAfterFirstEnter.filter(label => label === 'Option 3')).to.have.lengthOf(
+          1
+        );
+
+        await userEvent.keyboard('{Enter}');
+        await el.updateComplete;
+        await waitForNextFrame();
+        await waitForNextMacrotask();
+
+        const groupedLabelsAfterSecondEnter = Array.from(
+          selectedGroup.querySelectorAll('sl-combobox-grouped-option')
+        ).map(option => option.textContent?.trim());
+
+        expect(
+          groupedLabelsAfterSecondEnter.filter(label => label === 'Option 3')
+        ).to.have.lengthOf(0);
+      });
+
       describe('with grouped source options', () => {
         beforeEach(async () => {
           el = await fixture(html`

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -875,7 +875,7 @@ describe('sl-combobox', () => {
         const options = Array.from(el.querySelectorAll('sl-option'));
 
         expect(options[1]).not.to.have.attribute('current');
-        expect(input).not.to.have.attribute('aria-activedescendant');
+        expect(input).to.have.attribute('aria-activedescendant', options[1].id);
       });
     });
   });
@@ -1637,10 +1637,10 @@ describe('sl-combobox', () => {
 
         const options = el.querySelectorAll('sl-option');
 
-        expect(options[0]).to.have.attribute('aria-label', 'Group 1, Option 1');
-        expect(options[1]).to.have.attribute('aria-label', 'Group 1, Option 2');
-        expect(options[2]).to.have.attribute('aria-label', 'Group 2, Option 3');
-        expect(options[3]).to.have.attribute('aria-label', 'Group 2, Option 4');
+        expect(options[0]).to.have.attribute('aria-label', 'Option 1 (Group 1)');
+        expect(options[1]).to.have.attribute('aria-label', 'Option 2 (Group 1)');
+        expect(options[2]).to.have.attribute('aria-label', 'Option 3 (Group 2)');
+        expect(options[3]).to.have.attribute('aria-label', 'Option 4 (Group 2)');
       });
     });
 

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -159,18 +159,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   /** The group that contains all the selected options when `groupSelected` is set. */
   #selectedGroup?: SelectedGroup;
 
-  /** Cache for flattened option positions used during item rendering. */
-  #flattenedOptionPositions?: WeakMap<ComboboxItem<T, U>, number>;
-
-  /** Version of the items snapshot for which the flattened position cache is valid. */
-  #flattenedPositionCacheVersion = -1;
-
-  /** Monotonically increasing version for combobox-owned items mutations. */
-  #itemsVersion = 0;
-
-  /** Cached flattened option set size matching #flattenedOptionPositions. */
-  #flattenedOptionSetSize = 0;
-
   /** Flag to indicate when to use lit-virtualizer. */
   #useVirtualList = false;
 
@@ -400,7 +388,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     ) {
       if (this.options) {
         this.items = this.#prepareOptions(this.options);
-        this.#invalidateFlattenedOptionCache();
 
         this.listbox?.remove();
         this.listbox = this.shadowRoot!.createElement('sl-listbox');
@@ -411,7 +398,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         this.#useVirtualList = true;
       } else if (changes.get('options')) {
         this.items = [];
-        this.#invalidateFlattenedOptionCache();
         this.#useVirtualList = false;
       }
     }
@@ -483,7 +469,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       this.#useVirtualList
     ) {
       this.items = this.items.map(o => ({ ...o, visible: true }));
-      this.#invalidateFlattenedOptionCache();
       this.listbox!.items = this.items;
     }
 
@@ -869,7 +854,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         const { hasSelected, items, selectedItems } = this.#getListboxOptions(this.listbox);
 
         this.items = items;
-        this.#invalidateFlattenedOptionCache();
         this.selectedItems = selectedItems;
 
         // The selected option can be set either via:
@@ -891,7 +875,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     } else {
       this.input.removeAttribute('aria-controls');
       this.items = [];
-      this.#invalidateFlattenedOptionCache();
     }
   }
 
@@ -1044,7 +1027,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     };
 
     this.items = [item, ...this.items];
-    this.#invalidateFlattenedOptionCache();
 
     if (this.#useVirtualList) {
       this.listbox!.items = this.items;
@@ -1074,7 +1056,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     }
 
     this.items = this.items.filter(i => i !== item);
-    this.#invalidateFlattenedOptionCache();
 
     this.selectedItems = this.selectedItems.filter(i => i !== item);
 
@@ -1101,7 +1082,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
 
     // Insert the new grouped option *after* any existing grouped options
     this.items = [...this.items.slice(0, index), groupedItem, ...this.items.slice(index)];
-    this.#invalidateFlattenedOptionCache();
 
     this.selectedItems = [...this.selectedItems, groupedItem];
 
@@ -1136,7 +1116,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     }
 
     this.items = this.items.filter(i => i !== item);
-    this.#invalidateFlattenedOptionCache();
     this.selectedItems = this.selectedItems.filter(i => i !== item);
 
     if (this.#useVirtualList) {
@@ -1169,7 +1148,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
 
       if (this.optionGroupPath) {
         this.items = [selectedHeader, ...this.items];
-        this.#invalidateFlattenedOptionCache();
       } else {
         const allOptionsHeader: ComboboxItem = {
           id: `sl-combobox-option-group-${nextUniqueId++}`,
@@ -1179,7 +1157,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         };
 
         this.items = [selectedHeader, allOptionsHeader, ...this.items];
-        this.#invalidateFlattenedOptionCache();
       }
     } else {
       this.#selectedGroup ||= this.shadowRoot!.createElement('sl-combobox-selected-group');
@@ -1198,7 +1175,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         this.items[0].type === 'group'
       ) {
         this.items = this.items.slice(1);
-        this.#invalidateFlattenedOptionCache();
       } else {
         return;
       }
@@ -1212,7 +1188,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         this.items[0].type === 'group'
       ) {
         this.items = this.items.slice(1);
-        this.#invalidateFlattenedOptionCache();
       }
 
       this.listbox!.items = this.items;
@@ -1355,13 +1330,14 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       el.value = item.value;
       el.setAttribute('aria-selected', item.selected ? 'true' : 'false');
 
-      // Read flattened option metadata from a per-items cache to avoid O(n²)
-      // work when many options are rendered by the virtualizer.
-      const flattenedPosition = this.#getFlattenedOptionPosition(item);
+      // aria-posinset / aria-setsize for the virtual list: delegate to the listbox cache so the
+      // logic lives in one place. For non-virtual (slotted) options the listbox already applies
+      // these in its #onSlotChange → #applyFlattenedOptionAccessibility path.
+      const flattenedPosition = this.listbox!.getFlattenedPosition(item);
 
       if (flattenedPosition !== -1) {
         el.setAttribute('aria-posinset', (flattenedPosition + 1).toString());
-        el.setAttribute('aria-setsize', this.#flattenedOptionSetSize.toString());
+        el.setAttribute('aria-setsize', this.listbox!.getFlattenedSetSize().toString());
       }
 
       // Add group context to accessible name for Safari/VoiceOver compatibility
@@ -1399,31 +1375,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     }
   }
 
-  #getFlattenedOptionPosition(item: ComboboxItem<T, U>): number {
-    if (
-      this.#flattenedPositionCacheVersion !== this.#itemsVersion ||
-      !this.#flattenedOptionPositions
-    ) {
-      this.#flattenedOptionPositions = new WeakMap<ComboboxItem<T, U>, number>();
-      this.#flattenedPositionCacheVersion = this.#itemsVersion;
-
-      let position = 0;
-      this.items.forEach(i => {
-        if ('option' in i) {
-          this.#flattenedOptionPositions!.set(i, position++);
-        }
-      });
-
-      this.#flattenedOptionSetSize = position;
-    }
-
-    return this.#flattenedOptionPositions.get(item) ?? -1;
-  }
-
-  #invalidateFlattenedOptionCache(): void {
-    this.#itemsVersion += 1;
-  }
-
   #updateCreateCustomOption(labelAndValue?: string): void {
     if (labelAndValue?.trim()) {
       if (this.createCustomOption) {
@@ -1440,7 +1391,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         };
 
         this.items = [this.createCustomOption, ...this.items];
-        this.#invalidateFlattenedOptionCache();
       }
 
       if (this.#useVirtualList) {
@@ -1462,7 +1412,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       }
     } else if (this.createCustomOption) {
       this.items = this.items.filter(i => i !== this.createCustomOption);
-      this.#invalidateFlattenedOptionCache();
 
       if (this.#useVirtualList) {
         this.listbox!.items = this.items;

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -159,6 +159,18 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   /** The group that contains all the selected options when `groupSelected` is set. */
   #selectedGroup?: SelectedGroup;
 
+  /** Cache for flattened option positions used during item rendering. */
+  #flattenedOptionPositions?: WeakMap<ComboboxItem<T, U>, number>;
+
+  /** Version of the items snapshot for which the flattened position cache is valid. */
+  #flattenedPositionCacheVersion = -1;
+
+  /** Monotonically increasing version for combobox-owned items mutations. */
+  #itemsVersion = 0;
+
+  /** Cached flattened option set size matching #flattenedOptionPositions. */
+  #flattenedOptionSetSize = 0;
+
   /** Flag to indicate when to use lit-virtualizer. */
   #useVirtualList = false;
 
@@ -388,6 +400,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     ) {
       if (this.options) {
         this.items = this.#prepareOptions(this.options);
+        this.#invalidateFlattenedOptionCache();
 
         this.listbox?.remove();
         this.listbox = this.shadowRoot!.createElement('sl-listbox');
@@ -398,6 +411,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         this.#useVirtualList = true;
       } else if (changes.get('options')) {
         this.items = [];
+        this.#invalidateFlattenedOptionCache();
         this.#useVirtualList = false;
       }
     }
@@ -469,6 +483,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       this.#useVirtualList
     ) {
       this.items = this.items.map(o => ({ ...o, visible: true }));
+      this.#invalidateFlattenedOptionCache();
       this.listbox!.items = this.items;
     }
 
@@ -854,6 +869,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         const { hasSelected, items, selectedItems } = this.#getListboxOptions(this.listbox);
 
         this.items = items;
+        this.#invalidateFlattenedOptionCache();
         this.selectedItems = selectedItems;
 
         // The selected option can be set either via:
@@ -875,6 +891,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     } else {
       this.input.removeAttribute('aria-controls');
       this.items = [];
+      this.#invalidateFlattenedOptionCache();
     }
   }
 
@@ -1027,6 +1044,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     };
 
     this.items = [item, ...this.items];
+    this.#invalidateFlattenedOptionCache();
 
     if (this.#useVirtualList) {
       this.listbox!.items = this.items;
@@ -1056,6 +1074,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     }
 
     this.items = this.items.filter(i => i !== item);
+    this.#invalidateFlattenedOptionCache();
 
     this.selectedItems = this.selectedItems.filter(i => i !== item);
 
@@ -1082,6 +1101,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
 
     // Insert the new grouped option *after* any existing grouped options
     this.items = [...this.items.slice(0, index), groupedItem, ...this.items.slice(index)];
+    this.#invalidateFlattenedOptionCache();
 
     this.selectedItems = [...this.selectedItems, groupedItem];
 
@@ -1116,6 +1136,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     }
 
     this.items = this.items.filter(i => i !== item);
+    this.#invalidateFlattenedOptionCache();
     this.selectedItems = this.selectedItems.filter(i => i !== item);
 
     if (this.#useVirtualList) {
@@ -1148,6 +1169,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
 
       if (this.optionGroupPath) {
         this.items = [selectedHeader, ...this.items];
+        this.#invalidateFlattenedOptionCache();
       } else {
         const allOptionsHeader: ComboboxItem = {
           id: `sl-combobox-option-group-${nextUniqueId++}`,
@@ -1157,6 +1179,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         };
 
         this.items = [selectedHeader, allOptionsHeader, ...this.items];
+        this.#invalidateFlattenedOptionCache();
       }
     } else {
       this.#selectedGroup ||= this.shadowRoot!.createElement('sl-combobox-selected-group');
@@ -1175,6 +1198,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         this.items[0].type === 'group'
       ) {
         this.items = this.items.slice(1);
+        this.#invalidateFlattenedOptionCache();
       } else {
         return;
       }
@@ -1188,6 +1212,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         this.items[0].type === 'group'
       ) {
         this.items = this.items.slice(1);
+        this.#invalidateFlattenedOptionCache();
       }
 
       this.listbox!.items = this.items;
@@ -1330,13 +1355,13 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       el.value = item.value;
       el.setAttribute('aria-selected', item.selected ? 'true' : 'false');
 
-      // Calculate flattened position: only count options, not group headers
-      const allOptions = this.items.filter(i => 'option' in i);
-      const flattenedPosition = allOptions.indexOf(item);
+      // Read flattened option metadata from a per-items cache to avoid O(n²)
+      // work when many options are rendered by the virtualizer.
+      const flattenedPosition = this.#getFlattenedOptionPosition(item);
 
       if (flattenedPosition !== -1) {
         el.setAttribute('aria-posinset', (flattenedPosition + 1).toString());
-        el.setAttribute('aria-setsize', allOptions.length.toString());
+        el.setAttribute('aria-setsize', this.#flattenedOptionSetSize.toString());
       }
 
       // Add group context to accessible name for Safari/VoiceOver compatibility
@@ -1374,6 +1399,31 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     }
   }
 
+  #getFlattenedOptionPosition(item: ComboboxItem<T, U>): number {
+    if (
+      this.#flattenedPositionCacheVersion !== this.#itemsVersion ||
+      !this.#flattenedOptionPositions
+    ) {
+      this.#flattenedOptionPositions = new WeakMap<ComboboxItem<T, U>, number>();
+      this.#flattenedPositionCacheVersion = this.#itemsVersion;
+
+      let position = 0;
+      this.items.forEach(i => {
+        if ('option' in i) {
+          this.#flattenedOptionPositions!.set(i, position++);
+        }
+      });
+
+      this.#flattenedOptionSetSize = position;
+    }
+
+    return this.#flattenedOptionPositions.get(item) ?? -1;
+  }
+
+  #invalidateFlattenedOptionCache(): void {
+    this.#itemsVersion += 1;
+  }
+
   #updateCreateCustomOption(labelAndValue?: string): void {
     if (labelAndValue?.trim()) {
       if (this.createCustomOption) {
@@ -1390,6 +1440,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         };
 
         this.items = [this.createCustomOption, ...this.items];
+        this.#invalidateFlattenedOptionCache();
       }
 
       if (this.#useVirtualList) {
@@ -1411,6 +1462,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       }
     } else if (this.createCustomOption) {
       this.items = this.items.filter(i => i !== this.createCustomOption);
+      this.#invalidateFlattenedOptionCache();
 
       if (this.#useVirtualList) {
         this.listbox!.items = this.items;

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -962,12 +962,24 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         }
 
         // Ensure the option has an aria-selected attribute
-        if (!el.hasAttribute('aria-selected')) {
-          el.setAttribute('aria-selected', Boolean(el.selected).toString());
-        }
+        el.setAttribute('aria-selected', Boolean(el.selected).toString());
 
         return item;
       });
+
+    // Update aria-posinset and aria-setsize for flattened list structure
+    // Also add group context to accessible names
+    items.forEach((item, flattenedIndex) => {
+      if (item.element) {
+        item.element.setAttribute('aria-posinset', (flattenedIndex + 1).toString());
+        item.element.setAttribute('aria-setsize', items.length.toString());
+
+        // Add group context to accessible name for Safari/VoiceOver compatibility
+        if (item.group) {
+          item.element.setAttribute('aria-label', `${item.group}, ${item.label}`);
+        }
+      }
+    });
 
     return { hasSelected, items, selectedItems };
   }
@@ -1304,12 +1316,18 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       el.value = item.value;
       el.setAttribute('aria-selected', item.selected ? 'true' : 'false');
 
-      if (typeof item.index === 'number') {
-        el.setAttribute('aria-posinset', (item.index + 1).toString());
+      // Calculate flattened position: only count options, not group headers
+      const allOptions = this.items.filter(i => 'option' in i);
+      const flattenedPosition = allOptions.indexOf(item);
+
+      if (flattenedPosition !== -1) {
+        el.setAttribute('aria-posinset', (flattenedPosition + 1).toString());
+        el.setAttribute('aria-setsize', allOptions.length.toString());
       }
 
-      if (this.options) {
-        el.setAttribute('aria-setsize', this.options.length.toString());
+      // Add group context to accessible name for Safari/VoiceOver compatibility
+      if (item.group) {
+        el.setAttribute('aria-label', `${item.group}, ${item.label}`);
       }
 
       if (el instanceof GroupedOption) {

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -1225,6 +1225,10 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       this.selectedItems.forEach(item => this.#removeSelectedOption(item));
       this.selectedItems = [item];
     }
+
+    item.current = false;
+    this.#updateCurrent(this.selectedItems.find(i => i.id === item.id));
+
     if (item.element instanceof Option) {
       item.element.selected = item.selected;
       item.element.style.display = item.visible ? '' : 'none';

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -682,10 +682,17 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     this.wrapper?.showPopover();
 
     if (!this.multiple && !this.#popoverOpenedViaKeyboard) {
+      // Mouse-open should keep AT context without applying visual current highlight.
+      if (this.currentItem) {
+        this.currentItem.current = false;
+      }
+      this.currentItem?.element?.removeAttribute('current');
+      this.listbox?.querySelector('[current]')?.removeAttribute('current');
+
       const selectedItem = this.selectedItems[0] ?? this.items.find(i => i.selected);
 
       if (selectedItem) {
-        this.#updateCurrent(selectedItem, 'instant');
+        this.#updateCurrent(selectedItem, 'instant', { visual: false });
       } else {
         const selectedOption =
           this.querySelector<Option>('sl-option[selected]') ??
@@ -932,7 +939,9 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
           );
 
         if (selectedItem) {
-          this.#updateCurrent(selectedItem, 'instant');
+          this.#updateCurrent(selectedItem, 'instant', {
+            visual: this.#popoverOpenedViaKeyboard
+          });
         } else if (selectedOptionElement?.id) {
           // Fallback for timing-sensitive open paths where internal item state
           // has not synchronized yet. Keep AT context without visual highlight.
@@ -1424,7 +1433,11 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   }
 
   /** Updates the options to reflect the current one. */
-  #updateCurrent(option?: ComboboxItem<T, U>, scrollBehaviour: ScrollBehavior = 'instant'): void {
+  #updateCurrent(
+    option?: ComboboxItem<T, U>,
+    scrollBehaviour: ScrollBehavior = 'instant',
+    { visual = true }: { visual?: boolean } = {}
+  ): void {
     if (this.currentItem) {
       this.currentItem.current = false;
       this.input.removeAttribute('aria-activedescendant');
@@ -1442,14 +1455,19 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
 
     this.currentItem = option;
     if (this.currentItem) {
-      this.currentItem.current = true;
+      this.currentItem.current = visual;
 
       this.input.setAttribute('aria-activedescendant', this.currentItem.id);
 
       // Check if element exists and is still connected (not a stale, disconnected element from virtualization)
       if (this.currentItem.element?.isConnected) {
         // Element exists and is connected, use scrollIntoView (avoid duplicate scrolling)
-        this.currentItem.element.setAttribute('current', '');
+        if (visual) {
+          this.currentItem.element.setAttribute('current', '');
+        } else {
+          this.currentItem.element.removeAttribute('current');
+        }
+
         this.currentItem.element.scrollIntoView({ block: 'start', behavior: scrollBehaviour });
       } else {
         // Element doesn't exist or is disconnected (virtual list), use scrollToIndex

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -680,6 +680,23 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
 
   #onInputClick(): void {
     this.wrapper?.showPopover();
+
+    if (!this.multiple && !this.#popoverOpenedViaKeyboard) {
+      const selectedItem = this.selectedItems[0] ?? this.items.find(i => i.selected);
+
+      if (selectedItem) {
+        this.#updateCurrent(selectedItem, { visual: false });
+      } else {
+        const selectedOption =
+          this.querySelector<Option>('sl-option[selected]') ??
+          this.querySelector<Option>('sl-option');
+
+        if (selectedOption) {
+          selectedOption.id ||= `sl-combobox-option-${nextUniqueId++}`;
+          this.input.setAttribute('aria-activedescendant', selectedOption.id);
+        }
+      }
+    }
   }
 
   #onKeydown(event: KeyboardEvent): void {
@@ -824,7 +841,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     if (this.listbox) {
       this.listbox.id ||= `sl-combobox-listbox-${nextUniqueId++}`;
       this.input.setAttribute('aria-controls', this.listbox.id);
-      this.input.setAttribute('aria-owns', this.listbox.id);
 
       if (this.multiple) {
         this.listbox.setAttribute('aria-multiselectable', 'true');
@@ -858,7 +874,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       }
     } else {
       this.input.removeAttribute('aria-controls');
-      this.input.removeAttribute('aria-owns');
       this.items = [];
     }
   }
@@ -907,8 +922,21 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
           this.listbox?.scrollIntoView({ block: 'start' });
         }
 
-        if (this.selectedItems.length && this.#popoverOpenedViaKeyboard) {
-          this.#updateCurrent(this.selectedItems[0]);
+        const selectedOptionElement = this.listbox?.querySelector<Option>('sl-option[selected]');
+        const selectedItem =
+          this.selectedItems[0] ??
+          this.items.find(
+            i => i.selected || (selectedOptionElement && i.id === selectedOptionElement.id)
+          );
+
+        if (selectedItem) {
+          this.#updateCurrent(selectedItem, {
+            visual: this.#popoverOpenedViaKeyboard
+          });
+        } else if (selectedOptionElement?.id) {
+          // Fallback for timing-sensitive open paths where internal item state
+          // has not synchronized yet. Keep AT context without visual highlight.
+          this.input.setAttribute('aria-activedescendant', selectedOptionElement.id);
         }
       }
 
@@ -966,20 +994,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
 
         return item;
       });
-
-    // Update aria-posinset and aria-setsize for flattened list structure
-    // Also add group context to accessible names
-    items.forEach((item, flattenedIndex) => {
-      if (item.element) {
-        item.element.setAttribute('aria-posinset', (flattenedIndex + 1).toString());
-        item.element.setAttribute('aria-setsize', items.length.toString());
-
-        // Add group context to accessible name for Safari/VoiceOver compatibility
-        if (item.group) {
-          item.element.setAttribute('aria-label', `${item.group}, ${item.label}`);
-        }
-      }
-    });
 
     return { hasSelected, items, selectedItems };
   }
@@ -1409,7 +1423,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   }
 
   /** Updates the options to reflect the current one. */
-  #updateCurrent(option?: ComboboxItem<T, U>): void {
+  #updateCurrent(option?: ComboboxItem<T, U>, { visual = true }: { visual?: boolean } = {}): void {
     if (this.currentItem) {
       this.currentItem.current = false;
       this.input.removeAttribute('aria-activedescendant');
@@ -1419,12 +1433,17 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     this.currentItem = option;
 
     if (this.currentItem) {
-      this.currentItem.current = true;
+      this.currentItem.current = visual;
 
       this.input.setAttribute('aria-activedescendant', this.currentItem.id);
 
       if (this.currentItem.element) {
-        this.currentItem.element.setAttribute('current', '');
+        if (visual) {
+          this.currentItem.element.setAttribute('current', '');
+        } else {
+          this.currentItem.element.removeAttribute('current');
+        }
+
         this.currentItem.element.scrollIntoView({ block: 'nearest' });
       } else {
         this.listbox?.scrollToIndex(this.items.indexOf(this.currentItem), { block: 'nearest' });

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -1351,7 +1351,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
 
       // Add group context to accessible name for Safari/VoiceOver compatibility
       if (item.group) {
-        el.setAttribute('aria-label', `${item.group}, ${item.label}`);
+        el.setAttribute('aria-label', `${item.label} (${item.group})`);
       }
 
       if (el instanceof GroupedOption) {

--- a/packages/components/listbox/src/listbox.spec.ts
+++ b/packages/components/listbox/src/listbox.spec.ts
@@ -287,4 +287,140 @@ describe('sl-listbox', () => {
       expect(option).not.to.have.attribute('aria-label');
     });
   });
+
+  describe('flattened position cache', () => {
+    it('should compute flattened positions correctly with grouped options', async () => {
+      type GroupedOption = {
+        group: string;
+        label: string;
+        selected: boolean;
+        value: string;
+      };
+
+      const listbox = await fixture<Listbox<GroupedOption>>(html`
+        <sl-listbox
+          option-group-path="group"
+          option-label-path="label"
+          option-selected-path="selected"
+          option-value-path="value"></sl-listbox>
+      `);
+
+      listbox.options = [
+        { group: 'Fruits', label: 'Apple', selected: false, value: 'apple' },
+        { group: 'Fruits', label: 'Banana', selected: true, value: 'banana' },
+        { group: 'Vegetables', label: 'Carrot', selected: false, value: 'carrot' },
+        { group: 'Vegetables', label: 'Potato', selected: false, value: 'potato' }
+      ];
+      await listbox.updateComplete;
+
+      const items = listbox.items!,
+        optionItems = items.filter(
+          (item): item is Extract<ListboxItem<GroupedOption, string>, { option: GroupedOption }> =>
+            'option' in item
+        ),
+        groupItems = items.filter(item => !('option' in item));
+
+      expect(listbox.getFlattenedSetSize()).to.equal(4);
+      expect(optionItems.map(item => listbox.getFlattenedPosition(item))).to.deep.equal([
+        0, 1, 2, 3
+      ]);
+      expect(groupItems.map(item => listbox.getFlattenedPosition(item))).to.deep.equal([-1, -1]);
+    });
+
+    it('should resolve flattened position for payload items with same id but different object instance', async () => {
+      const listbox = await fixture<Listbox<string>>(html`<sl-listbox></sl-listbox>`),
+        items: Array<ListboxItem<string, string>> = [
+          { id: 'group-a', label: 'Group A' },
+          { id: 'opt-a', label: 'Option A', option: 'A', selected: false, value: 'A' },
+          { id: 'opt-b', label: 'Option B', option: 'B', selected: true, value: 'B' }
+        ];
+
+      listbox.items = items;
+      await listbox.updateComplete;
+      await waitForVirtualizer();
+
+      const payloadWithSameId: ListboxItem<string, string> = {
+        id: 'opt-b',
+        label: 'Option B (payload clone)',
+        option: 'B',
+        selected: false,
+        value: 'B'
+      };
+
+      expect(payloadWithSameId).not.to.equal(items[2]);
+      expect(listbox.getFlattenedPosition(payloadWithSameId)).to.equal(1);
+    });
+
+    it('should refresh flattened positions across options/items changes and after clearing items', async () => {
+      type SimpleOption = { label: string; value: string };
+
+      const listbox = await fixture<Listbox<SimpleOption, string>>(html`
+        <sl-listbox option-label-path="label" option-value-path="value"></sl-listbox>
+      `);
+
+      listbox.options = [
+        { label: 'One', value: 'one' },
+        { label: 'Two', value: 'two' }
+      ];
+      await listbox.updateComplete;
+      await waitForVirtualizer();
+
+      const firstOptionItems = listbox.items!.filter(
+          (item): item is Extract<ListboxItem<SimpleOption, string>, { option: SimpleOption }> =>
+            'option' in item
+        ),
+        firstPayload = { ...firstOptionItems[0] };
+
+      expect(listbox.getFlattenedSetSize()).to.equal(2);
+      expect(listbox.getFlattenedPosition(firstPayload)).to.equal(0);
+
+      listbox.options = [{ label: 'Three', value: 'three' }];
+      await listbox.updateComplete;
+      await waitForVirtualizer();
+
+      const secondOptionItems = listbox.items!.filter(
+        (item): item is Extract<ListboxItem<SimpleOption, string>, { option: SimpleOption }> =>
+          'option' in item
+      );
+
+      expect(listbox.getFlattenedSetSize()).to.equal(1);
+      expect(listbox.getFlattenedPosition(secondOptionItems[0])).to.equal(0);
+      expect(listbox.getFlattenedPosition(firstPayload)).to.equal(-1);
+
+      listbox.items = [
+        { id: 'manual-group', label: 'Manual Group' },
+        {
+          id: 'manual-opt-1',
+          label: 'Manual One',
+          option: { label: 'M1', value: 'm1' },
+          value: 'm1'
+        },
+        {
+          id: 'manual-opt-2',
+          label: 'Manual Two',
+          option: { label: 'M2', value: 'm2' },
+          value: 'm2'
+        }
+      ];
+      await listbox.updateComplete;
+      await waitForVirtualizer();
+
+      const manualPayload: ListboxItem<SimpleOption, string> = {
+        id: 'manual-opt-2',
+        label: 'Manual Two clone',
+        option: { label: 'M2', value: 'm2' },
+        value: 'm2'
+      };
+
+      expect(listbox.getFlattenedSetSize()).to.equal(2);
+      expect(listbox.getFlattenedPosition(manualPayload)).to.equal(1);
+
+      listbox.items = undefined;
+      await listbox.updateComplete;
+      await waitForVirtualizer();
+
+      expect(listbox.getFlattenedSetSize()).to.equal(0);
+      expect(listbox.getFlattenedPosition(manualPayload)).to.equal(-1);
+    });
+  });
 });

--- a/packages/components/listbox/src/listbox.spec.ts
+++ b/packages/components/listbox/src/listbox.spec.ts
@@ -422,5 +422,33 @@ describe('sl-listbox', () => {
       expect(listbox.getFlattenedSetSize()).to.equal(0);
       expect(listbox.getFlattenedPosition(manualPayload)).to.equal(-1);
     });
+
+    it('should refresh flattened cache immediately when items is replaced', async () => {
+      const listbox = await fixture<Listbox<string, string>>(html`<sl-listbox></sl-listbox>`);
+
+      listbox.items = [
+        { id: 'initial-opt-1', label: 'Initial One', option: 'one', value: 'one' },
+        { id: 'initial-opt-2', label: 'Initial Two', option: 'two', value: 'two' }
+      ];
+      await listbox.updateComplete;
+
+      expect(listbox.getFlattenedSetSize()).to.equal(2);
+
+      listbox.items = [
+        { id: 'replacement-group', label: 'Replacement Group' },
+        { id: 'replacement-opt-1', label: 'Replacement One', option: 'one', value: 'one' }
+      ];
+      await listbox.updateComplete;
+
+      const replacementPayload: ListboxItem<string, string> = {
+        id: 'replacement-opt-1',
+        label: 'Replacement One payload',
+        option: 'one',
+        value: 'one'
+      };
+
+      expect(listbox.getFlattenedPosition(replacementPayload)).to.equal(0);
+      expect(listbox.getFlattenedSetSize()).to.equal(1);
+    });
   });
 });

--- a/packages/components/listbox/src/listbox.spec.ts
+++ b/packages/components/listbox/src/listbox.spec.ts
@@ -113,4 +113,49 @@ describe('sl-listbox', () => {
       );
     });
   });
+
+  describe('slotted options accessibility', () => {
+    it('should derive grouped option aria-label from nested slotted content', async () => {
+      el = await fixture(html`
+        <sl-listbox>
+          <sl-option-group label="Group">
+            <sl-option><span>Label</span></sl-option>
+          </sl-option-group>
+        </sl-listbox>
+      `);
+      await el.updateComplete;
+
+      const option = el.querySelector<Option>('sl-option');
+
+      expect(option).to.exist;
+      expect(option).to.have.attribute('aria-label', 'Label (Group)');
+    });
+
+    it('should clear stale aria-label when option moves out of a group', async () => {
+      const listbox = await fixture<Listbox>(html`
+        <sl-listbox>
+          <sl-option-group label="Group">
+            <sl-option id="opt1">Option 1</sl-option>
+          </sl-option-group>
+          <div id="container"></div>
+        </sl-listbox>
+      `);
+      await listbox.updateComplete;
+
+      const option = listbox.querySelector<Option>('#opt1')!;
+      const container = listbox.querySelector<HTMLElement>('#container')!;
+
+      // Initially in group, should have generated aria-label and marker
+      expect(option).to.have.attribute('aria-label', 'Option 1 (Group)');
+      expect(option).to.have.attribute('data-generated-aria-label', 'true');
+
+      // Move option out of group and re-apply accessibility (public API)
+      container.appendChild(option);
+      await listbox.updateComplete;
+      listbox.applyFlattenedOptionAccessibility([option]);
+
+      // aria-label should be cleared since option is no longer in a group
+      expect(option).not.to.have.attribute('aria-label');
+    });
+  });
 });

--- a/packages/components/listbox/src/listbox.spec.ts
+++ b/packages/components/listbox/src/listbox.spec.ts
@@ -13,6 +13,13 @@ const waitForVirtualizer = async (): Promise<void> => {
   await waitForNextFrame();
 };
 
+const getVirtualizer = (listbox: Listbox): Element | undefined =>
+  Array.from(listbox.children).find(
+    child =>
+      child.hasAttribute('data-virtual-list') ||
+      child.tagName.toLowerCase().includes('virtual-list')
+  );
+
 describe('sl-listbox', () => {
   let el: Listbox;
 
@@ -40,7 +47,7 @@ describe('sl-listbox', () => {
     }));
 
     const queryVirtualized = <T extends Element = Element>(selector: string): T[] => {
-      const virtualList = el.querySelector('sl-virtual-list');
+      const virtualList = getVirtualizer(el);
 
       return Array.from(virtualList?.shadowRoot?.querySelectorAll<T>(selector) ?? []);
     };
@@ -60,7 +67,7 @@ describe('sl-listbox', () => {
     });
 
     it('should render a virtualizer', () => {
-      expect(el.querySelector('sl-virtual-list')).to.exist;
+      expect(getVirtualizer(el)).to.exist;
     });
 
     it('should render options for each option', () => {
@@ -144,7 +151,7 @@ describe('sl-listbox', () => {
       await waitForVirtualizer();
 
       // Now should have the attribute
-      expect(unconstrained.querySelector('sl-virtual-list')).to.exist;
+      expect(getVirtualizer(unconstrained)).to.exist;
       expect(unconstrained.hasAttribute('data-virtual-unconstrained')).to.be.true;
 
       // Verify CSS fallback is applied

--- a/packages/components/listbox/src/listbox.ts
+++ b/packages/components/listbox/src/listbox.ts
@@ -77,6 +77,18 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
   /** The virtualizer instance when the `options` property is set. */
   #virtualizer?: LitVirtualizer;
 
+  /** Cache mapping each option item to its 0-based flattened position (excludes group headers). */
+  #flattenedPositionCache?: WeakMap<ListboxItem<T, U>, number>;
+
+  /** Cache version matching the items version when the cache was last built. */
+  #flattenedPositionCacheVersion = -1;
+
+  /** Monotonically increasing version, incremented whenever `items` changes. */
+  #itemsVersion = 0;
+
+  /** Total number of option items in the last built cache. */
+  #flattenedSetSize = 0;
+
   /**
    * The emphasis of the selected options in the listbox.
    *
@@ -164,6 +176,8 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
     }
 
     if (changes.has('items')) {
+      this.#itemsVersion++;
+
       if (this.items) {
         this.#virtualizer ||= this.shadowRoot!.createElement('lit-virtualizer');
         this.#virtualizer.items = (this.items ?? []) as unknown[];
@@ -214,6 +228,57 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
    */
   applyFlattenedOptionAccessibility(options: Option[]): void {
     this.#applyFlattenedOptionAccessibility(options);
+  }
+
+  /**
+   * Returns the 0-based flattened position of an option item among all option items (group headers
+   * are excluded). Returns -1 if the item is a group header or is not in `items`.
+   *
+   * @internal Used by virtual-list consumers (e.g. combobox) so they don't need a duplicate cache.
+   */
+  getFlattenedPosition(item: ListboxItem<T, U>): number {
+    if (!this.items || !('option' in item)) return -1;
+
+    if (
+      this.#flattenedPositionCacheVersion !== this.#itemsVersion ||
+      !this.#flattenedPositionCache
+    ) {
+      this.#buildFlattenedPositionCache();
+    }
+
+    return this.#flattenedPositionCache!.get(item) ?? -1;
+  }
+
+  /**
+   * Returns the total number of option items (group headers excluded) in the current `items` array.
+   *
+   * @internal Companion to `getFlattenedPosition`.
+   */
+  getFlattenedSetSize(): number {
+    if (!this.items) return 0;
+
+    if (
+      this.#flattenedPositionCacheVersion !== this.#itemsVersion ||
+      !this.#flattenedPositionCache
+    ) {
+      this.#buildFlattenedPositionCache();
+    }
+
+    return this.#flattenedSetSize;
+  }
+
+  #buildFlattenedPositionCache(): void {
+    this.#flattenedPositionCache = new WeakMap<ListboxItem<T, U>, number>();
+    this.#flattenedPositionCacheVersion = this.#itemsVersion;
+
+    let position = 0;
+    (this.items ?? []).forEach(i => {
+      if ('option' in i) {
+        this.#flattenedPositionCache!.set(i, position++);
+      }
+    });
+
+    this.#flattenedSetSize = position;
   }
 
   #prepareOptions(options: T[]): Array<ListboxItem<T, U>> {
@@ -304,16 +369,14 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
       element.selected = item.selected;
       element.value = item.value;
 
-      // Calculate flattened position: only count options, not group headers
-      const allOptions = (this.items || []).filter((i): i is ListboxOption<T, U> => 'option' in i);
-      const flattenedPosition = allOptions.indexOf(item);
+      const flattenedPosition = this.getFlattenedPosition(item);
 
       if (flattenedPosition !== -1) {
         this.#applyOptionAccessibility(element, {
           group: item.group,
           label: item.label,
           position: flattenedPosition + 1,
-          setSize: allOptions.length,
+          setSize: this.getFlattenedSetSize(),
           selected: item.selected
         });
       }

--- a/packages/components/listbox/src/listbox.ts
+++ b/packages/components/listbox/src/listbox.ts
@@ -260,6 +260,23 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
       element.selected = item.selected;
       element.value = item.value;
 
+      // Calculate flattened position: only count options, not group headers
+      const allOptions = (this.items || []).filter((i): i is ListboxOption<T, U> => 'option' in i);
+      const flattenedPosition = allOptions.indexOf(item);
+
+      if (flattenedPosition !== -1) {
+        element.setAttribute('aria-posinset', (flattenedPosition + 1).toString());
+        element.setAttribute('aria-setsize', allOptions.length.toString());
+      }
+
+      // Ensure aria-selected is always set for Safari/VoiceOver compatibility
+      element.setAttribute('aria-selected', item.selected ? 'true' : 'false');
+
+      // Add group context to accessible name for Safari/VoiceOver compatibility
+      if (item.group) {
+        element.setAttribute('aria-label', `${item.label} (${item.group})`);
+      }
+
       return element;
     } else {
       const element = this.shadowRoot!.createElement('sl-option-group-header');

--- a/packages/components/listbox/src/listbox.ts
+++ b/packages/components/listbox/src/listbox.ts
@@ -157,6 +157,12 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
       this.#propagateEmphasis();
     }
 
+    // Keep slotted options normalized out of the box, even if consumers don't
+    // explicitly trigger listbox-specific slotchange timing.
+    if (!this.options && !this.items) {
+      this.#onSlotChange();
+    }
+
     if (changes.has('items')) {
       if (this.items) {
         this.#virtualizer ||= this.shadowRoot!.createElement('lit-virtualizer');
@@ -186,7 +192,7 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
   }
 
   override render(): TemplateResult {
-    return html`<slot @slotchange=${this.#propagateEmphasis}></slot>`;
+    return html`<slot @slotchange=${this.#onSlotChange}></slot>`;
   }
 
   scrollToIndex(index: number, options?: ScrollIntoViewOptions): void {
@@ -198,6 +204,16 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
         .at(index)
         ?.scrollIntoView(options);
     }
+  }
+
+  /**
+   * Applies flattened accessibility metadata to options.
+   *
+   * Kept public so composed consumers can trigger deterministic timing when options are projected
+   * through nested slots.
+   */
+  applyFlattenedOptionAccessibility(options: Option[]): void {
+    this.#applyFlattenedOptionAccessibility(options);
   }
 
   #prepareOptions(options: T[]): Array<ListboxItem<T, U>> {
@@ -251,6 +267,34 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
     });
   }
 
+  #onSlotChange(): void {
+    this.#propagateEmphasis();
+
+    const options = Array.from(this.querySelectorAll('sl-option')).filter(
+      (el): el is Option => el instanceof Option
+    );
+
+    this.#applyFlattenedOptionAccessibility(options);
+  }
+
+  #applyFlattenedOptionAccessibility(options: Option[]): void {
+    const metadata = options.map(option => ({
+      group: option.closest<OptionGroup>('sl-option-group')?.label,
+      label: option.textContent?.trim() || '',
+      option
+    }));
+
+    metadata.forEach((item, index) => {
+      this.#applyOptionAccessibility(item.option, {
+        group: item.group,
+        label: item.label,
+        position: index + 1,
+        setSize: metadata.length,
+        selected: item.option.selected
+      });
+    });
+  }
+
   #renderItem(item: ListboxItem<T, U>, index: number): Element {
     if ('option' in item) {
       const element = this.shadowRoot!.createElement('sl-option');
@@ -265,16 +309,13 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
       const flattenedPosition = allOptions.indexOf(item);
 
       if (flattenedPosition !== -1) {
-        element.setAttribute('aria-posinset', (flattenedPosition + 1).toString());
-        element.setAttribute('aria-setsize', allOptions.length.toString());
-      }
-
-      // Ensure aria-selected is always set for Safari/VoiceOver compatibility
-      element.setAttribute('aria-selected', item.selected ? 'true' : 'false');
-
-      // Add group context to accessible name for Safari/VoiceOver compatibility
-      if (item.group) {
-        element.setAttribute('aria-label', `${item.label} (${item.group})`);
+        this.#applyOptionAccessibility(element, {
+          group: item.group,
+          label: item.label,
+          position: flattenedPosition + 1,
+          setSize: allOptions.length,
+          selected: item.selected
+        });
       }
 
       return element;
@@ -285,6 +326,31 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
       element.innerText = item.label;
 
       return element;
+    }
+  }
+
+  #applyOptionAccessibility(
+    option: Option,
+    {
+      group,
+      label,
+      position,
+      selected,
+      setSize
+    }: {
+      group?: string;
+      label: string;
+      position: number;
+      selected?: boolean;
+      setSize: number;
+    }
+  ): void {
+    option.setAttribute('aria-posinset', position.toString());
+    option.setAttribute('aria-setsize', setSize.toString());
+    option.setAttribute('aria-selected', Boolean(selected).toString());
+
+    if (group) {
+      option.setAttribute('aria-label', `${label} (${group})`);
     }
   }
 }

--- a/packages/components/listbox/src/listbox.ts
+++ b/packages/components/listbox/src/listbox.ts
@@ -77,8 +77,8 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
   /** The virtual list instance when the `options` or `items` property is set. */
   #virtualizer?: VirtualList<ListboxItem<T, U>>;
 
-  /** Cache mapping each option item to its 0-based flattened position (excludes group headers). */
-  #flattenedPositionCache?: WeakMap<ListboxItem<T, U>, number>;
+  /** Cache mapping each option id to its 0-based flattened position (excludes group headers). */
+  #flattenedPositionCache?: Map<string, number>;
 
   /** Cache version matching the items version when the cache was last built. */
   #flattenedPositionCacheVersion = -1;
@@ -88,6 +88,9 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
 
   /** Total number of option items in the last built cache. */
   #flattenedSetSize = 0;
+
+  /** Cache mapping items array index to flattened option position, or -1 for non-option rows. */
+  #flattenedIndexCache?: number[];
 
   /**
    * The emphasis of the selected options in the listbox.
@@ -167,16 +170,29 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
     ) {
       if (this.options) {
         this.items = this.#prepareOptions(this.options);
+        this.#itemsVersion++;
         // Update attribute after setting items
         this.#updateVirtualConstraintAttribute();
       } else if (changes.get('options')) {
         this.items = undefined;
+        this.#itemsVersion++;
+        this.#flattenedPositionCache = undefined;
+        this.#flattenedIndexCache = undefined;
+        this.#flattenedSetSize = 0;
         this.removeAttribute('data-virtual-unconstrained');
       }
     }
 
     // Also handle direct items assignment
     if (changes.has('items')) {
+      this.#itemsVersion++;
+
+      if (!this.items) {
+        this.#flattenedPositionCache = undefined;
+        this.#flattenedIndexCache = undefined;
+        this.#flattenedSetSize = 0;
+      }
+
       this.#updateVirtualConstraintAttribute();
     }
   }
@@ -353,7 +369,7 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
    * @internal Used by virtual-list consumers (e.g. combobox) so they don't need a duplicate cache.
    */
   getFlattenedPosition(item: ListboxItem<T, U>): number {
-    if (!this.items || !('option' in item)) return -1;
+    if (!this.items) return -1;
 
     if (
       this.#flattenedPositionCacheVersion !== this.#itemsVersion ||
@@ -362,7 +378,7 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
       this.#buildFlattenedPositionCache();
     }
 
-    return this.#flattenedPositionCache!.get(item) ?? -1;
+    return this.#flattenedPositionCache!.get(item.id) ?? -1;
   }
 
   /**
@@ -384,17 +400,37 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
   }
 
   #buildFlattenedPositionCache(): void {
-    this.#flattenedPositionCache = new WeakMap<ListboxItem<T, U>, number>();
+    this.#flattenedPositionCache = new Map<string, number>();
     this.#flattenedPositionCacheVersion = this.#itemsVersion;
 
+    const items = this.items ?? [];
+    this.#flattenedIndexCache = new Array(items.length).fill(-1);
+
     let position = 0;
-    (this.items ?? []).forEach(i => {
+    items.forEach((i, index) => {
       if ('option' in i) {
-        this.#flattenedPositionCache!.set(i, position++);
+        this.#flattenedPositionCache!.set(i.id, position++);
+        this.#flattenedIndexCache![index] = position - 1;
       }
     });
 
     this.#flattenedSetSize = position;
+  }
+
+  #getFlattenedPositionByIndex(index: number): number {
+    if (!this.items || index < 0 || index >= this.items.length) {
+      return -1;
+    }
+
+    if (
+      this.#flattenedPositionCacheVersion !== this.#itemsVersion ||
+      !this.#flattenedPositionCache ||
+      !this.#flattenedIndexCache
+    ) {
+      this.#buildFlattenedPositionCache();
+    }
+
+    return this.#flattenedIndexCache![index] ?? -1;
   }
 
   #prepareOptions(options: T[]): Array<ListboxItem<T, U>> {
@@ -520,11 +556,16 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
 
       const flattenedPosition = this.getFlattenedPosition(item);
 
-      if (flattenedPosition !== -1) {
+      // Virtual-list integrations may render from an item payload that does not round-trip through
+      // the exact cache lookup path. Fall back to an O(1) index-based lookup.
+      const resolvedFlattenedPosition =
+        flattenedPosition !== -1 ? flattenedPosition : this.#getFlattenedPositionByIndex(index);
+
+      if (resolvedFlattenedPosition !== -1) {
         this.#applyOptionAccessibility(element, {
           group: item.group,
           label: item.label,
-          position: flattenedPosition + 1,
+          position: resolvedFlattenedPosition + 1,
           setSize: this.getFlattenedSetSize(),
           selected: item.selected
         });

--- a/packages/components/listbox/src/listbox.ts
+++ b/packages/components/listbox/src/listbox.ts
@@ -521,16 +521,16 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
     const processedOptions = new Set(metadata.map(m => m.option));
 
     this.querySelectorAll('sl-option').forEach(option => {
-      if (!processedOptions.has(option)) {
+      if (
+        !processedOptions.has(option) &&
+        option.getAttribute('data-generated-aria-label') === 'true'
+      ) {
         const currentGroup = option.closest<OptionGroup>('sl-option-group')?.label;
-        const hasGeneratedLabel =
-          option.hasAttribute('aria-label') &&
-          option.getAttribute('aria-label')!.includes('(') &&
-          option.getAttribute('aria-label')!.includes(')');
 
         // If option has a generated aria-label but no current group, it's stale
-        if (hasGeneratedLabel && !currentGroup) {
+        if (!currentGroup) {
           option.removeAttribute('aria-label');
+          option.removeAttribute('data-generated-aria-label');
         }
       }
     });

--- a/packages/components/listbox/src/listbox.ts
+++ b/packages/components/listbox/src/listbox.ts
@@ -234,6 +234,7 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
         const renderer = this.renderer;
 
         this.#virtualizer ||= this.shadowRoot!.createElement('sl-virtual-list');
+        this.#virtualizer.setAttribute('data-virtual-list', '');
         this.#virtualizer.items = this.items ?? [];
         this.#virtualizer.scrollMargin = 0;
         const gapValue = parseFloat(getComputedStyle(this).gap);
@@ -562,8 +563,13 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
 
     if (group && label.trim()) {
       option.setAttribute('aria-label', `${label} (${group})`);
+      option.setAttribute('data-generated-aria-label', 'true');
     } else {
-      option.removeAttribute('aria-label');
+      if (option.getAttribute('data-generated-aria-label') === 'true') {
+        option.removeAttribute('aria-label');
+      }
+
+      option.removeAttribute('data-generated-aria-label');
     }
   }
 }

--- a/packages/components/listbox/src/listbox.ts
+++ b/packages/components/listbox/src/listbox.ts
@@ -80,6 +80,9 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
   /** Cache mapping each option id to its 0-based flattened position (excludes group headers). */
   #flattenedPositionCache?: Map<string, number>;
 
+  /** Items reference used when the flattened cache was last built. */
+  #flattenedPositionCacheItems?: Array<ListboxItem<T, U>>;
+
   /** Cache version matching the items version when the cache was last built. */
   #flattenedPositionCacheVersion = -1;
 
@@ -177,6 +180,7 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
         this.items = undefined;
         this.#itemsVersion++;
         this.#flattenedPositionCache = undefined;
+        this.#flattenedPositionCacheItems = undefined;
         this.#flattenedIndexCache = undefined;
         this.#flattenedSetSize = 0;
         this.removeAttribute('data-virtual-unconstrained');
@@ -189,6 +193,7 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
 
       if (!this.items) {
         this.#flattenedPositionCache = undefined;
+        this.#flattenedPositionCacheItems = undefined;
         this.#flattenedIndexCache = undefined;
         this.#flattenedSetSize = 0;
       }
@@ -371,10 +376,7 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
   getFlattenedPosition(item: ListboxItem<T, U>): number {
     if (!this.items) return -1;
 
-    if (
-      this.#flattenedPositionCacheVersion !== this.#itemsVersion ||
-      !this.#flattenedPositionCache
-    ) {
+    if (this.#shouldRebuildFlattenedPositionCache()) {
       this.#buildFlattenedPositionCache();
     }
 
@@ -389,18 +391,24 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
   getFlattenedSetSize(): number {
     if (!this.items) return 0;
 
-    if (
-      this.#flattenedPositionCacheVersion !== this.#itemsVersion ||
-      !this.#flattenedPositionCache
-    ) {
+    if (this.#shouldRebuildFlattenedPositionCache()) {
       this.#buildFlattenedPositionCache();
     }
 
     return this.#flattenedSetSize;
   }
 
+  #shouldRebuildFlattenedPositionCache(): boolean {
+    return (
+      this.#flattenedPositionCacheVersion !== this.#itemsVersion ||
+      this.#flattenedPositionCacheItems !== this.items ||
+      !this.#flattenedPositionCache
+    );
+  }
+
   #buildFlattenedPositionCache(): void {
     this.#flattenedPositionCache = new Map<string, number>();
+    this.#flattenedPositionCacheItems = this.items;
     this.#flattenedPositionCacheVersion = this.#itemsVersion;
 
     const items = this.items ?? [];
@@ -422,11 +430,7 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
       return -1;
     }
 
-    if (
-      this.#flattenedPositionCacheVersion !== this.#itemsVersion ||
-      !this.#flattenedPositionCache ||
-      !this.#flattenedIndexCache
-    ) {
+    if (this.#shouldRebuildFlattenedPositionCache() || !this.#flattenedIndexCache) {
       this.#buildFlattenedPositionCache();
     }
 

--- a/packages/components/listbox/src/listbox.ts
+++ b/packages/components/listbox/src/listbox.ts
@@ -345,7 +345,7 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
   #applyFlattenedOptionAccessibility(options: Option[]): void {
     const metadata = options.map(option => ({
       group: option.closest<OptionGroup>('sl-option-group')?.label,
-      label: option.textContent?.trim() || '',
+      label: this.#getOptionLabel(option),
       option
     }));
 
@@ -358,6 +358,39 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
         selected: item.option.selected
       });
     });
+
+    // Clean up stale aria-label on any options that moved out of groups.
+    // This ensures that if an option was previously grouped and had a generated
+    // aria-label, but then moved out of the group, the stale label is removed.
+    const processedOptions = new Set(metadata.map(m => m.option));
+
+    this.querySelectorAll('sl-option').forEach(option => {
+      if (!processedOptions.has(option)) {
+        const currentGroup = option.closest<OptionGroup>('sl-option-group')?.label;
+        const hasGeneratedLabel =
+          option.hasAttribute('aria-label') &&
+          option.getAttribute('aria-label')!.includes('(') &&
+          option.getAttribute('aria-label')!.includes(')');
+
+        // If option has a generated aria-label but no current group, it's stale
+        if (hasGeneratedLabel && !currentGroup) {
+          option.removeAttribute('aria-label');
+        }
+      }
+    });
+  }
+
+  #getOptionLabel(option: Option): string {
+    const assignedNodes =
+      option.shadowRoot?.querySelector('slot')?.assignedNodes({ flatten: true }) ??
+      Array.from(option.childNodes);
+
+    const label = assignedNodes
+      .map(node => node.textContent || '')
+      .join('')
+      .trim();
+
+    return label || option.innerText?.trim() || option.textContent?.trim() || '';
   }
 
   #renderItem(item: ListboxItem<T, U>, index: number): Element {
@@ -412,8 +445,10 @@ export class Listbox<T = any, U = T> extends ScopedElementsMixin(LitElement) {
     option.setAttribute('aria-setsize', setSize.toString());
     option.setAttribute('aria-selected', Boolean(selected).toString());
 
-    if (group) {
+    if (group && label.trim()) {
       option.setAttribute('aria-label', `${label} (${group})`);
+    } else {
+      option.removeAttribute('aria-label');
     }
   }
 }

--- a/packages/components/listbox/src/option-group-header.ts
+++ b/packages/components/listbox/src/option-group-header.ts
@@ -19,6 +19,14 @@ export class OptionGroupHeader extends LitElement {
   /** Will render a horizontal divider when set. */
   @property({ type: Boolean, reflect: true }) divider?: boolean;
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    // Group headers are presentational and should be hidden from assistive technology
+    // to maintain a flat listbox structure for Safari/VoiceOver compatibility.
+    this.setAttribute('aria-hidden', 'true');
+  }
+
   override render(): TemplateResult {
     return html`
       ${this.divider ? html`<div class="divider"></div>` : nothing}

--- a/packages/components/listbox/src/option-group.spec.ts
+++ b/packages/components/listbox/src/option-group.spec.ts
@@ -53,6 +53,8 @@ describe('sl-option-group', () => {
 
   it('should consume and remove label when attribute is set later', async () => {
     el.setAttribute('label', 'Later label');
+    // Wait for MutationObserver to fire and set the property
+    await new Promise(resolve => setTimeout(resolve, 0));
     await el.updateComplete;
 
     expect(el).not.to.have.attribute('label');

--- a/packages/components/listbox/src/option-group.spec.ts
+++ b/packages/components/listbox/src/option-group.spec.ts
@@ -39,4 +39,24 @@ describe('sl-option-group', () => {
 
     expect(header).to.have.attribute('aria-hidden', 'true');
   });
+
+  it('should consume and remove the label attribute from markup', async () => {
+    const group = await fixture<OptionGroup>(
+      html`<sl-option-group label="Group label"></sl-option-group>`
+    );
+    await group.updateComplete;
+
+    expect(group).not.to.have.attribute('label');
+    expect(group.label).to.equal('Group label');
+    expect(group.renderRoot.querySelector('sl-option-group-header')).to.have.text('Group label');
+  });
+
+  it('should consume and remove label when attribute is set later', async () => {
+    el.setAttribute('label', 'Later label');
+    await el.updateComplete;
+
+    expect(el).not.to.have.attribute('label');
+    expect(el.label).to.equal('Later label');
+    expect(el.renderRoot.querySelector('sl-option-group-header')).to.have.text('Later label');
+  });
 });

--- a/packages/components/listbox/src/option-group.spec.ts
+++ b/packages/components/listbox/src/option-group.spec.ts
@@ -11,8 +11,9 @@ describe('sl-option-group', () => {
     el = await fixture(html`<sl-option-group></sl-option-group>`);
   });
 
-  it('should have a group role', () => {
-    expect(el).to.have.attribute('role', 'group');
+  it('should not have a group role for Safari/VoiceOver compatibility', () => {
+    // We removed role="group" because it breaks Safari/VoiceOver when inside role="listbox"
+    expect(el).not.to.have.attribute('role', 'group');
   });
 
   it('should not have a label by default', () => {
@@ -28,5 +29,14 @@ describe('sl-option-group', () => {
 
     expect(header).to.exist;
     expect(header).to.have.text('Group label');
+  });
+
+  it('should have aria-hidden="true" on the group header for Safari/VoiceOver compatibility', async () => {
+    el.label = 'Group label';
+    await el.updateComplete;
+
+    const header = el.renderRoot.querySelector('sl-option-group-header');
+
+    expect(header).to.have.attribute('aria-hidden', 'true');
   });
 });

--- a/packages/components/listbox/src/option-group.ts
+++ b/packages/components/listbox/src/option-group.ts
@@ -26,6 +26,22 @@ declare global {
  * @slot default - The option's label.
  */
 export class OptionGroup extends ScopedElementsMixin(LitElement) {
+  /** Watches for `label` attribute updates so we can consume and remove it from the host. */
+  #labelObserver = new MutationObserver(mutations => {
+    mutations.forEach(mutation => {
+      if (mutation.type !== 'attributes' || mutation.attributeName !== 'label') {
+        return;
+      }
+
+      const value = this.getAttribute('label');
+
+      if (value !== null) {
+        this.label = value;
+        this.removeAttribute('label');
+      }
+    });
+  });
+
   /** @internal */
   static get scopedElements(): ScopedElementsMap {
     return {
@@ -37,10 +53,19 @@ export class OptionGroup extends ScopedElementsMixin(LitElement) {
   static override styles: CSSResultGroup = styles;
 
   /** The optional label for the group. */
-  @property() label?: string;
+  @property({ attribute: false }) label?: string;
 
   override connectedCallback(): void {
     super.connectedCallback();
+
+    // Consume `label` from markup and remove it from the host element to avoid
+    // exposing group labels in Safari/VoiceOver's listbox parsing path.
+    if (this.hasAttribute('label')) {
+      this.label = this.getAttribute('label') || undefined;
+      this.removeAttribute('label');
+    }
+
+    this.#labelObserver.observe(this, { attributes: true, attributeFilter: ['label'] });
 
     // NOTE: We do NOT set role="group" here because it breaks Safari/VoiceOver.
     // When role="group" is inside role="listbox", Safari loses track of the
@@ -57,6 +82,12 @@ export class OptionGroup extends ScopedElementsMixin(LitElement) {
       }
     `;
     this.prepend(style);
+  }
+
+  override disconnectedCallback(): void {
+    this.#labelObserver.disconnect();
+
+    super.disconnectedCallback();
   }
 
   override updated(changes: PropertyValues<this>): void {

--- a/packages/components/listbox/src/option-group.ts
+++ b/packages/components/listbox/src/option-group.ts
@@ -2,14 +2,7 @@ import {
   type ScopedElementsMap,
   ScopedElementsMixin
 } from '@open-wc/scoped-elements/lit-element.js';
-import {
-  type CSSResultGroup,
-  LitElement,
-  type PropertyValues,
-  type TemplateResult,
-  html,
-  nothing
-} from 'lit';
+import { type CSSResultGroup, LitElement, type TemplateResult, html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 import { OptionGroupHeader } from './option-group-header.js';
 import styles from './option-group.scss.js';
@@ -88,13 +81,6 @@ export class OptionGroup extends ScopedElementsMixin(LitElement) {
     this.#labelObserver.disconnect();
 
     super.disconnectedCallback();
-  }
-
-  override updated(changes: PropertyValues<this>): void {
-    super.updated(changes);
-
-    // NOTE: We no longer set aria-label on the group element because we removed
-    // role="group". Group context is now conveyed through option labels instead.
   }
 
   override render(): TemplateResult {

--- a/packages/components/listbox/src/option-group.ts
+++ b/packages/components/listbox/src/option-group.ts
@@ -42,7 +42,10 @@ export class OptionGroup extends ScopedElementsMixin(LitElement) {
   override connectedCallback(): void {
     super.connectedCallback();
 
-    this.setAttribute('role', 'group');
+    // NOTE: We do NOT set role="group" here because it breaks Safari/VoiceOver.
+    // When role="group" is inside role="listbox", Safari loses track of the
+    // listbox/option relationship, causing incorrect item counts and aria-selected
+    // announcements. Instead, we flatten the structure and use aria-hidden headers.
 
     // This is a workaround, because :has is not working in Safari and Firefox with :host element as it works in Chrome
     const style = document.createElement('style');
@@ -59,13 +62,8 @@ export class OptionGroup extends ScopedElementsMixin(LitElement) {
   override updated(changes: PropertyValues<this>): void {
     super.updated(changes);
 
-    if (changes.has('label')) {
-      if (this.label) {
-        this.setAttribute('aria-label', this.label);
-      } else {
-        this.removeAttribute('aria-label');
-      }
-    }
+    // NOTE: We no longer set aria-label on the group element because we removed
+    // role="group". Group context is now conveyed through option labels instead.
   }
 
   override render(): TemplateResult {

--- a/packages/components/select/src/select.spec.ts
+++ b/packages/components/select/src/select.spec.ts
@@ -352,6 +352,67 @@ describe('sl-select', () => {
 
       expect(el.value).to.equal('5');
     });
+
+    it('should not have role="group" on option-group elements', () => {
+      const groups = el.querySelectorAll('sl-option-group');
+
+      groups.forEach(group => {
+        expect(group).not.to.have.attribute('role', 'group');
+      });
+    });
+
+    it('should have aria-hidden="true" on group headers', () => {
+      const groups = el.querySelectorAll('sl-option-group');
+
+      groups.forEach(group => {
+        const header = group.shadowRoot?.querySelector('sl-option-group-header');
+        expect(header).to.have.attribute('aria-hidden', 'true');
+      });
+    });
+
+    it('should have flattened aria-posinset and aria-setsize across all options', () => {
+      const options = el.options;
+
+      expect(options).to.have.lengthOf(4);
+
+      options.forEach((option, index) => {
+        expect(option).to.have.attribute('aria-posinset', (index + 1).toString());
+        expect(option).to.have.attribute('aria-setsize', '4');
+      });
+    });
+
+    it('should include group context in option accessible names', () => {
+      const options = el.options;
+
+      expect(options[0]).to.have.attribute('aria-label', 'Group 1, Option 1');
+      expect(options[1]).to.have.attribute('aria-label', 'Group 1, Option 2');
+      expect(options[2]).to.have.attribute('aria-label', 'Group 1, Option 3');
+      expect(options[3]).to.have.attribute('aria-label', 'Group 2, Option 4');
+    });
+
+    it('should have aria-selected="false" on all unselected options', () => {
+      const options = el.options;
+
+      options.forEach(option => {
+        expect(option).to.have.attribute('aria-selected', 'false');
+      });
+    });
+
+    it('should have aria-selected="true" only on the selected option', async () => {
+      button.focus();
+      await userEvent.keyboard('{ArrowDown}');
+      await el.updateComplete;
+
+      await userEvent.keyboard('{Enter}');
+      await el.updateComplete;
+
+      const options = el.options;
+
+      expect(options[0]).to.have.attribute('aria-selected', 'true');
+      expect(options[1]).to.have.attribute('aria-selected', 'false');
+      expect(options[2]).to.have.attribute('aria-selected', 'false');
+      expect(options[3]).to.have.attribute('aria-selected', 'false');
+    });
   });
 
   describe('disabled', () => {

--- a/packages/components/select/src/select.spec.ts
+++ b/packages/components/select/src/select.spec.ts
@@ -384,10 +384,10 @@ describe('sl-select', () => {
     it('should include group context in option accessible names', () => {
       const options = el.options;
 
-      expect(options[0]).to.have.attribute('aria-label', 'Group 1, Option 1');
-      expect(options[1]).to.have.attribute('aria-label', 'Group 1, Option 2');
-      expect(options[2]).to.have.attribute('aria-label', 'Group 1, Option 3');
-      expect(options[3]).to.have.attribute('aria-label', 'Group 2, Option 4');
+      expect(options[0]).to.have.attribute('aria-label', 'Option 1 (Group 1)');
+      expect(options[1]).to.have.attribute('aria-label', 'Option 2 (Group 1)');
+      expect(options[2]).to.have.attribute('aria-label', 'Option 3 (Group 1)');
+      expect(options[3]).to.have.attribute('aria-label', 'Option 4 (Group 2)');
     });
 
     it('should have aria-selected="false" on all unselected options', () => {

--- a/packages/components/select/src/select.ts
+++ b/packages/components/select/src/select.ts
@@ -632,22 +632,7 @@ export class Select<T = any> extends ObserveAttributesMixin(
   #onSlotchange(): void {
     this.#verifyRegisteredListboxElements();
 
-    // Update all options with flattened accessibility attributes
-    this.options.forEach((option, flattenedIndex) => {
-      // Ensure aria-selected is always set for Safari/VoiceOver compatibility
-      option.setAttribute('aria-selected', 'false');
-
-      // Set flattened position in the listbox
-      option.setAttribute('aria-posinset', (flattenedIndex + 1).toString());
-      option.setAttribute('aria-setsize', this.options.length.toString());
-
-      // Add group context to accessible name for Safari/VoiceOver compatibility
-      const group = option.closest('sl-option-group');
-      if (group?.label) {
-        const label = option.textContent?.trim() || '';
-        option.setAttribute('aria-label', `${group.label}, ${label}`);
-      }
-    });
+    this.listbox?.applyFlattenedOptionAccessibility(this.options);
 
     if (this.value !== undefined && this.value !== null) {
       this.#setSelectedOption(

--- a/packages/components/select/src/select.ts
+++ b/packages/components/select/src/select.ts
@@ -632,7 +632,22 @@ export class Select<T = any> extends ObserveAttributesMixin(
   #onSlotchange(): void {
     this.#verifyRegisteredListboxElements();
 
-    this.options.forEach(option => option.setAttribute('aria-selected', 'false'));
+    // Update all options with flattened accessibility attributes
+    this.options.forEach((option, flattenedIndex) => {
+      // Ensure aria-selected is always set for Safari/VoiceOver compatibility
+      option.setAttribute('aria-selected', 'false');
+
+      // Set flattened position in the listbox
+      option.setAttribute('aria-posinset', (flattenedIndex + 1).toString());
+      option.setAttribute('aria-setsize', this.options.length.toString());
+
+      // Add group context to accessible name for Safari/VoiceOver compatibility
+      const group = option.closest('sl-option-group');
+      if (group?.label) {
+        const label = option.textContent?.trim() || '';
+        option.setAttribute('aria-label', `${group.label}, ${label}`);
+      }
+    });
 
     if (this.value !== undefined && this.value !== null) {
       this.#setSelectedOption(


### PR DESCRIPTION
This pull request focuses on improving accessibility for grouped options in `sl-combobox`, `sl-listbox`, and `sl-select` components, specifically targeting better compatibility with Safari/VoiceOver. The main changes remove problematic ARIA roles, ensure correct ARIA attributes for all options, and enhance accessible names to include group context. Comprehensive tests were added to verify these behaviors.

**Accessibility improvements for grouped options:**

* Removed `role="group"` from `sl-option-group` elements and their headers, as it caused issues with Safari/VoiceOver, and stopped setting `aria-label` on group elements. Group context is now conveyed through option labels instead. [[1]](diffhunk://#diff-6446cabc9d47ba3a9d7048cf55039d0d54fb0d25fc5e2b76d4679608b3bf2b5fL45-R48) [[2]](diffhunk://#diff-6446cabc9d47ba3a9d7048cf55039d0d54fb0d25fc5e2b76d4679608b3bf2b5fL62-R66) [[3]](diffhunk://#diff-1a351f5ef58727e6c8b9726d848c7024211761c33e332a4af9caa642c8ec51fbL14-R16) [[4]](diffhunk://#diff-35008062a8c72c8035b697e5604e597bb52badfa6e2641d8d2e681f866495904L1464-R1464)
* Ensured all group headers (`sl-option-group-header`) are hidden from assistive technology by setting `aria-hidden="true"`. [[1]](diffhunk://#diff-426d6917b25c801270081cae29b17c66abb52aa11e39a64a0627d37509eb5c4bR22-R29) [[2]](diffhunk://#diff-1a351f5ef58727e6c8b9726d848c7024211761c33e332a4af9caa642c8ec51fbR33-R41)

**ARIA attribute management and accessible names:**

* All options now have `aria-selected`, `aria-posinset`, and `aria-setsize` attributes set, reflecting their flattened position in the list, for improved screen reader support. [[1]](diffhunk://#diff-8f9a70134090f1e8edb4e27b08e8b9849ea6c405ed1572a298eeb85a3e3fac7bL965-R983) [[2]](diffhunk://#diff-8f9a70134090f1e8edb4e27b08e8b9849ea6c405ed1572a298eeb85a3e3fac7bL1307-R1330) [[3]](diffhunk://#diff-be68c48472b6719d5792a4a1c740687494b76b240423cae8166ae3202ec5adb6R263-R279) [[4]](diffhunk://#diff-6ea74c255de79a708c4a9d9fa60e943de1c2496fb403f0ff334d34ea1b1edf1aL635-R650)
* Option accessible names now include group context (e.g., "Option 1 (Group 1)") for better clarity in assistive technology, especially Safari/VoiceOver. [[1]](diffhunk://#diff-8f9a70134090f1e8edb4e27b08e8b9849ea6c405ed1572a298eeb85a3e3fac7bL965-R983) [[2]](diffhunk://#diff-8f9a70134090f1e8edb4e27b08e8b9849ea6c405ed1572a298eeb85a3e3fac7bL1307-R1330) [[3]](diffhunk://#diff-be68c48472b6719d5792a4a1c740687494b76b240423cae8166ae3202ec5adb6R263-R279) [[4]](diffhunk://#diff-6ea74c255de79a708c4a9d9fa60e943de1c2496fb403f0ff334d34ea1b1edf1aL635-R650)

**Test coverage:**

* Added and updated tests for `sl-combobox`, `sl-listbox`, and `sl-select` to verify the absence of `role="group"`, presence of `aria-hidden="true"` on headers, correct ARIA attributes on options, and inclusion of group context in accessible names. [[1]](diffhunk://#diff-35008062a8c72c8035b697e5604e597bb52badfa6e2641d8d2e681f866495904R1481-R1646) [[2]](diffhunk://#diff-1a351f5ef58727e6c8b9726d848c7024211761c33e332a4af9caa642c8ec51fbL14-R16) [[3]](diffhunk://#diff-1a351f5ef58727e6c8b9726d848c7024211761c33e332a4af9caa642c8ec51fbR33-R41) [[4]](diffhunk://#diff-aac52560e55e707aa104e8546077fb0373ac4d26bbe54ab7fa78c658a0e96691R355-R415)

These changes collectively ensure that grouped options are presented in a way that is accessible and compatible with major screen readers, with a particular focus on Safari/VoiceOver.

Left = main, right = new:
https://storybook.sanomalearning.design/?path=/story/form-combobox-single--value

https://github.com/user-attachments/assets/bef44e45-7d59-4f39-80d3-78173d80c3a5

https://storybook.sanomalearning.design/?path=/story/form-combobox-single--selected

https://github.com/user-attachments/assets/8bf4358a-ef69-4cd7-b01a-c55aa1402395

https://storybook.sanomalearning.design/?path=/story/form-combobox-multiple--basic

https://github.com/user-attachments/assets/f89bd223-070b-4590-9ffa-5469769a19bc

https://storybook.sanomalearning.design/?path=/story/form-combobox-single--filter-results

https://github.com/user-attachments/assets/337304ee-4f67-4028-966e-d21e62babb3f


