### PR TITLE
fix(listbox): contain overscroll in virtualized listboxes

### DIFF
--- a/.changeset/tall-apes-wash.md
+++ b/.changeset/tall-apes-wash.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/listbox': patch
+---
+
+Prevent scroll chaining from listboxes to the underlying page by containing overscroll on the listbox host. This fixes unstable scrolling and flickering options in virtualized combobox popovers when wheel scrolling at the end of the list.

--- a/.changeset/tall-apes-wash.md
+++ b/.changeset/tall-apes-wash.md
@@ -2,4 +2,4 @@
 '@sl-design-system/listbox': patch
 ---
 
-Prevent scroll chaining from listboxes to the underlying page by containing overscroll on the listbox host. This fixes unstable scrolling and flickering options in virtualized combobox popovers when wheel scrolling at the end of the list.
+Prevent unstable scrolling in virtualized listboxes by disabling scroll anchoring and containing overscroll on the listbox host. This fixes cases where small touchpad scrolls could keep snapping the rendered range back to the same option, and prevents wheel scrolling at list boundaries from scrolling the underlying page.

--- a/packages/components/listbox/src/listbox.scss
+++ b/packages/components/listbox/src/listbox.scss
@@ -5,6 +5,7 @@
   flex-direction: column;
   gap: var(--sl-size-025);
   overflow: auto;
+  overscroll-behavior: contain;
   padding: var(--sl-size-100) 0;
   scroll-padding-block: var(--sl-size-100);
   scrollbar-width: thin;

--- a/packages/components/listbox/src/listbox.scss
+++ b/packages/components/listbox/src/listbox.scss
@@ -5,6 +5,7 @@
   flex-direction: column;
   gap: var(--sl-size-025);
   overflow: auto;
+  overflow-anchor: none;
   overscroll-behavior: contain;
   padding: var(--sl-size-100) 0;
   scroll-padding-block: var(--sl-size-100);


### PR DESCRIPTION
## Summary

Fix unstable scrolling in virtualized `sl-listbox` instances used by `sl-combobox`.

The listbox host now contains overscroll and disables scroll anchoring. This prevents two related scroll issues in virtualized combobox popovers:

- wheel scrolling at the end of the list no longer scrolls the page behind the popover
- small touchpad scrolls no longer snap the rendered virtual range back to the same option

## Details

When a virtualized combobox list reaches a scroll boundary, wheel events could chain to the underlying page. That changed the popover’s available space and caused the virtual list range to recalculate.

Separately, browser scroll anchoring could fight with virtualized DOM replacement during small touchpad scrolls. This made the list appear stuck on the same top option until the user scrolled more aggressively.



### BEFORE

https://github.com/user-attachments/assets/e770c0f6-7361-432c-b94f-ce03959820aa


### AFTER

https://github.com/user-attachments/assets/639d2ce5-83de-4d7c-a362-99627ca9fccd




