### PR TITLE
fix(combobox): Fix combobox chevron animation in Safari

### DIFF
--- a/.changeset/breezy-singers-begin.md
+++ b/.changeset/breezy-singers-begin.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/combobox': patch
+---
+
+Fix Safari-specific combobox animations by rotating the chevron from the toggle button's `aria-expanded` state and avoiding unsupported `overlay` transition behavior when closing the listbox.

--- a/packages/components/combobox/src/combobox.scss
+++ b/packages/components/combobox/src/combobox.scss
@@ -40,7 +40,7 @@ sl-text-field {
     }
   }
 
-  &:has(+ :popover-open) sl-icon {
+  button[aria-expanded='true'] sl-icon {
     rotate: 180deg;
   }
 }
@@ -82,14 +82,17 @@ sl-icon {
   scrollbar-width: thin;
 
   @media (prefers-reduced-motion: no-preference) {
-    transition: 0.2s cubic-bezier(0.25, 0, 0.3, 1);
-    transition-behavior: allow-discrete;
+    transition: opacity 0.2s cubic-bezier(0.25, 0, 0.3, 1);
 
-    // Animating the overlay property is a workaround in Chromium for the wrapper
-    // to suddenly change position on fadeout, *even though* inset-block-start
-    // remains unchanged. This bug is also present in Safari, but that doesn't
-    // support the overlay property yet.
-    transition-property: display, opacity, overlay;
+    @supports (overlay: auto) {
+      transition: 0.2s cubic-bezier(0.25, 0, 0.3, 1);
+      transition-behavior: allow-discrete;
+
+      // Animating the overlay property is a workaround in Chromium for the wrapper
+      // to suddenly change position on fadeout, *even though* inset-block-start
+      // remains unchanged.
+      transition-property: display, opacity, overlay;
+    }
   }
 
   &:popover-open {

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -221,6 +221,16 @@ describe('sl-combobox', () => {
       expect(button).to.have.attribute('aria-expanded', 'true');
     });
 
+    it('should update aria-expanded on the button immediately when toggling the popover', () => {
+      const button = el.renderRoot.querySelector<HTMLElement>('button[slot="suffix"]');
+
+      button?.click();
+      expect(button).to.have.attribute('aria-expanded', 'true');
+
+      button?.click();
+      expect(button).to.have.attribute('aria-expanded', 'false');
+    });
+
     it('should switch aria-expanded back to "false" when the popover closes', async () => {
       const button = el.renderRoot.querySelector<HTMLElement>('button[slot="suffix"]');
 

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -589,6 +589,11 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   }
 
   #onBeforeToggle(event: ToggleEvent): void {
+    const expanded = event.newState === 'open',
+      button = this.renderRoot.querySelector<HTMLButtonElement>('button[slot="suffix"]');
+
+    button?.setAttribute('aria-expanded', expanded.toString());
+
     if (event.newState === 'open') {
       this.input.setAttribute('aria-expanded', 'true');
       this.wrapper!.style.inlineSize = `${this.getBoundingClientRect().width}px`;


### PR DESCRIPTION
## Summary

Fixes a Safari-specific combobox animation issue where the chevron icon did not rotate while the toggle button remained hovered after opening the listbox.

## Changes

- Updates the chevron rotation CSS to use the toggle button's `aria-expanded` state instead of detecting the adjacent open popover with `:has(+ :popover-open)`.
- Sets `aria-expanded` on the toggle button synchronously during `beforetoggle`, so the icon state updates immediately.
- Limits `display/overlay` popover transition behavior to browsers that support `overlay`, avoiding a Safari issue where the listbox briefly appears in the wrong position while closing.
- Adds a regression test for immediate `aria-expanded` updates on the toggle button.


### BEFORE

https://github.com/user-attachments/assets/cff9fa40-48f8-40ee-bde7-9456153547d6


### AFTER

https://github.com/user-attachments/assets/1e135573-ff45-4858-9415-748cf09b30e3



