### PR TITLE
fix(examples nested-forms): Fix nested custom form value binding example

### DIFF
--- a/examples/lit/src/nested-form/child-form.spec.ts
+++ b/examples/lit/src/nested-form/child-form.spec.ts
@@ -60,13 +60,13 @@ describe('example-child-form', () => {
 
     form.value = {
       user: {
-        firstName: 'Frans',
-        lastName: 'de Boer',
+        firstName: 'Captain',
+        lastName: 'Debug',
         address: {
-          postalCode: '8989AA',
-          houseNumber: '17',
-          street: 'Wiardaplantage',
-          city: 'Leeuwarden'
+          postalCode: '404OK',
+          houseNumber: '42',
+          street: 'Breakpoint Boulevard',
+          city: 'Stacktrace City'
         }
       }
     };
@@ -80,11 +80,11 @@ describe('example-child-form', () => {
       childTextField = (name: string): TextField | null =>
         childForm.renderRoot.querySelector<TextField>(`sl-text-field[name="${name}"]`);
 
-    await waitForFieldValue(parentTextField('user.firstName'), 'Frans');
-    await waitForFieldValue(parentTextField('user.lastName'), 'de Boer');
-    await waitForFieldValue(childTextField('postalCode'), '8989AA');
-    await waitForFieldValue(childTextField('houseNumber'), '17');
-    await waitForFieldValue(childTextField('street'), 'Wiardaplantage');
-    await waitForFieldValue(childTextField('city'), 'Leeuwarden');
+    await waitForFieldValue(parentTextField('user.firstName'), 'Captain');
+    await waitForFieldValue(parentTextField('user.lastName'), 'Debug');
+    await waitForFieldValue(childTextField('postalCode'), '404OK');
+    await waitForFieldValue(childTextField('houseNumber'), '42');
+    await waitForFieldValue(childTextField('street'), 'Breakpoint Boulevard');
+    await waitForFieldValue(childTextField('city'), 'Stacktrace City');
   });
 });

--- a/examples/lit/src/nested-form/child-form.spec.ts
+++ b/examples/lit/src/nested-form/child-form.spec.ts
@@ -50,10 +50,11 @@ describe('example-child-form', () => {
     `);
 
     await waitForControls(form, ['user.firstName', 'user.lastName', 'user.address']);
-    const childForm = form.querySelector<ChildForm>('example-child-form-test')!,
-      addressForm = childForm.renderRoot.querySelector<Form>('sl-form')!;
-    await waitForControls(addressForm, ['postalCode', 'houseNumber', 'street', 'city']);
+    const childForm = form.querySelector<ChildForm>('example-child-form-test')!;
     await childForm.updateComplete;
+
+    const addressForm = childForm.renderRoot.querySelector<Form>('sl-form')!;
+    await waitForControls(addressForm, ['postalCode', 'houseNumber', 'street', 'city']);
     await addressForm.updateComplete;
     await new Promise(requestAnimationFrame);
 

--- a/examples/lit/src/nested-form/child-form.spec.ts
+++ b/examples/lit/src/nested-form/child-form.spec.ts
@@ -1,0 +1,65 @@
+import { type Form } from '@sl-design-system/form';
+import '@sl-design-system/form/register.js';
+import { type TextField } from '@sl-design-system/text-field';
+import '@sl-design-system/text-field/register.js';
+import { fixture } from '@sl-design-system/vitest-browser-lit';
+import { html } from 'lit';
+import { describe, expect, it } from 'vitest';
+import { ChildForm } from './child-form.js';
+
+try {
+  customElements.define('example-child-form-test', ChildForm);
+} catch {
+  /* empty */
+}
+
+describe('example-child-form', () => {
+  it('should set child form values from the parent form value', async () => {
+    const form = await fixture<Form>(html`
+      <sl-form>
+        <sl-form-field label="First name">
+          <sl-text-field name="user.firstName" required></sl-text-field>
+        </sl-form-field>
+
+        <sl-form-field label="Last name">
+          <sl-text-field name="user.lastName" required></sl-text-field>
+        </sl-form-field>
+
+        <sl-form-field label="Address">
+          <example-child-form-test name="user.address" required></example-child-form-test>
+        </sl-form-field>
+      </sl-form>
+    `);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    form.value = {
+      user: {
+        firstName: 'Frans',
+        lastName: 'de Boer',
+        address: {
+          postalCode: '8989AA',
+          houseNumber: '17',
+          street: 'Wiardaplantage',
+          city: 'Leeuwarden'
+        }
+      }
+    };
+
+    const childForm = form.querySelector<ChildForm>('example-child-form-test')!;
+    await childForm.updateComplete;
+    await childForm.renderRoot.querySelector<Form>('sl-form')!.updateComplete;
+
+    const parentTextField = (name: string): TextField | null =>
+        form.querySelector(`sl-text-field[name="${name}"]`),
+      childTextField = (name: string): TextField | null =>
+        childForm.renderRoot.querySelector(`sl-text-field[name="${name}"]`);
+
+    expect(parentTextField('user.firstName')?.value).to.equal('Frans');
+    expect(parentTextField('user.lastName')?.value).to.equal('de Boer');
+    expect(childTextField('postalCode')?.value).to.equal('8989AA');
+    expect(childTextField('houseNumber')?.value).to.equal('17');
+    expect(childTextField('street')?.value).to.equal('Wiardaplantage');
+    expect(childTextField('city')?.value).to.equal('Leeuwarden');
+  });
+});

--- a/examples/lit/src/nested-form/child-form.spec.ts
+++ b/examples/lit/src/nested-form/child-form.spec.ts
@@ -7,10 +7,28 @@ import { html } from 'lit';
 import { describe, expect, it } from 'vitest';
 import { ChildForm } from './child-form.js';
 
-try {
+if (!customElements.get('example-child-form-test')) {
   customElements.define('example-child-form-test', ChildForm);
-} catch {
-  /* empty */
+}
+
+async function waitForControls(form: Form, names: string[]): Promise<void> {
+  for (
+    let i = 0;
+    i < 10 && !names.every(name => form.controls.some(control => control.name === name));
+    i++
+  ) {
+    await new Promise(requestAnimationFrame);
+  }
+
+  expect(form.controls.map(control => control.name)).to.include.members(names);
+}
+
+async function waitForFieldValue(field: TextField | null, value: string): Promise<void> {
+  for (let i = 0; i < 10 && field?.value !== value; i++) {
+    await new Promise(requestAnimationFrame);
+  }
+
+  expect(field?.value).to.equal(value);
 }
 
 describe('example-child-form', () => {
@@ -31,7 +49,13 @@ describe('example-child-form', () => {
       </sl-form>
     `);
 
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await waitForControls(form, ['user.firstName', 'user.lastName', 'user.address']);
+    const childForm = form.querySelector<ChildForm>('example-child-form-test')!,
+      addressForm = childForm.renderRoot.querySelector<Form>('sl-form')!;
+    await waitForControls(addressForm, ['postalCode', 'houseNumber', 'street', 'city']);
+    await childForm.updateComplete;
+    await addressForm.updateComplete;
+    await new Promise(requestAnimationFrame);
 
     form.value = {
       user: {
@@ -45,21 +69,21 @@ describe('example-child-form', () => {
         }
       }
     };
-
-    const childForm = form.querySelector<ChildForm>('example-child-form-test')!;
+    await form.updateComplete;
     await childForm.updateComplete;
-    await childForm.renderRoot.querySelector<Form>('sl-form')!.updateComplete;
+    await new Promise(requestAnimationFrame);
+    await addressForm.updateComplete;
 
     const parentTextField = (name: string): TextField | null =>
         form.querySelector(`sl-text-field[name="${name}"]`),
       childTextField = (name: string): TextField | null =>
         childForm.renderRoot.querySelector(`sl-text-field[name="${name}"]`);
 
-    expect(parentTextField('user.firstName')?.value).to.equal('Frans');
-    expect(parentTextField('user.lastName')?.value).to.equal('de Boer');
-    expect(childTextField('postalCode')?.value).to.equal('8989AA');
-    expect(childTextField('houseNumber')?.value).to.equal('17');
-    expect(childTextField('street')?.value).to.equal('Wiardaplantage');
-    expect(childTextField('city')?.value).to.equal('Leeuwarden');
+    await waitForFieldValue(parentTextField('user.firstName'), 'Frans');
+    await waitForFieldValue(parentTextField('user.lastName'), 'de Boer');
+    await waitForFieldValue(childTextField('postalCode'), '8989AA');
+    await waitForFieldValue(childTextField('houseNumber'), '17');
+    await waitForFieldValue(childTextField('street'), 'Wiardaplantage');
+    await waitForFieldValue(childTextField('city'), 'Leeuwarden');
   });
 });

--- a/examples/lit/src/nested-form/child-form.spec.ts
+++ b/examples/lit/src/nested-form/child-form.spec.ts
@@ -75,9 +75,9 @@ describe('example-child-form', () => {
     await addressForm.updateComplete;
 
     const parentTextField = (name: string): TextField | null =>
-        form.querySelector(`sl-text-field[name="${name}"]`),
+        form.querySelector<TextField>(`sl-text-field[name="${name}"]`),
       childTextField = (name: string): TextField | null =>
-        childForm.renderRoot.querySelector(`sl-text-field[name="${name}"]`);
+        childForm.renderRoot.querySelector<TextField>(`sl-text-field[name="${name}"]`);
 
     await waitForFieldValue(parentTextField('user.firstName'), 'Frans');
     await waitForFieldValue(parentTextField('user.lastName'), 'de Boer');

--- a/examples/lit/src/nested-form/child-form.ts
+++ b/examples/lit/src/nested-form/child-form.ts
@@ -100,7 +100,6 @@ export class ChildForm extends ScopedElementsMixin(FormControlMixin(LitElement))
 
           void form.updateComplete.then(() => {
             this.setCustomValidity(form.invalid ? 'Please enter a valid address.' : '');
-            this.updateValidity();
           });
         }
       }

--- a/examples/lit/src/nested-form/child-form.ts
+++ b/examples/lit/src/nested-form/child-form.ts
@@ -97,6 +97,11 @@ export class ChildForm extends ScopedElementsMixin(FormControlMixin(LitElement))
 
         if (form) {
           form.value = this.value;
+
+          void form.updateComplete.then(() => {
+            this.setCustomValidity(form.invalid ? 'Please enter a valid address.' : '');
+            this.updateValidity();
+          });
         }
       }
     }

--- a/examples/lit/src/nested-form/child-form.ts
+++ b/examples/lit/src/nested-form/child-form.ts
@@ -38,6 +38,7 @@ export class ChildForm extends ScopedElementsMixin(FormControlMixin(LitElement))
   static override styles: CSSResultGroup = styles;
 
   #form = new FormController<Partial<Address>>(this);
+  #valueUpdatedFromInternal = false;
 
   /** Needed since we don't have a native input element. */
   internals = this.attachInternals();
@@ -89,7 +90,11 @@ export class ChildForm extends ScopedElementsMixin(FormControlMixin(LitElement))
     super.updated(changes);
 
     if (changes.has('value')) {
-      this.#form.value = this.value;
+      if (this.#valueUpdatedFromInternal) {
+        this.#valueUpdatedFromInternal = false;
+      } else {
+        this.#form.value = this.value;
+      }
     }
   }
 
@@ -106,6 +111,7 @@ export class ChildForm extends ScopedElementsMixin(FormControlMixin(LitElement))
     event.preventDefault();
     event.stopPropagation();
 
+    this.#valueUpdatedFromInternal = true;
     this.value = this.#form.value;
     this.setCustomValidity(this.#form.invalid ? 'Please enter a valid address.' : '');
 

--- a/examples/lit/src/nested-form/child-form.ts
+++ b/examples/lit/src/nested-form/child-form.ts
@@ -93,7 +93,11 @@ export class ChildForm extends ScopedElementsMixin(FormControlMixin(LitElement))
       if (this.#valueUpdatedFromInternal) {
         this.#valueUpdatedFromInternal = false;
       } else {
-        this.#form.value = this.value;
+        const form = this.renderRoot.querySelector<Form>('sl-form');
+
+        if (form) {
+          form.value = this.value;
+        }
       }
     }
   }

--- a/examples/lit/src/nested-form/child-form.ts
+++ b/examples/lit/src/nested-form/child-form.ts
@@ -4,7 +4,13 @@ import {
 } from '@open-wc/scoped-elements/lit-element.js';
 import { Form, FormControlMixin, FormController, FormField } from '@sl-design-system/form';
 import { TextField } from '@sl-design-system/text-field';
-import { type CSSResultGroup, LitElement, type TemplateResult, html } from 'lit';
+import {
+  type CSSResultGroup,
+  LitElement,
+  type PropertyValues,
+  type TemplateResult,
+  html
+} from 'lit';
 import { property } from 'lit/decorators.js';
 import styles from './child-form.scss.js';
 
@@ -31,7 +37,7 @@ export class ChildForm extends ScopedElementsMixin(FormControlMixin(LitElement))
   /** @internal */
   static override styles: CSSResultGroup = styles;
 
-  #form = new FormController<Address>(this);
+  #form = new FormController<Partial<Address>>(this);
 
   /** Needed since we don't have a native input element. */
   internals = this.attachInternals();
@@ -40,6 +46,7 @@ export class ChildForm extends ScopedElementsMixin(FormControlMixin(LitElement))
   @property({ type: Boolean }) override required?: boolean;
 
   /** The form value. */
+  @property({ attribute: false })
   override value?: Partial<Address> = {};
 
   override connectedCallback(): void {
@@ -76,6 +83,14 @@ export class ChildForm extends ScopedElementsMixin(FormControlMixin(LitElement))
     super.reportValidity();
 
     return this.#form.reportValidity();
+  }
+
+  override updated(changes: PropertyValues<this>): void {
+    super.updated(changes);
+
+    if (changes.has('value')) {
+      this.#form.value = this.value;
+    }
   }
 
   #onChange(): void {

--- a/examples/lit/src/nested-form/nested-form.ts
+++ b/examples/lit/src/nested-form/nested-form.ts
@@ -52,6 +52,7 @@ export class NestedForm extends ScopedElementsMixin(LitElement) {
         </sl-form-field>
 
         <sl-button-bar align="end">
+          <sl-button @click=${this.#onLoadProfile}>Load profile</sl-button>
           <sl-button @click=${this.#onClick}>Submit</sl-button>
         </sl-button-bar>
       </sl-form>
@@ -61,5 +62,20 @@ export class NestedForm extends ScopedElementsMixin(LitElement) {
 
   #onClick() {
     this.#form.reportValidity();
+  }
+
+  #onLoadProfile(): void {
+    this.#form.value = {
+      user: {
+        firstName: 'Captain',
+        lastName: 'Debug',
+        address: {
+          postalCode: '404OK',
+          houseNumber: '42',
+          street: 'Breakpoint Boulevard',
+          city: 'Stacktrace City'
+        }
+      }
+    };
   }
 }

--- a/package.json
+++ b/package.json
@@ -356,6 +356,7 @@
       "command": "vitest --project=unit",
       "dependencies": [
         "build:components",
+        "build:examples",
         "test:setup"
       ],
       "files": [

--- a/package.json
+++ b/package.json
@@ -360,6 +360,7 @@
       ],
       "files": [
         "web-test-runner.config.mjs",
+        "examples/lit/**/*.ts",
         "packages/components/**/*.spec.ts"
       ]
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         extends: true,
         test: {
           name: 'unit',
-          include: ['packages/components/**/*.spec.ts'],
+          include: ['packages/components/**/*.spec.ts', 'examples/lit/**/*.spec.ts'],
           browser: {
             enabled: true,
             headless: true,


### PR DESCRIPTION
## Summary

Fix the nested form example so a custom form control correctly syncs parent-provided form values into its internal form.

When `sl-form.value` is set with a nested value such as `user.address`, the parent form already passes that object to the custom control through `formValue`. The example child form did not propagate its received `value` into its own internal `FormController`, so the address fields stayed empty.

This PR:
- marks the child form `value` as a reactive property
- syncs external `value` changes into the child form controller
- adds a regression test covering parent form value binding for the nested custom form example
- includes `examples/lit` specs in the unit test config

No changeset is included because this only updates examples/tests, not published production component code.


### BEFORE

https://github.com/user-attachments/assets/df4824b0-74fd-467e-8bd4-0f2956702517

### AFTER 

https://github.com/user-attachments/assets/1f4998af-912e-4d90-b622-a343312ee0ad
