### PR TITLE
fix(combobox tag): remove fake combobox tag focus

### DIFF
--- a/.changeset/nine-singers-worry.md
+++ b/.changeset/nine-singers-worry.md
@@ -3,4 +3,4 @@
 '@sl-design-system/tag': patch
 ---
 
-Improved keyboard and screen reader behavior for removable tags in comboboxes and tag lists. Comboboxes no longer move fake focus from the input to selected tags with Left/Right arrow keys, while tag navigation remains available once focus is inside the tag list. The hidden tag-list navigation instructions are now `aria-hidden` while still being exposed through `aria-describedby`
+Improved keyboard and screen reader behavior for removable tags in comboboxes and tag lists. Comboboxes no longer move fake focus from the input to selected tags with Left/Right arrow keys, while tag navigation remains available once focus is inside the tag list. The hidden tag-list navigation instructions are now `aria-hidden` while still being exposed through `aria-describedby`.

--- a/.changeset/nine-singers-worry.md
+++ b/.changeset/nine-singers-worry.md
@@ -1,0 +1,6 @@
+---
+'@sl-design-system/combobox': patch
+'@sl-design-system/tag': patch
+---
+
+Improved keyboard and screen reader behavior for removable tags in comboboxes and tag lists. Comboboxes no longer move fake focus from the input to selected tags with Left/Right arrow keys, while tag navigation remains available once focus is inside the tag list. The hidden tag-list navigation instructions are now `aria-hidden` while still being exposed through `aria-describedby`

--- a/packages/components/combobox/src/combobox.scss
+++ b/packages/components/combobox/src/combobox.scss
@@ -56,10 +56,6 @@ sl-tag-list {
 sl-tag {
   outline-offset: 0;
   outline-width: 0;
-
-  &.focused {
-    outline: var(--sl-size-borderWidth-default) solid var(--sl-color-border-focused);
-  }
 }
 
 sl-icon {

--- a/packages/components/combobox/src/combobox.scss
+++ b/packages/components/combobox/src/combobox.scss
@@ -46,11 +46,15 @@ sl-text-field {
 }
 
 sl-tag-list {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   max-inline-size: 66%;
   min-inline-size: 0;
   position: relative;
   z-index: 1;
+}
+
+sl-tag-list[data-stacked-active] {
+  flex-grow: 1;
 }
 
 sl-tag {

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1266,8 +1266,7 @@ describe('sl-combobox', () => {
         el.style.maxInlineSize = '300px';
         el.value = ['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6'];
         await el.updateComplete;
-        await new Promise(resolve => setTimeout(resolve, 300));
-        await el.updateComplete;
+        await waitForNextFrame();
         await waitForNextFrame();
 
         const tagList = el.renderRoot.querySelector('sl-tag-list')!,
@@ -1328,8 +1327,7 @@ describe('sl-combobox', () => {
             count
           );
           await el.updateComplete;
-          await new Promise(resolve => setTimeout(resolve, 300));
-          await el.updateComplete;
+          await waitForNextFrame();
           await waitForNextFrame();
 
           const inputWidth = input.getBoundingClientRect().width,

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1238,6 +1238,28 @@ describe('sl-combobox', () => {
         expect(gap).to.be.lessThan(16);
       });
 
+      it('should keep one selected tag visible next to the stack counter in limited space', async () => {
+        el.style.maxInlineSize = '300px';
+        el.value = ['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6'];
+        await el.updateComplete;
+        await new Promise(resolve => setTimeout(resolve, 300));
+        await el.updateComplete;
+        await waitForNextFrame();
+
+        const tagList = el.renderRoot.querySelector('sl-tag-list')!,
+          stackTag = tagList.renderRoot.querySelector('.stack sl-tag'),
+          selectedTags = Array.from(el.renderRoot.querySelectorAll('sl-tag')),
+          visibleSelectedTags = selectedTags.filter(
+            tag => getComputedStyle(tag).display !== 'none'
+          );
+
+        expect(stackTag).to.exist;
+        expect(stackTag).to.have.trimmed.text(
+          `+${selectedTags.length - visibleSelectedTags.length}`
+        );
+        expect(visibleSelectedTags.length).to.be.greaterThan(0);
+      });
+
       it('should not flicker when selecting many items in a limited space', async () => {
         el.style.maxInlineSize = '300px';
 

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -942,6 +942,21 @@ describe('sl-combobox', () => {
         expect(options[1]).to.be.displayed;
         expect(options[2]).to.be.displayed;
       });
+
+      it('should ignore option navigation when filtering hides all options', async () => {
+        input.focus();
+        await userEvent.keyboard('Foo');
+        await el.updateComplete;
+
+        expect(el.items.filter(item => item.type === 'option' && item.visible)).to.have.lengthOf(0);
+
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.keyboard('{Home}');
+        await el.updateComplete;
+
+        expect(el.currentItem).to.be.undefined;
+        expect(input).not.to.have.attribute('aria-activedescendant');
+      });
     });
 
     describe('current item on open', () => {

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1247,37 +1247,27 @@ describe('sl-combobox', () => {
       });
 
       it('should keep the input width bounded while adding tags in limited space', async () => {
-        vi.useFakeTimers();
+        el.style.maxInlineSize = '300px';
+        const textField = el.renderRoot.querySelector('sl-text-field') as HTMLElement;
 
-        try {
-          el.style.maxInlineSize = '300px';
-          const textField = el.renderRoot.querySelector('sl-text-field') as HTMLElement;
+        for (const count of [1, 2, 3, 4, 5, 6]) {
+          el.value = ['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6'].slice(
+            0,
+            count
+          );
+          await el.updateComplete;
+          await new Promise(resolve => setTimeout(resolve, 300));
+          await el.updateComplete;
+          await waitForNextFrame();
 
-          for (const count of [1, 2, 3, 4, 5, 6]) {
-            el.value = [
-              'Option 1',
-              'Option 2',
-              'Option 3',
-              'Option 4',
-              'Option 5',
-              'Option 6'
-            ].slice(0, count);
-            await el.updateComplete;
-            await vi.advanceTimersByTimeAsync(300);
-            await el.updateComplete;
-            await waitForNextFrame();
+          const inputWidth = input.getBoundingClientRect().width,
+            fieldWidth = textField.getBoundingClientRect().width,
+            comboboxWidth = el.getBoundingClientRect().width;
 
-            const inputWidth = input.getBoundingClientRect().width,
-              fieldWidth = textField.getBoundingClientRect().width,
-              comboboxWidth = el.getBoundingClientRect().width;
-
-            expect(inputWidth).to.be.a('number');
-            expect(Number.isFinite(inputWidth)).to.be.true;
-            expect(inputWidth).to.be.at.most(fieldWidth + 0.5);
-            expect(comboboxWidth).to.be.at.most(300.5);
-          }
-        } finally {
-          vi.useRealTimers();
+          expect(inputWidth).to.be.a('number');
+          expect(Number.isFinite(inputWidth)).to.be.true;
+          expect(inputWidth).to.be.at.most(fieldWidth + 0.5);
+          expect(comboboxWidth).to.be.at.most(300.5);
         }
       });
 

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1272,16 +1272,69 @@ describe('sl-combobox', () => {
         expect(removable).to.be.true;
       });
 
-      it('should not show fake tag focus when navigating remove buttons', async () => {
-        const tags = Array.from(el.renderRoot.querySelectorAll('sl-tag')),
-          button = tags[0].renderRoot.querySelector('button');
+      it('should use the first removable tag button and input as combobox tab stops', async () => {
+        const wrapper = await fixture<HTMLDivElement>(html`
+            <div>
+              <button>Before</button>
+              <sl-combobox multiple .value=${['Option 1', 'Option 2']}>
+                <sl-listbox>
+                  <sl-option>Option 1</sl-option>
+                  <sl-option>Option 2</sl-option>
+                  <sl-option>Option 3</sl-option>
+                </sl-listbox>
+              </sl-combobox>
+              <button>After</button>
+            </div>
+          `),
+          combobox = wrapper.querySelector('sl-combobox')!,
+          input = combobox.querySelector<HTMLInputElement>('input[slot="input"]')!;
 
-        button?.dispatchEvent(
-          new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowRight' })
-        );
+        await combobox.updateComplete;
+        await waitForNextFrame();
+        await combobox.updateComplete;
+
+        const tags = Array.from(combobox.renderRoot.querySelectorAll('sl-tag')),
+          buttons = tags.map(tag => tag.renderRoot.querySelector('button'));
+
+        expect(tags).to.have.lengthOf(2);
+
+        wrapper.querySelector('button')!.focus();
+
+        await userEvent.tab();
+
+        expect(combobox.renderRoot.activeElement).to.equal(tags[0]);
+        expect(tags[0].shadowRoot?.activeElement).to.equal(buttons[0]);
+
+        await userEvent.keyboard('{ArrowRight}');
+
+        expect(combobox.renderRoot.activeElement).to.equal(tags[1]);
+        expect(tags[1].shadowRoot?.activeElement).to.equal(buttons[1]);
+
+        await userEvent.keyboard('{ArrowLeft}');
+
+        expect(combobox.renderRoot.activeElement).to.equal(tags[0]);
+        expect(tags[0].shadowRoot?.activeElement).to.equal(buttons[0]);
+
+        await userEvent.tab();
+
+        expect(document.activeElement).to.equal(input);
+
+        await userEvent.tab();
+
+        expect(document.activeElement).to.equal(wrapper.querySelector('button:last-child'));
+      });
+
+      it('should not show fake tag focus when navigating from the input with arrow keys', async () => {
+        const tags = Array.from(el.renderRoot.querySelectorAll('sl-tag'));
+
+        input.focus();
+        input.setSelectionRange(0, 0);
+
+        await userEvent.keyboard('{ArrowLeft}');
         await el.updateComplete;
 
         expect(tags.some(tag => tag.classList.contains('focused'))).to.be.false;
+        expect(document.activeElement).to.equal(input);
       });
 
       it('should stack options when there is limited space', async () => {

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1197,56 +1197,53 @@ describe('sl-combobox', () => {
       it('should keep the input caret next to the visible tags', async () => {
         await waitForNextFrame();
 
-const visibleTags = Array.from(el.renderRoot.querySelectorAll('sl-tag')).filter(
-    tag => getComputedStyle(tag).display !== 'none'
-  ),
-  lastTag = visibleTags.at(-1);
+        const visibleTags = Array.from(el.renderRoot.querySelectorAll('sl-tag')).filter(
+            tag => getComputedStyle(tag).display !== 'none'
+          ),
+          lastTag = visibleTags.at(-1);
 
-expect(lastTag, 'expected at least one visible tag').to.exist;
+        expect(lastTag, 'expected at least one visible tag').to.exist;
 
-const inputRect = input.getBoundingClientRect(),
-  lastTagRect = lastTag!.getBoundingClientRect(),
-  gap = inputRect.left - lastTagRect.right;
+        const inputRect = input.getBoundingClientRect(),
+          lastTagRect = lastTag!.getBoundingClientRect(),
+          gap = inputRect.left - lastTagRect.right;
 
         expect(gap).to.be.at.least(0);
         expect(gap).to.be.lessThan(16);
       });
 
       it('should not flicker when selecting many items in a limited space', async () => {
-        vi.useFakeTimers();
+        el.style.maxInlineSize = '300px';
 
-        try {
-          el.style.maxInlineSize = '300px';
+        // Select items that would trigger a collapse
+        el.value = ['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6'];
+        await el.updateComplete;
 
-          // Select items that would trigger a collapse
-          el.value = ['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5', 'Option 6'];
-          await el.updateComplete;
+        const getVisibilityState = () =>
+          Array.from(el.renderRoot.querySelectorAll('sl-tag')).map(
+            tag => tag.style.display !== 'none'
+          );
 
-          const getVisibilityState = () =>
-            Array.from(el.renderRoot.querySelectorAll('sl-tag')).map(
-              tag => tag.style.display !== 'none'
-            );
+        // Allow initial layout/stacking to settle. Use real timers because ResizeObserver delivery
+        // is browser-driven and can deadlock with fake timers in CI.
+        await new Promise(resolve => setTimeout(resolve, 300));
+        await el.updateComplete;
+        await waitForNextFrame();
 
-          // Allow initial layout/stacking to settle.
-          await vi.advanceTimersByTimeAsync(300);
-          await el.updateComplete;
-          await waitForNextFrame();
-          const firstState = getVisibilityState(),
-            firstInputWidth = input.getBoundingClientRect().width;
+        const firstState = getVisibilityState(),
+          firstInputWidth = input.getBoundingClientRect().width;
 
-          // Wait long enough to cover any potential oscillation cycles
-          await vi.advanceTimersByTimeAsync(500);
-          await el.updateComplete;
-          await waitForNextFrame();
-          const secondState = getVisibilityState(),
-            secondInputWidth = input.getBoundingClientRect().width;
+        // Wait long enough to cover any potential oscillation cycles.
+        await new Promise(resolve => setTimeout(resolve, 500));
+        await el.updateComplete;
+        await waitForNextFrame();
 
-          // If the component flickers, the visibility pattern of tags would change over time.
-          expect(secondState).to.deep.equal(firstState);
-          expect(secondInputWidth).to.be.closeTo(firstInputWidth, 0.5);
-        } finally {
-          vi.useRealTimers();
-        }
+        const secondState = getVisibilityState(),
+          secondInputWidth = input.getBoundingClientRect().width;
+
+        // If the component flickers, the visibility pattern of tags would change over time.
+        expect(secondState).to.deep.equal(firstState);
+        expect(secondInputWidth).to.be.closeTo(firstInputWidth, 0.5);
       });
 
       it('should keep the input width bounded while adding tags in limited space', async () => {

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1293,7 +1293,8 @@ describe('sl-combobox', () => {
         await waitForNextFrame();
         await combobox.updateComplete;
 
-        const tags = Array.from(combobox.renderRoot.querySelectorAll('sl-tag')),
+        const comboboxRoot = combobox.renderRoot as ShadowRoot,
+          tags = Array.from(comboboxRoot.querySelectorAll('sl-tag')),
           buttons = tags.map(tag => tag.renderRoot.querySelector('button'));
 
         expect(tags).to.have.lengthOf(2);
@@ -1302,17 +1303,17 @@ describe('sl-combobox', () => {
 
         await userEvent.tab();
 
-        expect(combobox.renderRoot.activeElement).to.equal(tags[0]);
+        expect(comboboxRoot.activeElement).to.equal(tags[0]);
         expect(tags[0].shadowRoot?.activeElement).to.equal(buttons[0]);
 
         await userEvent.keyboard('{ArrowRight}');
 
-        expect(combobox.renderRoot.activeElement).to.equal(tags[1]);
+        expect(comboboxRoot.activeElement).to.equal(tags[1]);
         expect(tags[1].shadowRoot?.activeElement).to.equal(buttons[1]);
 
         await userEvent.keyboard('{ArrowLeft}');
 
-        expect(combobox.renderRoot.activeElement).to.equal(tags[0]);
+        expect(comboboxRoot.activeElement).to.equal(tags[0]);
         expect(tags[0].shadowRoot?.activeElement).to.equal(buttons[0]);
 
         await userEvent.tab();

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1187,13 +1187,16 @@ describe('sl-combobox', () => {
       it('should keep the input caret next to the visible tags', async () => {
         await waitForNextFrame();
 
-        const visibleTags = Array.from(el.renderRoot.querySelectorAll('sl-tag')).filter(
-            tag => getComputedStyle(tag).display !== 'none'
-          ),
-          lastTag = visibleTags.at(-1)!,
-          inputRect = input.getBoundingClientRect(),
-          lastTagRect = lastTag.getBoundingClientRect(),
-          gap = inputRect.left - lastTagRect.right;
+const visibleTags = Array.from(el.renderRoot.querySelectorAll('sl-tag')).filter(
+    tag => getComputedStyle(tag).display !== 'none'
+  ),
+  lastTag = visibleTags.at(-1);
+
+expect(lastTag, 'expected at least one visible tag').to.exist;
+
+const inputRect = input.getBoundingClientRect(),
+  lastTagRect = lastTag!.getBoundingClientRect(),
+  gap = inputRect.left - lastTagRect.right;
 
         expect(gap).to.be.at.least(0);
         expect(gap).to.be.lessThan(16);

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1174,7 +1174,7 @@ describe('sl-combobox', () => {
         const styles = getComputedStyle(tagList);
         const hostStyles = getComputedStyle(el);
 
-        expect(styles.flexGrow).to.equal('1');
+        expect(styles.flexGrow).to.equal('0');
         expect(styles.flexShrink).to.equal('1');
         expect(styles.flexBasis).to.equal('auto');
         expect(styles.minInlineSize).to.equal('0px');
@@ -1182,6 +1182,21 @@ describe('sl-combobox', () => {
         expect(styles.position).to.equal('relative');
         expect(styles.zIndex).to.equal('1');
         expect(hostStyles.contain).to.include('inline-size');
+      });
+
+      it('should keep the input caret next to the visible tags', async () => {
+        await waitForNextFrame();
+
+        const visibleTags = Array.from(el.renderRoot.querySelectorAll('sl-tag')).filter(
+            tag => getComputedStyle(tag).display !== 'none'
+          ),
+          lastTag = visibleTags.at(-1)!,
+          inputRect = input.getBoundingClientRect(),
+          lastTagRect = lastTag.getBoundingClientRect(),
+          gap = inputRect.left - lastTagRect.right;
+
+        expect(gap).to.be.at.least(0);
+        expect(gap).to.be.lessThan(16);
       });
 
       it('should not flicker when selecting many items in a limited space', async () => {

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -36,6 +36,32 @@ describe('sl-combobox', () => {
     await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
   };
 
+  const waitForActiveElement = async (
+    root: Document | ShadowRoot,
+    expected: Element,
+    timeout = 1000
+  ): Promise<void> => {
+    const startedAt = Date.now();
+
+    while (root.activeElement !== expected && Date.now() - startedAt < timeout) {
+      await waitForNextMacrotask();
+      await waitForNextFrame();
+    }
+
+    expect(root.activeElement).to.equal(expected);
+  };
+
+  const waitForCondition = async (condition: () => boolean, timeout = 1000): Promise<void> => {
+    const startedAt = Date.now();
+
+    while (!condition() && Date.now() - startedAt < timeout) {
+      await waitForNextMacrotask();
+      await waitForNextFrame();
+    }
+
+    expect(condition()).to.be.true;
+  };
+
   describe('defaults', () => {
     beforeEach(async () => {
       el = await fixture(html`
@@ -1309,35 +1335,41 @@ describe('sl-combobox', () => {
         await combobox.updateComplete;
 
         const comboboxRoot = combobox.renderRoot as ShadowRoot,
+          tagList = comboboxRoot.querySelector('sl-tag-list')!,
           tags = Array.from(comboboxRoot.querySelectorAll('sl-tag')),
           buttons = tags.map(tag => tag.renderRoot.querySelector('button'));
 
         expect(tags).to.have.lengthOf(2);
+        await tagList.updateComplete;
+        await waitForCondition(() => tags[0].getAttribute('tabindex') === '0');
 
-        wrapper.querySelector('button')!.focus();
+        expect(tags[0]).to.have.attribute('tabindex', '0');
+        expect(tags[1]).to.have.attribute('tabindex', '-1');
+        expect(buttons[0]).to.have.attribute('tabindex', '0');
+        expect(buttons[1]).to.have.attribute('tabindex', '-1');
 
-        await userEvent.tab();
+        tags[0].focus();
 
-        expect(comboboxRoot.activeElement).to.equal(tags[0]);
-        expect(tags[0].shadowRoot?.activeElement).to.equal(buttons[0]);
+        await waitForActiveElement(comboboxRoot, tags[0]);
+        await waitForActiveElement(tags[0].shadowRoot!, buttons[0]!);
 
         await userEvent.keyboard('{ArrowRight}');
 
-        expect(comboboxRoot.activeElement).to.equal(tags[1]);
-        expect(tags[1].shadowRoot?.activeElement).to.equal(buttons[1]);
+        await waitForActiveElement(comboboxRoot, tags[1]);
+        await waitForActiveElement(tags[1].shadowRoot!, buttons[1]!);
 
         await userEvent.keyboard('{ArrowLeft}');
 
-        expect(comboboxRoot.activeElement).to.equal(tags[0]);
-        expect(tags[0].shadowRoot?.activeElement).to.equal(buttons[0]);
+        await waitForActiveElement(comboboxRoot, tags[0]);
+        await waitForActiveElement(tags[0].shadowRoot!, buttons[0]!);
 
         await userEvent.tab();
 
-        expect(document.activeElement).to.equal(input);
+        await waitForActiveElement(document, input);
 
         await userEvent.tab();
 
-        expect(document.activeElement).to.equal(wrapper.querySelector('button:last-child'));
+        await waitForActiveElement(document, wrapper.querySelector('button:last-child')!);
       });
 
       it('should not show fake tag focus when navigating from the input with arrow keys', async () => {

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -749,6 +749,10 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
       // Limit navigation to the visible options
       const items = this.items.filter(i => i.type === 'option' && i.visible);
 
+      if (items.length === 0) {
+        return;
+      }
+
       let delta = 0,
         index = -1;
 

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -570,6 +570,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     }
   }
 
+  /** @internal */
   override updateInternalValidity(): void {
     if (!this.validity.customError) {
       if (this.multiple) {

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -196,9 +196,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   /** When set, will filter the results in the listbox based on user input. */
   @property({ type: Boolean, attribute: 'filter-results' }) filterResults?: boolean;
 
-  /** @internal The currently (fake) focused tag. */
-  @state() focusedTag?: ComboboxItem<T, U>;
-
   /** @internal Emits when the component gains focus. */
   @event({ name: 'sl-focus' }) focusEvent!: EventEmitter<SlFocusEvent>;
 
@@ -504,7 +501,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         ${this.multiple && this.selectedItems.length
           ? html`
               <sl-tag-list
-                @focusin=${this.#onTagListFocusIn}
                 ?disabled=${this.disabled}
                 aria-label=${msg('Selected options', { id: 'sl.combobox.selectedOptions' })}
                 size=${ifDefined(this.size)}
@@ -517,8 +513,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
                     <sl-tag
                       @sl-remove=${(event: SlRemoveEvent) => this.#onRemove(item, event)}
                       ?disabled=${this.disabled}
-                      ?removable=${!this.disabled}
-                      class=${this.focusedTag === item ? 'focused' : ''}>
+                      ?removable=${!this.disabled}>
                       ${item.label}
                     </sl-tag>
                   `
@@ -712,7 +707,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
 
     const isSelectOnlySpace = !!this.selectOnly && event.key === ' ';
 
-    if ((event.key === 'Enter' || isSelectOnlySpace) && !this.focusedTag) {
+    if (event.key === 'Enter' || isSelectOnlySpace) {
       if (isSelectOnlySpace) {
         event.preventDefault();
       }
@@ -730,41 +725,13 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
           this.wrapper?.hidePopover();
         }
       }
-    } else if (['ArrowLeft', 'ArrowRight'].includes(event.key) && this.input.selectionStart === 0) {
-      if (this.focusedTag) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-
-      // Limit navigation to the visible tags
-      const min =
-        this.selectedItems.length -
-        Array.from(this.renderRoot.querySelectorAll('sl-tag')).filter(
-          tag => tag.style.display !== 'none'
-        ).length;
-
-      let index = this.focusedTag
-        ? this.selectedItems.indexOf(this.focusedTag)
-        : this.selectedItems.length;
-      index += event.key === 'ArrowLeft' ? -1 : 1;
-      index = Math.max(min, index);
-      index = Math.min(this.selectedItems.length, index);
-
-      if (index === this.selectedItems.length) {
-        this.focusedTag = undefined;
-      } else {
-        this.focusedTag = this.selectedItems[index];
-      }
-    } else if (event.key === 'Backspace' && this.focusedTag && this.input.selectionStart === 0) {
-      this.#onRemove(this.focusedTag);
-      this.focusedTag = undefined;
     } else if (
       !this.wrapper?.matches(':popover-open') &&
       ['ArrowDown', 'ArrowUp'].includes(event.key)
     ) {
       this.#popoverOpenedViaKeyboard = true;
       this.wrapper?.showPopover();
-    } else if (['ArrowDown', 'ArrowUp', 'End', 'Home'].includes(event.key) && !this.focusedTag) {
+    } else if (['ArrowDown', 'ArrowUp', 'End', 'Home'].includes(event.key)) {
       event.preventDefault();
       event.stopPropagation();
 
@@ -852,15 +819,18 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
     }
   }
 
-  #onTagListFocusIn(): void {
-    this.focusedTag = undefined;
+  #getVisibleRemovableTags(): Tag[] {
+    return Array.from(this.renderRoot.querySelectorAll<Tag>('sl-tag')).filter(
+      tag => tag.removable && tag.style.display !== 'none'
+    );
   }
 
   #getNextSelectedTagItem(item: ComboboxItem<T, U>): ComboboxItem<T, U> | undefined {
     const tags = Array.from(this.renderRoot.querySelectorAll<Tag>('sl-tag')),
+      visibleTags = new Set(this.#getVisibleRemovableTags()),
       visibleTagItems = tags
         .map((tag, index) => ({ item: this.selectedItems[index], tag }))
-        .filter(({ item, tag }) => item && tag.removable && tag.style.display !== 'none'),
+        .filter(({ item, tag }) => item && visibleTags.has(tag)),
       index = visibleTagItems.findIndex(({ item: tagItem }) => tagItem === item);
 
     return visibleTagItems[index + 1]?.item ?? visibleTagItems[index - 1]?.item;
@@ -869,10 +839,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   #focusSelectedTag(item?: ComboboxItem<T, U>): void {
     const tags = Array.from(this.renderRoot.querySelectorAll<Tag>('sl-tag')),
       tag = item ? tags[this.selectedItems.indexOf(item)] : undefined,
-      focusTarget =
-        tag && tag.style.display !== 'none'
-          ? tag
-          : tags.find(tag => tag.removable && tag.style.display !== 'none');
+      focusTarget = tag && tag.style.display !== 'none' ? tag : this.#getVisibleRemovableTags()[0];
 
     if (focusTarget) {
       focusTarget.focus();
@@ -930,9 +897,6 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   #onTextFieldBlur(event: SlBlurEvent): void {
     event.preventDefault();
     event.stopPropagation();
-
-    // Clear the focused tag before the focus moves out of the input
-    this.focusedTag = undefined;
 
     this.blurEvent.emit();
     this.updateState({ touched: true });

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -511,7 +511,10 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
                   item => item,
                   item => html`
                     <sl-tag
-                      @sl-remove=${(event: SlRemoveEvent) => this.#onRemove(item, event)}
+                      @sl-remove=${(event: SlRemoveEvent) => {
+                        event.stopPropagation();
+                        this.#onRemove(item, event);
+                      }}
                       ?disabled=${this.disabled}
                       ?removable=${!this.disabled}>
                       ${item.label}

--- a/packages/components/tag/src/tag-list.scss
+++ b/packages/components/tag/src/tag-list.scss
@@ -64,3 +64,13 @@
   flex-wrap: wrap;
   gap: var(--sl-size-050);
 }
+
+.visually-hidden {
+  block-size: 1px;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  inline-size: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+}

--- a/packages/components/tag/src/tag-list.scss
+++ b/packages/components/tag/src/tag-list.scss
@@ -64,13 +64,3 @@
   flex-wrap: wrap;
   gap: var(--sl-size-050);
 }
-
-.visually-hidden {
-  block-size: 1px;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  inline-size: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-}

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -245,14 +245,23 @@ describe('sl-tag-list', () => {
     it('should clear managed tabindexes when keyboard navigation is disabled', async () => {
       await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
 
-      const tags = Array.from(el.querySelectorAll('sl-tag'));
+      const tags = Array.from(el.querySelectorAll('sl-tag')),
+        buttons = tags.map(tag => tag.renderRoot.querySelector('button')!);
 
       expect(tags.map(tag => tag.getAttribute('tabindex'))).to.deep.equal(['0', '-1', '-1']);
+      expect(buttons.map(button => button.tabIndex)).to.deep.equal([0, -1, -1]);
 
       el.keyboardNavigation = false;
       await el.updateComplete;
+      await Promise.all(tags.map(tag => tag.updateComplete));
 
       expect(tags.map(tag => tag.hasAttribute('tabindex'))).to.deep.equal([false, false, false]);
+      expect(buttons.map(button => button.hasAttribute('tabindex'))).to.deep.equal([
+        false,
+        false,
+        false
+      ]);
+      expect(buttons.map(button => button.tabIndex)).to.deep.equal([0, 0, 0]);
     });
 
     it('should resync the navigation description when the list updates', async () => {

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -415,7 +415,7 @@ describe('sl-tag-list', () => {
       expect(visibleTag?.tabIndex).to.equal(-1);
     });
 
-    it('should keep the stack tag in the tab order when all regular tags are hidden', async () => {
+    it('should keep the stack tag in the tab order when only one regular tag is visible', async () => {
       el = await fixture(html`
         <sl-tag-list disabled stacked style="inline-size: 1px;">
           <sl-tag disabled removable>My very long label 1</sl-tag>
@@ -434,7 +434,8 @@ describe('sl-tag-list', () => {
       expect(stackTag).not.to.have.attribute('disabled');
       expect(stackTag).to.be.displayed;
       expect(stackTag.tabIndex).to.equal(0);
-      expect(visibleTags).to.have.length(0);
+      expect(visibleTags).to.have.length(1);
+      expect(visibleTags[0].tabIndex).to.equal(-1);
     });
 
     it('should not have a stack when there is enough space', async () => {
@@ -627,7 +628,7 @@ describe('sl-tag-list', () => {
       expect(el.stackSize).to.equal(2);
     });
 
-    it('should hide the last tag when it does not fit in the remaining width', async () => {
+    it('should keep the last tag visible even when it does not fit in the remaining width', async () => {
       el = await fixture(html`
         <sl-tag-list stacked style="gap: 10px; padding: 0; margin: 0; border: none;">
           <sl-tag style="inline-size: 100px;">Tag 1</sl-tag>
@@ -650,8 +651,8 @@ describe('sl-tag-list', () => {
       const tags = Array.from(el.querySelectorAll('sl-tag'));
       const visibility = tags.map(t => t.style.display);
 
-      expect(visibility).to.deep.equal(['none', 'none', 'none']);
-      expect(el.stackSize).to.equal(3);
+      expect(visibility).to.deep.equal(['none', 'none', '']);
+      expect(el.stackSize).to.equal(2);
     });
 
     it('should not overwrite cached stack width when the stack measurement is 0', async () => {

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -644,7 +644,7 @@ describe('sl-tag-list', () => {
       `);
 
       // Container is 140px, stack 40px, gap 10px => remaining width is 90px.
-      // Last tag is 100px, so it should be hidden.
+      // Last tag is 100px, but it remains visible so the stack counter is not shown alone.
       el.getBoundingClientRect = () => new DOMRect(0, 0, 140, 20);
       el.stack!.getBoundingClientRect = () => new DOMRect(0, 0, 40, 20);
 

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -488,10 +488,16 @@ describe('sl-tag-list', () => {
       const stack = el.renderRoot.querySelector('.stack') as HTMLElement;
       const unobserveSpy = vi.spyOn(ResizeObserver.prototype, 'unobserve');
 
+      await triggerVisibilityUpdate();
+      expect(el.stackSize).to.be.greaterThan(0);
+      expect(el).to.have.attribute('data-stacked-active');
+
       el.stacked = false;
       await el.updateComplete;
 
       expect(unobserveSpy.mock.calls.some(([target]) => target === stack)).to.be.true;
+      expect(el.stackSize).to.equal(0);
+      expect(el).not.to.have.attribute('data-stacked-active');
 
       unobserveSpy.mockRestore();
     });

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -153,7 +153,7 @@ describe('sl-tag-list', () => {
 
       expect(button).to.have.attribute('aria-describedby', 'navigation-description');
       expect(description).to.have.class('visually-hidden');
-      expect(description).not.to.have.attribute('aria-hidden');
+      expect(description).to.have.attribute('aria-hidden', 'true');
       expect(description).to.have.trimmed.text('Use arrow keys to move between removable tags.');
     });
 
@@ -195,6 +195,51 @@ describe('sl-tag-list', () => {
       await userEvent.tab();
 
       expect(document.activeElement).to.equal(after);
+    });
+
+    it('should allow tabbing through removable tag buttons when keyboard navigation is disabled', async () => {
+      el = await fixture(html`
+        <div>
+          <button>Before</button>
+          <sl-tag-list .keyboardNavigation=${false}>
+            <sl-tag removable>My label 1</sl-tag>
+            <sl-tag removable>My label 2</sl-tag>
+            <sl-tag removable>My label 3</sl-tag>
+          </sl-tag-list>
+          <button>After</button>
+        </div>
+      `).then(wrapper => wrapper.querySelector('sl-tag-list')!);
+
+      await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+      const wrapper = el.parentElement!,
+        before = wrapper.querySelector('button')!,
+        tags = Array.from(el.querySelectorAll('sl-tag')),
+        buttons = tags.map(tag => tag.renderRoot.querySelector('button')!);
+
+      expect(tags.map(tag => tag.hasAttribute('tabindex'))).to.deep.equal([false, false, false]);
+      expect(buttons.map(button => button.tabIndex)).to.deep.equal([0, 0, 0]);
+      expect(tags.map(tag => tag.navigationDescription)).to.deep.equal([
+        undefined,
+        undefined,
+        undefined
+      ]);
+
+      before.focus();
+      await userEvent.tab();
+
+      expect(document.activeElement).to.equal(tags[0]);
+      expect(tags[0].shadowRoot?.activeElement).to.equal(buttons[0]);
+
+      await userEvent.tab();
+
+      expect(document.activeElement).to.equal(tags[1]);
+      expect(tags[1].shadowRoot?.activeElement).to.equal(buttons[1]);
+
+      await userEvent.keyboard('{ArrowRight}');
+
+      expect(document.activeElement).to.equal(tags[1]);
+      expect(tags[1].shadowRoot?.activeElement).to.equal(buttons[1]);
     });
 
     it('should resync the navigation description when the list updates', async () => {

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -576,6 +576,7 @@ describe('sl-tag-list', () => {
 
       expect(visibility).to.deep.equal(['none', 'none', '']);
       expect(el.stackSize).to.equal(2);
+      expect(el).to.have.attribute('data-stacked-active');
     });
 
     it('should keep the last tag visible when it fits in the remaining width', async () => {
@@ -685,6 +686,7 @@ describe('sl-tag-list', () => {
 
       expect(tags.map(tag => tag.style.display)).to.deep.equal(['', '']);
       expect(el.stackSize).to.equal(0);
+      expect(el).not.to.have.attribute('data-stacked-active');
       expect(stack.style.display).to.equal('none');
     });
   });

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -242,6 +242,19 @@ describe('sl-tag-list', () => {
       expect(tags[1].shadowRoot?.activeElement).to.equal(buttons[1]);
     });
 
+    it('should clear managed tabindexes when keyboard navigation is disabled', async () => {
+      await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+      const tags = Array.from(el.querySelectorAll('sl-tag'));
+
+      expect(tags.map(tag => tag.getAttribute('tabindex'))).to.deep.equal(['0', '-1', '-1']);
+
+      el.keyboardNavigation = false;
+      await el.updateComplete;
+
+      expect(tags.map(tag => tag.hasAttribute('tabindex'))).to.deep.equal([false, false, false]);
+    });
+
     it('should resync the navigation description when the list updates', async () => {
       const tag = el.querySelector('sl-tag')!;
 

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -321,12 +321,16 @@ describe('sl-tag-list', () => {
 
     it('should have a tooltip for the stack', () => {
       const tag = el.renderRoot.querySelector('sl-tag'),
-        tooltip = el.renderRoot.querySelector('sl-tooltip');
+        tooltip = el.renderRoot.querySelector('sl-tooltip'),
+        description = el.renderRoot.querySelector('#hidden-elements-description');
 
       expect(tooltip).to.exist;
-      expect(tooltip?.id).to.equal(tag?.getAttribute('aria-labelledby'));
+      expect(tag).not.to.have.attribute('aria-labelledby');
+      expect(tag).to.have.attribute('aria-describedby', 'tooltip hidden-elements-description');
+      expect(description).to.have.class('visually-hidden');
 
-      const tagContent = tooltip?.textContent?.trim();
+      const tagContent = tooltip?.textContent?.trim(),
+        descriptionContent = description?.textContent?.trim();
 
       expect(tagContent).to.exist;
       expect(tagContent?.includes('List of hidden elements:')).to.be.true;
@@ -335,6 +339,7 @@ describe('sl-tag-list', () => {
           'My label 1, My label 2, My label 3, My label 4, My label 5, My label 6, My label 7'
         )
       ).to.be.true;
+      expect(descriptionContent).to.equal(tagContent);
     });
 
     it('should have a stack with a tag, which contains the stack size', () => {

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -322,11 +322,13 @@ describe('sl-tag-list', () => {
     it('should have a tooltip for the stack', () => {
       const tag = el.renderRoot.querySelector('sl-tag'),
         tooltip = el.renderRoot.querySelector('sl-tooltip'),
-        description = el.renderRoot.querySelector('#hidden-elements-description');
+        label = tag?.renderRoot.querySelector('[part="label"]'),
+        description = tag?.renderRoot.querySelector('#label-description');
 
       expect(tooltip).to.exist;
       expect(tag).not.to.have.attribute('aria-labelledby');
-      expect(tag).to.have.attribute('aria-describedby', 'tooltip hidden-elements-description');
+      expect(tag).to.have.attribute('aria-describedby', 'tooltip');
+      expect(label).to.have.attribute('aria-describedby', 'label-description');
       expect(description).to.have.class('visually-hidden');
 
       const tagContent = tooltip?.textContent?.trim(),

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -272,7 +272,8 @@ export class TagList extends ScopedElementsMixin(LitElement) {
   }
 
   override render(): TemplateResult {
-    const hiddenTagsDescription = this.stacked ? this.#getHiddenTagsDescription() : '';
+    const hiddenTagsDescription =
+      this.stacked && this.stackSize > 0 ? this.#getHiddenTagsDescription() : '';
 
     return html`
       ${this.stacked

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -262,6 +262,8 @@ export class TagList extends ScopedElementsMixin(LitElement) {
         this.#resetInitialVisibilityState();
       } else {
         this.#resetInitialVisibilityState();
+        this.stackSize = 0;
+        this.removeAttribute('data-stacked-active');
         this.tags.forEach(tag => (tag.style.display = ''));
       }
     }

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -529,8 +529,9 @@ export class TagList extends ScopedElementsMixin(LitElement) {
       for (let i = 0; i < this.tags.length; i++) {
         const isLastTag = i === this.tags.length - 1;
 
-        // Keep the last tag visible only when it truly fits, to prevent overflow-induced width jitter.
-        if (isLastTag && sizes[i] <= availableWidth + SUBPIXEL_BUFFER_PX) {
+        // Keep at least one actual tag visible next to the stack counter. Otherwise users only see
+        // the number of hidden tags without any selected value context.
+        if (isLastTag) {
           break;
         }
 

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -581,8 +581,15 @@ export class TagList extends ScopedElementsMixin(LitElement) {
   }
 
   #clearManagedTabindexes(): void {
-    this.tags.forEach(tag => tag.removeAttribute('tabindex'));
-    this.stackTag?.removeAttribute('tabindex');
+    this.tags.forEach(tag => {
+      tag.removeAttribute('tabindex');
+      tag.requestUpdate();
+    });
+
+    if (this.stackTag) {
+      this.stackTag.removeAttribute('tabindex');
+      this.stackTag.requestUpdate();
+    }
   }
 
   #syncRovingTabindexController(): void {

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -270,7 +270,7 @@ export class TagList extends ScopedElementsMixin(LitElement) {
   }
 
   override render(): TemplateResult {
-    const hiddenTagsDescription = this.#getHiddenTagsDescription();
+    const hiddenTagsDescription = this.stacked ? this.#getHiddenTagsDescription() : '';
 
     return html`
       ${this.stacked

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -277,15 +277,13 @@ export class TagList extends ScopedElementsMixin(LitElement) {
         ? html`
             <div class="stack">
               <sl-tag
-                aria-describedby="tooltip hidden-elements-description"
+                .labelDescription=${hiddenTagsDescription}
+                aria-describedby="tooltip"
                 role="listitem"
                 size=${ifDefined(this.size)}
                 variant=${ifDefined(this.variant)}>
                 +${this.stackSize}
               </sl-tag>
-              <span id="hidden-elements-description" class="visually-hidden"
-                >${hiddenTagsDescription}</span
-              >
               <sl-tooltip id="tooltip" position="bottom" max-width="300">
                 ${hiddenTagsDescription}
               </sl-tooltip>

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -270,23 +270,24 @@ export class TagList extends ScopedElementsMixin(LitElement) {
   }
 
   override render(): TemplateResult {
+    const hiddenTagsDescription = this.#getHiddenTagsDescription();
+
     return html`
       ${this.stacked
         ? html`
             <div class="stack">
               <sl-tag
-                aria-labelledby="tooltip"
+                aria-describedby="tooltip hidden-elements-description"
                 role="listitem"
                 size=${ifDefined(this.size)}
                 variant=${ifDefined(this.variant)}>
                 +${this.stackSize}
               </sl-tag>
+              <span id="hidden-elements-description" class="visually-hidden"
+                >${hiddenTagsDescription}</span
+              >
               <sl-tooltip id="tooltip" position="bottom" max-width="300">
-                ${msg('List of hidden elements', { id: 'sl.tag.listOfHiddenElements' })}:
-                ${this.tags
-                  .filter(tag => tag.style.display === 'none')
-                  .map(tag => tag.label)
-                  .join(', ')}
+                ${hiddenTagsDescription}
               </sl-tooltip>
             </div>
           `
@@ -295,6 +296,15 @@ export class TagList extends ScopedElementsMixin(LitElement) {
         <slot @slotchange=${this.#onSlotChange}></slot>
       </div>
     `;
+  }
+
+  #getHiddenTagsDescription(): string {
+    const labels = this.tags
+      .filter(tag => tag.style.display === 'none')
+      .map(tag => tag.label)
+      .join(', ');
+
+    return `${msg('List of hidden elements', { id: 'sl.tag.listOfHiddenElements' })}: ${labels}`;
   }
 
   #onRemove(event: SlRemoveEvent & { target: Tag }): void {

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -249,6 +249,10 @@ export class TagList extends ScopedElementsMixin(LitElement) {
 
     if (changes.has('keyboardNavigation')) {
       this.#rovingTabindexController.clearElementCache();
+
+      if (!this.keyboardNavigation) {
+        this.#clearManagedTabindexes();
+      }
     }
 
     this.#syncRovingTabindexController();
@@ -562,6 +566,11 @@ export class TagList extends ScopedElementsMixin(LitElement) {
   #clearRovingTabindexCache(): void {
     this.#rovingTabindexController.clearElementCache();
     this.#syncRovingTabindexController();
+  }
+
+  #clearManagedTabindexes(): void {
+    this.tags.forEach(tag => tag.removeAttribute('tabindex'));
+    this.stackTag?.removeAttribute('tabindex');
   }
 
   #syncRovingTabindexController(): void {

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -544,6 +544,7 @@ export class TagList extends ScopedElementsMixin(LitElement) {
       (acc, tag) => (tag.style.display === 'none' ? acc + 1 : acc),
       0
     );
+    this.toggleAttribute('data-stacked-active', this.stackSize > 0);
     this.stack.style.display = this.stackSize === 0 ? 'none' : '';
     // Ensure legacy decoration classes are not kept on existing elements (e.g. after HMR).
     this.stack.classList.remove('double', 'triple');

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -147,6 +147,10 @@ export class TagList extends ScopedElementsMixin(LitElement) {
       return index === -1 ? 0 : index;
     },
     elements: () => {
+      if (!this.keyboardNavigation) {
+        return [];
+      }
+
       const stackTags =
         this.stacked &&
         this.stackTag &&
@@ -165,6 +169,9 @@ export class TagList extends ScopedElementsMixin(LitElement) {
 
   /** Disables removable tags in the tag list. */
   @property({ type: Boolean }) disabled?: boolean;
+
+  /** @internal Whether the tag list manages keyboard navigation between removable tags. */
+  @property({ attribute: false }) keyboardNavigation = true;
 
   /**
    * The size of the tag-list (determines size of tags inside the tag-list).
@@ -239,6 +246,11 @@ export class TagList extends ScopedElementsMixin(LitElement) {
     super.updated(changes);
 
     this.#syncTags();
+
+    if (changes.has('keyboardNavigation')) {
+      this.#rovingTabindexController.clearElementCache();
+    }
+
     this.#syncRovingTabindexController();
 
     if (changes.has('stacked')) {
@@ -396,7 +408,8 @@ export class TagList extends ScopedElementsMixin(LitElement) {
     });
 
     this.tags.forEach(tag => {
-      tag.navigationDescription = tag.removable ? navigationDescription : undefined;
+      tag.navigationDescription =
+        this.keyboardNavigation && tag.removable ? navigationDescription : undefined;
       this.#syncTagDisabledState(tag);
       tag.size = this.size;
       tag.variant = this.variant;
@@ -551,7 +564,8 @@ export class TagList extends ScopedElementsMixin(LitElement) {
   }
 
   #syncRovingTabindexController(): void {
-    const hasManagedElements = this.#rovingTabindexController.elements.length > 0;
+    const hasManagedElements =
+      this.keyboardNavigation && this.#rovingTabindexController.elements.length > 0;
 
     if (hasManagedElements && !this.#rovingTabindexManaged) {
       this.#rovingTabindexController.manage();

--- a/packages/components/tag/src/tag.scss
+++ b/packages/components/tag/src/tag.scss
@@ -89,7 +89,7 @@ button {
 
   @media (prefers-reduced-motion: no-preference) {
     transition: 200ms ease-in-out;
-    transition-property: background, outline-color;
+    transition-property: background;
   }
 
   &:not([aria-disabled='true']):hover {

--- a/packages/components/tag/src/tag.ts
+++ b/packages/components/tag/src/tag.ts
@@ -190,7 +190,7 @@ export class Tag extends ScopedElementsMixin(LitElement) {
             </button>
             ${this.navigationDescription
               ? html`
-                  <span id="navigation-description" class="visually-hidden"
+                  <span id="navigation-description" class="visually-hidden" aria-hidden="true"
                     >${this.navigationDescription}</span
                   >
                 `

--- a/packages/components/tag/src/tag.ts
+++ b/packages/components/tag/src/tag.ts
@@ -82,6 +82,9 @@ export class Tag extends ScopedElementsMixin(LitElement) {
   /** @internal Clarifies tag list keyboard navigation for assistive technologies. */
   @state() navigationDescription?: string;
 
+  /** @internal Additional description for the tag label. */
+  @property({ attribute: false }) labelDescription?: string;
+
   /**
    * Whether the tag component is removable.
    *
@@ -162,6 +165,12 @@ export class Tag extends ScopedElementsMixin(LitElement) {
         this.navigationDescription ? 'navigation-description' : undefined
       ]
         .filter(Boolean)
+        .join(' '),
+      labelDescription = [
+        this.tooltip ? 'tooltip' : undefined,
+        this.labelDescription ? 'label-description' : undefined
+      ]
+        .filter(Boolean)
         .join(' ');
 
     return html`
@@ -169,11 +178,14 @@ export class Tag extends ScopedElementsMixin(LitElement) {
       <div
         @blur=${this.#onBlur}
         @focus=${this.#onFocus}
-        aria-describedby=${ifDefined(this.tooltip ? 'tooltip' : undefined)}
+        aria-describedby=${ifDefined(labelDescription || undefined)}
         part="label"
         tabindex=${ifDefined(labelTabIndex)}>
         <slot @slotchange=${this.#onSlotChange}></slot>
       </div>
+      ${this.labelDescription
+        ? html`<span id="label-description" class="visually-hidden">${this.labelDescription}</span>`
+        : nothing}
       ${this.removable
         ? html`
             <button

--- a/packages/components/tag/src/tag.ts
+++ b/packages/components/tag/src/tag.ts
@@ -166,7 +166,7 @@ export class Tag extends ScopedElementsMixin(LitElement) {
       ]
         .filter(Boolean)
         .join(' '),
-      labelDescription = [
+      labelDescribedBy = [
         this.tooltip ? 'tooltip' : undefined,
         this.labelDescription ? 'label-description' : undefined
       ]
@@ -178,7 +178,7 @@ export class Tag extends ScopedElementsMixin(LitElement) {
       <div
         @blur=${this.#onBlur}
         @focus=${this.#onFocus}
-        aria-describedby=${ifDefined(labelDescription || undefined)}
+        aria-describedby=${ifDefined(labelDescribedBy || undefined)}
         part="label"
         tabindex=${ifDefined(labelTabIndex)}>
         <slot @slotchange=${this.#onSlotChange}></slot>

--- a/packages/components/tooltip/src/tooltip-shared.spec.ts
+++ b/packages/components/tooltip/src/tooltip-shared.spec.ts
@@ -14,6 +14,21 @@ describe('sl-tooltip shared', () => {
   let tooltip: Tooltip;
 
   const waitFor = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+  const waitForPopoverToOpen = async (popover: HTMLElement, timeout = 1500): Promise<void> => {
+    const startedAt = Date.now();
+
+    while (!popover.matches(':popover-open') && Date.now() - startedAt < timeout) {
+      await waitFor(25);
+    }
+
+    if (!popover.matches(':popover-open')) {
+      const id = (popover as HTMLElement & { id?: string }).id;
+      throw new Error(
+        `Timed out after ${timeout}ms waiting for popover${id ? ` with id "${id}"` : ''} to open.`
+      );
+    }
+  };
+
   const waitForPopoverToClose = async (popover: HTMLElement, timeout = 1000): Promise<void> => {
     const startedAt = Date.now();
 
@@ -44,7 +59,7 @@ describe('sl-tooltip shared', () => {
   it('should not stay open when moving rapidly between buttons and then out', async () => {
     // 1. Hover first button
     buttons[0].dispatchEvent(new Event('pointerover', { bubbles: true }));
-    await waitFor(Tooltip.hoverShowDelay + 50);
+    await waitForPopoverToOpen(tooltip);
 
     expect(tooltip.matches(':popover-open')).to.be.true;
     expect(tooltip.anchorElement).to.equal(buttons[0]);
@@ -69,7 +84,7 @@ describe('sl-tooltip shared', () => {
   it('should hide even if multiple pointerover events are fired for different buttons', async () => {
     // Hover btn 1
     buttons[0].dispatchEvent(new Event('pointerover', { bubbles: true }));
-    await waitFor(Tooltip.hoverShowDelay + 50);
+    await waitForPopoverToOpen(tooltip);
 
     expect(tooltip.matches(':popover-open')).to.be.true;
 
@@ -90,7 +105,7 @@ describe('sl-tooltip shared', () => {
   it('should update anchor immediately when moving between buttons while open', async () => {
     // 1. Hover first button and wait for it to open
     buttons[0].dispatchEvent(new Event('pointerover', { bubbles: true }));
-    await waitFor(Tooltip.hoverShowDelay + 50);
+    await waitForPopoverToOpen(tooltip);
     expect(tooltip.matches(':popover-open')).to.be.true;
     expect(tooltip.anchorElement).to.equal(buttons[0]);
     const firstInsetInlineStart = tooltip.style.insetInlineStart;

--- a/website/src/categories/components/combobox/accessibility.md
+++ b/website/src/categories/components/combobox/accessibility.md
@@ -14,9 +14,9 @@ eleventyNavigation:
 
 |Command|Description|
 |-|-|
-|Tab|Moves the focus into/outside of the component. Use arrow down to open the drop down.|
+|Tab|Moves the focus into/outside of the component. In a multiple combobox with selected removable tags, focus moves between the first removable tag and the combobox input.|
 |Arrow up/down|Moves the active option 1 position up/down. The focus indicator loops, so when you are at the last option and press "down" it will focus on the first option.|
-|Arrow left/right|When the combobox supports multiple selection, moves the focus to the tag on the left/right, assuming the caret is already at the beginning of the input.|
+|Arrow left/right|When focus is on a removable tag in the tag list, moves focus to the previous/next removable tag. Arrow left/right does not move focus from the combobox input to selected tags.|
 |Home/End|Moves the active option to the first/last option.|
 |Enter|Toggles the active option.|
 |Backspace|When a tag is focused, removes the tag. This is effectively the same as toggling the selected option using the Enter key.|

--- a/website/src/categories/components/combobox/accessibility.md
+++ b/website/src/categories/components/combobox/accessibility.md
@@ -18,8 +18,9 @@ eleventyNavigation:
 |Arrow up/down|Moves the active option 1 position up/down. The focus indicator loops, so when you are at the last option and press "down" it will focus on the first option.|
 |Arrow left/right|When focus is on a removable tag in the tag list, moves focus to the previous/next removable tag. Arrow left/right does not move focus from the combobox input to selected tags.|
 |Home/End|Moves the active option to the first/last option.|
-|Enter|Toggles the active option.|
-|Backspace|When a tag is focused, removes the tag. This is effectively the same as toggling the selected option using the Enter key.|
+|Enter|Toggles the active option. When focus is on a selected tag's remove button, removes that tag.|
+|Space|When focus is on a selected tag's remove button, removes that tag.|
+|Backspace/Delete|When focus is on a selected tag's remove button, removes that tag.|
 
 {.ds-table .ds-table-align-top}
 

--- a/website/src/categories/components/combobox/accessibility.md
+++ b/website/src/categories/components/combobox/accessibility.md
@@ -14,7 +14,7 @@ eleventyNavigation:
 
 |Command|Description|
 |-|-|
-|Tab|Moves the focus into/outside of the component. In a multiple combobox with selected removable tags, focus moves between the remove button of the first selected removable tag and the combobox input.|
+|Tab|Moves the focus into/outside of the component. In a multiple combobox with selected removable tags, focus moves between the tag list and the combobox input. When the tag list is stacked, the tag list tab stop is the stack counter; otherwise it is the remove button of the first selected removable tag.|
 |Arrow up/down|Moves the active option 1 position up/down. The focus indicator loops, so when you are at the last option and press "down" it will focus on the first option.|
 |Arrow left/right|When focus is on a selected tag's remove button, moves focus to the remove button of the previous/next selected removable tag. Arrow left/right does not move focus from the combobox input to selected tags.|
 |Home/End|Moves the active option to the first/last option.|

--- a/website/src/categories/components/combobox/accessibility.md
+++ b/website/src/categories/components/combobox/accessibility.md
@@ -15,7 +15,7 @@ eleventyNavigation:
 |Command|Description|
 |-|-|
 |Tab|Moves the focus into/outside of the component. In a multiple combobox with selected removable tags, focus moves between the tag list and the combobox input. When the tag list is stacked, the tag list tab stop is the stack counter; otherwise it is the remove button of the first selected removable tag.|
-|Arrow up/down|Moves the active option 1 position up/down. The focus indicator loops, so when you are at the last option and press "down" it will focus on the first option.|
+|Arrow up/down|Moves the active option one position up/down. The focus indicator loops, so when you are at the last option and press "down" it will focus on the first option.|
 |Arrow left/right|When focus is on a selected tag's remove button, moves focus to the remove button of the previous/next selected removable tag. Arrow left/right does not move focus from the combobox input to selected tags.|
 |Home/End|Moves the active option to the first/last option.|
 |Enter|Toggles the active option. When focus is on a selected tag's remove button, removes that tag.|

--- a/website/src/categories/components/combobox/accessibility.md
+++ b/website/src/categories/components/combobox/accessibility.md
@@ -14,7 +14,7 @@ eleventyNavigation:
 
 |Command|Description|
 |-|-|
-|Tab|Moves the focus into/outside of the component. In a multiple combobox with selected removable tags, focus moves between the first removable tag and the combobox input.|
+|Tab|Moves the focus into/outside of the component. In a multiple combobox with selected removable tags, focus moves between the remove button of the first removable tag and the combobox input.|
 |Arrow up/down|Moves the active option 1 position up/down. The focus indicator loops, so when you are at the last option and press "down" it will focus on the first option.|
 |Arrow left/right|When focus is on a removable tag in the tag list, moves focus to the previous/next removable tag. Arrow left/right does not move focus from the combobox input to selected tags.|
 |Home/End|Moves the active option to the first/last option.|

--- a/website/src/categories/components/combobox/accessibility.md
+++ b/website/src/categories/components/combobox/accessibility.md
@@ -14,9 +14,9 @@ eleventyNavigation:
 
 |Command|Description|
 |-|-|
-|Tab|Moves the focus into/outside of the component. In a multiple combobox with selected removable tags, focus moves between the remove button of the first removable tag and the combobox input.|
+|Tab|Moves the focus into/outside of the component. In a multiple combobox with selected removable tags, focus moves between the remove button of the first selected removable tag and the combobox input.|
 |Arrow up/down|Moves the active option 1 position up/down. The focus indicator loops, so when you are at the last option and press "down" it will focus on the first option.|
-|Arrow left/right|When focus is on a removable tag in the tag list, moves focus to the previous/next removable tag. Arrow left/right does not move focus from the combobox input to selected tags.|
+|Arrow left/right|When focus is on a selected tag's remove button, moves focus to the remove button of the previous/next selected removable tag. Arrow left/right does not move focus from the combobox input to selected tags.|
 |Home/End|Moves the active option to the first/last option.|
 |Enter|Toggles the active option. When focus is on a selected tag's remove button, removes that tag.|
 |Space|When focus is on a selected tag's remove button, removes that tag.|


### PR DESCRIPTION
## What changed

This PR improves keyboard and screen reader behavior for removable tags used in comboboxes and tag lists.

### Combobox

- Removed the old fake tag focus state from `<sl-combobox>`.
- Removed the `.focused` styling that visually placed focus on the whole tag.
- Left/Right arrow keys no longer move fake focus from the combobox input to selected tags.
- Up/Down arrow keys from the combobox input remain available for navigating the option list.
- When selected tags are present, the combobox uses two tab stops:
  - the first focusable removable tag button
  - the combobox input
- Once focus is inside the tag list, arrow keys move between removable tag buttons.
- After removing a tag, focus moves to the next/previous visible removable tag button when available, otherwise back to the input.

### Tag / Tag list

- Added `aria-hidden="true"` to the hidden navigation description text while keeping it referenced through `aria-describedby`.
- Added an internal `keyboardNavigation` switch for `<sl-tag-list>` so roving keyboard navigation can be disabled where needed.
- Added tests for the updated combobox tab/arrow behavior and tag-list navigation description behavior.