### PR TITLE
fix(combobox select): Re-export listbox option components from combobox and select

### DIFF
--- a/.changeset/bumpy-worms-wave.md
+++ b/.changeset/bumpy-worms-wave.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/combobox': patch
+---
+
+Export `Listbox`, `Option`, `OptionGroup`, and `OptionGroupHeader` from the combobox package and automatically register them when importing `register.js` to simplify importing and registration of combobox options.

--- a/.changeset/bumpy-worms-wave.md
+++ b/.changeset/bumpy-worms-wave.md
@@ -1,5 +1,6 @@
 ---
 '@sl-design-system/combobox': patch
+'@sl-design-system/select': patch
 ---
 
-Export listbox components from the combobox package and automatically register the listbox, option, and option group elements when importing `register.js` to simplify using combobox options.
+Export listbox components from the combobox and select packages and automatically register the listbox, option, and option group elements when importing `register.js` to simplify using options.

--- a/.changeset/bumpy-worms-wave.md
+++ b/.changeset/bumpy-worms-wave.md
@@ -2,4 +2,4 @@
 '@sl-design-system/combobox': patch
 ---
 
-Export `Listbox`, `Option`, `OptionGroup`, and `OptionGroupHeader` from the combobox package and automatically register them when importing `register.js` to simplify importing and registration of combobox options.
+Export listbox components from the combobox package and automatically register the listbox, option, and option group elements when importing `register.js` to simplify using combobox options.

--- a/packages/components/combobox/index.ts
+++ b/packages/components/combobox/index.ts
@@ -1,2 +1,2 @@
 export * from './src/combobox.js';
-export * from '@sl-design-system/listbox';
+export { Listbox, Option, OptionGroup } from '@sl-design-system/listbox';

--- a/packages/components/combobox/index.ts
+++ b/packages/components/combobox/index.ts
@@ -1,1 +1,2 @@
 export * from './src/combobox.js';
+export * from '@sl-design-system/listbox';

--- a/packages/components/combobox/register.ts
+++ b/packages/components/combobox/register.ts
@@ -1,3 +1,4 @@
+import '@sl-design-system/listbox/register.js';
 import { Combobox } from './src/combobox.js';
 
 customElements.define('sl-combobox', Combobox);

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -6,7 +6,7 @@ import { LitElement, type TemplateResult, html } from 'lit';
 import { spy } from 'sinon';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
-import { Option } from '../index.js';
+import { Listbox, Option, OptionGroup } from '../index.js';
 import '../register.js';
 import { type Combobox } from './combobox.js';
 import { type CustomOption } from './custom-option.js';
@@ -14,9 +14,14 @@ import { type GroupedOption } from './grouped-option.js';
 import { type SelectedGroup } from './selected-group.js';
 
 describe('sl-combobox', () => {
-  it('should export Option and register sl-option', () => {
+  it('should export and register listbox option components', () => {
+    expect(Listbox).to.exist;
     expect(Option).to.exist;
+    expect(OptionGroup).to.exist;
+
+    expect(customElements.get('sl-listbox')).to.equal(Listbox);
     expect(customElements.get('sl-option')).to.equal(Option);
+    expect(customElements.get('sl-option-group')).to.equal(OptionGroup);
   });
   let el: Combobox, input: HTMLInputElement;
 

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1,12 +1,12 @@
 import { type SlFormControlEvent } from '@sl-design-system/form';
 import '@sl-design-system/form/register.js';
-import '@sl-design-system/listbox/register.js';
 import { type SlChangeEvent } from '@sl-design-system/shared/events.js';
 import { fixture, oneEvent } from '@sl-design-system/vitest-browser-lit';
 import { LitElement, type TemplateResult, html } from 'lit';
 import { spy } from 'sinon';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
+import { Option } from '../index.js';
 import '../register.js';
 import { type Combobox } from './combobox.js';
 import { type CustomOption } from './custom-option.js';
@@ -14,6 +14,10 @@ import { type GroupedOption } from './grouped-option.js';
 import { type SelectedGroup } from './selected-group.js';
 
 describe('sl-combobox', () => {
+  it('should export Option and register sl-option', () => {
+    expect(Option).to.exist;
+    expect(customElements.get('sl-option')).to.equal(Option);
+  });
   let el: Combobox, input: HTMLInputElement;
 
   const waitForNextMacrotask = async (): Promise<void> => {

--- a/packages/components/select/index.ts
+++ b/packages/components/select/index.ts
@@ -1,2 +1,2 @@
 export * from './src/select.js';
-export * from '@sl-design-system/listbox';
+export { Listbox, Option, OptionGroup } from '@sl-design-system/listbox';

--- a/packages/components/select/index.ts
+++ b/packages/components/select/index.ts
@@ -1,1 +1,2 @@
 export * from './src/select.js';
+export * from '@sl-design-system/listbox';

--- a/packages/components/select/register.ts
+++ b/packages/components/select/register.ts
@@ -1,3 +1,4 @@
+import '@sl-design-system/listbox/register.js';
 import { Select } from './src/select.js';
 
 customElements.define('sl-select', Select);

--- a/packages/components/select/src/select.spec.ts
+++ b/packages/components/select/src/select.spec.ts
@@ -5,18 +5,22 @@ import {
 import { type SlFormControlEvent } from '@sl-design-system/form';
 import '@sl-design-system/form/register.js';
 import { Icon } from '@sl-design-system/icon';
-import { Option } from '@sl-design-system/listbox';
-import '@sl-design-system/listbox/register.js';
 import { fixture } from '@sl-design-system/vitest-browser-lit';
 import { LitElement, type TemplateResult, html } from 'lit';
 import { spy } from 'sinon';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
+import { Option } from '../index.js';
 import '../register.js';
 import { SelectButton } from './select-button.js';
 import { Select } from './select.js';
 
 describe('sl-select', () => {
+  it('should export Option and register sl-option', () => {
+    expect(Option).to.exist;
+    expect(customElements.get('sl-option')).to.equal(Option);
+  });
+
   let el: Select, button: SelectButton;
 
   describe('defaults', () => {

--- a/packages/components/select/src/select.spec.ts
+++ b/packages/components/select/src/select.spec.ts
@@ -10,15 +10,20 @@ import { LitElement, type TemplateResult, html } from 'lit';
 import { spy } from 'sinon';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
-import { Option } from '../index.js';
+import { Listbox, Option, OptionGroup } from '../index.js';
 import '../register.js';
 import { SelectButton } from './select-button.js';
 import { Select } from './select.js';
 
 describe('sl-select', () => {
-  it('should export Option and register sl-option', () => {
+  it('should export and register listbox option components', () => {
+    expect(Listbox).to.exist;
     expect(Option).to.exist;
+    expect(OptionGroup).to.exist;
+
+    expect(customElements.get('sl-listbox')).to.equal(Listbox);
     expect(customElements.get('sl-option')).to.equal(Option);
+    expect(customElements.get('sl-option-group')).to.equal(OptionGroup);
   });
 
   let el: Select, button: SelectButton;


### PR DESCRIPTION
### Summary
This PR improves Developer Experience (DX) for `<sl-combobox>` and `<sl-select>` by exposing the listbox option components from their package entrypoints.

Developers can now import `Listbox`, `Option`, and `OptionGroup` from `@sl-design-system/combobox` or `@sl-design-system/select` instead of importing them directly from `@sl-design-system/listbox`. Importing `@sl-design-system/combobox/register.js` or `@sl-design-system/select/register.js` also registers the listbox, option, and option group elements needed for declarative options.

The re-exports are intentionally limited to the supported listbox symbols used by combobox and select.