### PR TITLE
Add a rolldown plugin for importing CSS through import attributes

### DIFF
--- a/.changeset/large-deer-brake.md
+++ b/.changeset/large-deer-brake.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/rolldown-plugin-css-sheet': patch
+---
+
+Add a Rolldown/Vite plugin that imports `.css` files as constructable `CSSStyleSheet` instances when imported with a `type: 'css'` import attribute

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "tools/eslint-config",
     "tools/eslint-plugin-slds",
     "tools/example-data",
+    "tools/rolldown-plugin-css-sheet",
     "tools/stylelint-config",
     "tools/theme-selector-plugin",
     "tools/vitest-browser-lit",

--- a/tools/rolldown-plugin-css-sheet/README.md
+++ b/tools/rolldown-plugin-css-sheet/README.md
@@ -1,0 +1,42 @@
+# @sl-design-system/rolldown-plugin-css-sheet
+
+This package provides a [Rolldown](https://rolldown.rs)/[Vite](https://vite.dev) plugin that imports `.css` files as constructable [`CSSStyleSheet`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet) instances when they are imported with a `type: 'css'` import attribute.
+
+This lets you author component styles in plain `.css` files and consume them directly as adoptable stylesheets, for example with Lit:
+
+```ts
+import styles from './my-component.css' with { type: 'css' };
+
+export class MyComponent extends LitElement {
+  static styles = styles;
+}
+```
+
+The CSS file is turned into a module whose default export is a `CSSStyleSheet`:
+
+```js
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(/* contents of the .css file */);
+export default sheet;
+```
+
+## Usage
+
+Add the plugin to your Rolldown, `tsdown`, or Vite configuration:
+
+```js
+import { importCssSheet } from '@sl-design-system/rolldown-plugin-css-sheet';
+
+export default {
+  plugins: [importCssSheet()]
+};
+```
+
+Only `.css` imports that use the `with { type: 'css' }` attribute are handled; all other CSS imports are left untouched.
+
+## How it works
+
+- It resolves each matching `.css` import to a stable virtual module via `resolveId`, using the bundler's own resolver so aliases and bare specifiers work.
+- The same file always maps to the same virtual module, so a stylesheet imported from multiple places is shared rather than duplicated.
+- The real file is registered with `addWatchFile`, so editing the `.css` triggers a rebuild/HMR in watch mode.
+- A `type: 'css'` import attribute is detected directly (Rolldown/`tsdown`); for Vite, the importing file is scanned as a fallback.

--- a/tools/rolldown-plugin-css-sheet/index.d.ts
+++ b/tools/rolldown-plugin-css-sheet/index.d.ts
@@ -1,0 +1,3 @@
+import { type Plugin } from 'rolldown';
+
+export declare function importCssSheet(): Plugin;

--- a/tools/rolldown-plugin-css-sheet/index.js
+++ b/tools/rolldown-plugin-css-sheet/index.js
@@ -1,0 +1,87 @@
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+
+const JS_EXTENSIONS = new Set(['.ts', '.mts', '.js', '.mjs']);
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeTemplateLiteral(str) {
+  return str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
+}
+
+export function importCssSheet() {
+  // Two-way maps so the same real file always gets the same virtual ID,
+  // and files with identical names get a numeric suffix to stay unique.
+  const virtualToReal = new Map();
+  const realToVirtual = new Map();
+
+  function getVirtualId(resolvedPath, cssSource) {
+    if (realToVirtual.has(resolvedPath)) return realToVirtual.get(resolvedPath);
+
+    const filename = cssSource
+      .split('/')
+      .pop()
+      .replace(/\.css$/, '.stylesheet');
+    let candidate = `\0virtual:${filename}`;
+    let n = 1;
+    while (virtualToReal.has(candidate)) candidate = `\0virtual:${filename}-${n++}`;
+
+    virtualToReal.set(candidate, resolvedPath);
+    realToVirtual.set(resolvedPath, candidate);
+    return candidate;
+  }
+
+  return {
+    name: '@sl-design-system/rolldown-plugin-css-sheet',
+    enforce: 'pre',
+
+    async resolveId(source, importer, opts) {
+      if (!source.endsWith('.css') || !importer) return null;
+
+      // Strip query string from importer path (Vite sometimes adds these)
+      const importerPath = importer.includes('?') ? importer.split('?')[0] : importer;
+      if (!JS_EXTENSIONS.has(extname(importerPath))) return null;
+
+      // Check import attributes directly (rolldown/tsdown)
+      let isCssSheet = opts.attributes?.['type'] === 'css';
+
+      // Fallback: read importer file to detect 'with { type: "css" }' (Vite)
+      if (!isCssSheet) {
+        try {
+          const importerContent = await readFile(importerPath, 'utf8');
+          const pattern = escapeRegex(source) + `['"] *with *\\{ *type: *['"]css['"]`;
+          isCssSheet = new RegExp(pattern).test(importerContent);
+        } catch {
+          return null;
+        }
+      }
+
+      if (!isCssSheet) return null;
+
+      const resolved = await this.resolve(source, importer, { skipSelf: true });
+      if (!resolved) return null;
+
+      return getVirtualId(resolved.id, source);
+    },
+
+    async load(id) {
+      const realId = virtualToReal.get(id);
+      if (realId == null) return null;
+
+      const content = await readFile(realId, 'utf8');
+      this.addWatchFile(realId);
+
+      const escaped = escapeTemplateLiteral(content);
+      const code = [
+        `const styles = \`${escaped}\`;`,
+        'const sheet = new CSSStyleSheet();',
+        'sheet.replaceSync(styles);',
+        'export default sheet;'
+      ].join('\n');
+
+      return { code, map: null };
+    }
+  };
+}

--- a/tools/rolldown-plugin-css-sheet/package.json
+++ b/tools/rolldown-plugin-css-sheet/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "Rolldown/Vite plugin that imports .css files (with { type: 'css' }) as constructable CSSStyleSheet instances",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/sl-design-system/components.git",
@@ -21,6 +24,9 @@
       "types": "./index.d.ts",
       "default": "./index.js"
     }
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "peerDependencies": {
     "vite": ">=8"

--- a/tools/rolldown-plugin-css-sheet/package.json
+++ b/tools/rolldown-plugin-css-sheet/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@sl-design-system/rolldown-plugin-css-sheet",
+  "version": "0.0.0",
+  "description": "Rolldown/Vite plugin that imports .css files (with { type: 'css' }) as constructable CSSStyleSheet instances",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sl-design-system/components.git",
+    "directory": "tools/rolldown-plugin-css-sheet"
+  },
+  "homepage": "https://sanomalearning.design",
+  "bugs": {
+    "url": "https://github.com/sl-design-system/components/issues"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "module": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
+  "peerDependencies": {
+    "vite": ">=8"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6241,6 +6241,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@sl-design-system/rolldown-plugin-css-sheet@workspace:tools/rolldown-plugin-css-sheet":
+  version: 0.0.0-use.local
+  resolution: "@sl-design-system/rolldown-plugin-css-sheet@workspace:tools/rolldown-plugin-css-sheet"
+  peerDependencies:
+    vite: ">=8"
+  languageName: unknown
+  linkType: soft
+
 "@sl-design-system/sanoma-learning@workspace:packages/themes/sanoma-learning":
   version: 0.0.0-use.local
   resolution: "@sl-design-system/sanoma-learning@workspace:packages/themes/sanoma-learning"


### PR DESCRIPTION
When using `import styles from './styles.css' with { type: 'css' };`, i've copy pasted multiple inlines plugins so far in various prjojects. This PR aims to solve it by creating a single, published plugin that everybody can use.