### PR TITLE
fix(card): prevent duplicate title link clicks

### DIFF
--- a/.changeset/wicked-seals-add.md
+++ b/.changeset/wicked-seals-add.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/card': patch
+---
+
+Prevent duplicate title link clicks in cards with interactive slotted content. Card link proxying now uses a single stable click listener and ignores clicks from controls in the `menu-button` and `actions` slots, including toggle buttons and menu buttons.

--- a/packages/components/card/src/card.spec.ts
+++ b/packages/components/card/src/card.spec.ts
@@ -216,6 +216,54 @@ describe('<sl-card>', () => {
       el.click();
       expect(clicked).to.be.true;
     });
+
+    it('should not propagate clicks from the menu button to the link', () => {
+      const link = el.querySelector('a')!;
+      const toggleButton = el.querySelector('sl-toggle-button')!;
+
+      let linkClicks = 0;
+      link.addEventListener('click', event => {
+        event.preventDefault();
+        linkClicks += 1;
+      });
+
+      toggleButton.click();
+
+      expect(linkClicks).to.equal(0);
+    });
+
+    it('should only click the link once after the title slot changes', () => {
+      const titleSlot = el.shadowRoot!.querySelector('slot.title')!;
+      const link = el.querySelector('a')!;
+
+      let linkClicks = 0;
+      link.addEventListener('click', event => {
+        event.preventDefault();
+        linkClicks += 1;
+      });
+
+      titleSlot.dispatchEvent(new Event('slotchange'));
+      titleSlot.dispatchEvent(new Event('slotchange'));
+      el.click();
+
+      expect(linkClicks).to.equal(1);
+    });
+
+    it('should only dispatch one link click after interacting with the toggle button', () => {
+      const link = el.querySelector('a')!;
+      const toggleButton = el.querySelector('sl-toggle-button')!;
+
+      let linkClicks = 0;
+      link.addEventListener('click', event => {
+        event.preventDefault();
+        linkClicks += 1;
+      });
+
+      toggleButton.click();
+      link.click();
+
+      expect(linkClicks).to.equal(1);
+    });
   });
 
   describe('vertical orientation', () => {

--- a/packages/components/card/src/card.stories.ts
+++ b/packages/components/card/src/card.stories.ts
@@ -780,6 +780,68 @@ export const Actions: Story = {
   }
 };
 
+export const LinkWithToggleButton: Story = {
+  render: () => {
+    let linkClicks = 0,
+      toggleClicks = 0;
+
+    const updateCounters = (root: Element | null): void => {
+      root?.querySelector('[data-link-clicks]')?.replaceChildren(linkClicks.toString());
+      root?.querySelector('[data-toggle-clicks]')?.replaceChildren(toggleClicks.toString());
+    };
+
+    const onLinkClick = (event: Event): void => {
+      event.preventDefault();
+      linkClicks += 1;
+      updateCounters((event.currentTarget as Element).closest('.click-reproduction'));
+    };
+
+    const onToggleClick = (event: Event): void => {
+      toggleClicks += 1;
+      updateCounters((event.currentTarget as Element).closest('.click-reproduction'));
+    };
+
+    return html`
+      <style>
+        .click-reproduction {
+          display: grid;
+          gap: 12px;
+          max-width: 320px;
+        }
+
+        .click-reproduction__controls,
+        .click-reproduction__counts {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+        }
+      </style>
+      <div class="click-reproduction">
+        <sl-card>
+          <a href="https://example.com/book" target="_blank" @click=${onLinkClick}> Link text </a>
+          <sl-toggle-button
+            slot="menu-button"
+            aria-label="Favorite"
+            shape="pill"
+            @click=${onToggleClick}>
+            <sl-icon name="far-heart" slot="default"></sl-icon>
+            <sl-icon name="fas-heart" slot="pressed"></sl-icon>
+          </sl-toggle-button>
+        </sl-card>
+
+        <div class="click-reproduction__counts">
+          <sl-badge color="green" size="lg"
+            >Book link clicks: <span data-link-clicks>0</span></sl-badge
+          >
+          <sl-badge color="blue" size="lg"
+            >Favorite clicks: <span data-toggle-clicks>0</span></sl-badge
+          >
+        </div>
+      </div>
+    `;
+  }
+};
+
 export const RealWorldExamples: Story = {
   render: () => {
     return html`

--- a/packages/components/card/src/card.stories.ts
+++ b/packages/components/card/src/card.stories.ts
@@ -809,7 +809,6 @@ export const LinkWithToggleButton: Story = {
           max-width: 320px;
         }
 
-        .click-reproduction__controls,
         .click-reproduction__counts {
           display: flex;
           flex-wrap: wrap;
@@ -818,7 +817,7 @@ export const LinkWithToggleButton: Story = {
       </style>
       <div class="click-reproduction">
         <sl-card>
-          <a href="https://example.com/book" target="_blank" @click=${onLinkClick}> Link text </a>
+          <a href="https://example.com/book" target="_blank" rel="noopener noreferrer" @click=${onLinkClick}> Link text </a>
           <sl-toggle-button
             slot="menu-button"
             aria-label="Favorite"

--- a/packages/components/card/src/card.stories.ts
+++ b/packages/components/card/src/card.stories.ts
@@ -793,42 +793,57 @@ export const LinkWithToggleButton: Story = {
     const onLinkClick = (event: Event): void => {
       event.preventDefault();
       linkClicks += 1;
-      updateCounters((event.currentTarget as Element).closest('.click-reproduction'));
+      updateCounters((event.currentTarget as Element).closest('.link-with-toggle'));
     };
 
     const onToggleClick = (event: Event): void => {
       toggleClicks += 1;
-      updateCounters((event.currentTarget as Element).closest('.click-reproduction'));
+      updateCounters((event.currentTarget as Element).closest('.link-with-toggle'));
     };
 
     return html`
       <style>
-        .click-reproduction {
+        .link-with-toggle {
           display: grid;
           gap: 12px;
           max-width: 320px;
         }
 
-        .click-reproduction__counts {
+        .link-with-toggle__counts {
           display: flex;
           flex-wrap: wrap;
           gap: 8px;
         }
+
+        .link-with-toggle__favorite {
+          clip-path: circle(50%);
+        }
+
+        .link-with-toggle__favorite::part(wrapper) {
+          padding: var(--sl-size-075);
+        }
       </style>
-      <div class="click-reproduction">
+      <div class="link-with-toggle">
         <sl-card>
-          <a href="https://example.com/book" target="_blank" rel="noopener noreferrer" @click=${onLinkClick}> Link text </a>
+          <a
+            href="https://example.com/book"
+            target="_blank"
+            rel="noopener noreferrer"
+            @click=${onLinkClick}>
+            Link text
+          </a>
           <sl-toggle-button
+            class="link-with-toggle__favorite"
             slot="menu-button"
             aria-label="Favorite"
             shape="pill"
-            @click=${onToggleClick}>
+            @sl-toggle=${onToggleClick}>
             <sl-icon name="far-heart" slot="default"></sl-icon>
             <sl-icon name="fas-heart" slot="pressed"></sl-icon>
           </sl-toggle-button>
         </sl-card>
 
-        <div class="click-reproduction__counts">
+        <div class="link-with-toggle__counts">
           <sl-badge color="green" size="lg"
             >Book link clicks: <span data-link-clicks>0</span></sl-badge
           >

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -19,6 +19,20 @@ declare global {
 
 export type CardOrientation = 'horizontal' | 'vertical';
 
+const interactiveSelector = [
+  'a',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  '[role="button"]',
+  '[slot="actions"]',
+  '[slot="menu-button"]',
+  'sl-button',
+  'sl-menu-button',
+  'sl-toggle-button'
+].join(',');
+
 /**
  * Use cards to display media and text in a compact, appealing way.
  *
@@ -311,20 +325,6 @@ export class Card extends ScopedElementsMixin(LitElement) {
   };
 
   #shouldIgnoreClick(event: MouseEvent): boolean {
-    const interactiveSelector = [
-      'a',
-      'button',
-      'input',
-      'select',
-      'textarea',
-      '[role="button"]',
-      '[slot="actions"]',
-      '[slot="menu-button"]',
-      'sl-button',
-      'sl-menu-button',
-      'sl-toggle-button'
-    ].join(',');
-
     return event.composedPath().some(el => {
       if (el === this.#titleLink) {
         return true;

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -311,6 +311,20 @@ export class Card extends ScopedElementsMixin(LitElement) {
   };
 
   #shouldIgnoreClick(event: MouseEvent): boolean {
+    const interactiveSelector = [
+      'a',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      '[role="button"]',
+      '[slot="actions"]',
+      '[slot="menu-button"]',
+      'sl-button',
+      'sl-menu-button',
+      'sl-toggle-button'
+    ].join(',');
+
     return event.composedPath().some(el => {
       if (el === this.#titleLink) {
         return true;
@@ -320,24 +334,7 @@ export class Card extends ScopedElementsMixin(LitElement) {
         return ['actions', 'menu-button'].includes(el.name) || el.classList.contains('title');
       }
 
-      return (
-        el instanceof Element &&
-        el.matches(
-          [
-            'a',
-            'button',
-            'input',
-            'select',
-            'textarea',
-            '[role="button"]',
-            '[slot="actions"]',
-            '[slot="menu-button"]',
-            'sl-button',
-            'sl-menu-button',
-            'sl-toggle-button'
-          ].join(',')
-        )
-      );
+      return el instanceof Element && el.matches(interactiveSelector);
     });
   }
 }

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -47,6 +47,9 @@ export class Card extends ScopedElementsMixin(LitElement) {
     this.#setLineClamp();
   });
 
+  /** @internal The link in the title slot that receives card clicks. */
+  #titleLink?: HTMLAnchorElement;
+
   /** @internal The slotted media. */
   @queryAssignedElements({ slot: 'media' }) media?: HTMLElement[];
 
@@ -80,10 +83,12 @@ export class Card extends ScopedElementsMixin(LitElement) {
     this.#setOrientation();
     this.#setGridSpan();
 
+    this.addEventListener('click', this.#onClick);
     this.#resizeObserver?.observe(this);
   }
 
   override disconnectedCallback(): void {
+    this.removeEventListener('click', this.#onClick);
     this.#resizeObserver?.disconnect();
 
     super.disconnectedCallback();
@@ -267,28 +272,11 @@ export class Card extends ScopedElementsMixin(LitElement) {
     }
 
     const title: HTMLSlotElement | null = this.shadowRoot.querySelector('slot.title');
+    this.#titleLink = title
+      ?.assignedNodes({ flatten: true })
+      .find(el => el instanceof HTMLAnchorElement);
 
-    if (title && title.assignedNodes({ flatten: true }).length > 0) {
-      const link = title
-        .assignedNodes({ flatten: true })
-        .find(el => el instanceof HTMLAnchorElement);
-      if (!link) {
-        this.classList.remove('sl-has-link');
-        this.removeEventListener('click', () => {});
-      } else {
-        this.classList.add('sl-has-link');
-        this.addEventListener('click', (e: MouseEvent) => {
-          const shouldStopPropagation = e
-            .composedPath()
-            .find(
-              el => el instanceof Element && (el.matches('sl-button') || el.matches('slot.title'))
-            );
-          if (!shouldStopPropagation) {
-            link.click();
-          }
-        });
-      }
-    }
+    this.classList.toggle('sl-has-link', !!this.#titleLink);
   }
 
   #setMenuButton(): void {
@@ -312,5 +300,44 @@ export class Card extends ScopedElementsMixin(LitElement) {
         menuButton.size = 'md';
       }
     }
+  }
+
+  #onClick = (event: MouseEvent): void => {
+    if (!this.#titleLink || this.#shouldIgnoreClick(event)) {
+      return;
+    }
+
+    this.#titleLink.click();
+  };
+
+  #shouldIgnoreClick(event: MouseEvent): boolean {
+    return event.composedPath().some(el => {
+      if (el === this.#titleLink) {
+        return true;
+      }
+
+      if (el instanceof HTMLSlotElement) {
+        return ['actions', 'menu-button'].includes(el.name) || el.classList.contains('title');
+      }
+
+      return (
+        el instanceof Element &&
+        el.matches(
+          [
+            'a',
+            'button',
+            'input',
+            'select',
+            'textarea',
+            '[role="button"]',
+            '[slot="actions"]',
+            '[slot="menu-button"]',
+            'sl-button',
+            'sl-menu-button',
+            'sl-toggle-button'
+          ].join(',')
+        )
+      );
+    });
   }
 }

--- a/packages/components/card/src/card.ts
+++ b/packages/components/card/src/card.ts
@@ -273,8 +273,8 @@ export class Card extends ScopedElementsMixin(LitElement) {
 
     const title: HTMLSlotElement | null = this.shadowRoot.querySelector('slot.title');
     this.#titleLink = title
-      ?.assignedNodes({ flatten: true })
-      .find(el => el instanceof HTMLAnchorElement);
+      ?.assignedElements({ flatten: true })
+      .find((el): el is HTMLAnchorElement => el instanceof HTMLAnchorElement);
 
     this.classList.toggle('sl-has-link', !!this.#titleLink);
   }


### PR DESCRIPTION
## Summary

Fix duplicate link clicks in `sl-card` when the card contains a title link and interactive slotted controls, such as `sl-toggle-button` in the `menu-button` slot.

Previously, `sl-card` added a new anonymous host click listener every time the title slot was processed. Those listeners could not be removed, so repeated slot updates could cause the card to proxy the same click to the title link multiple times.

This change stores the title link on the component and uses a single stable click listener for the card. It also prevents card-to-link click proxying when the original click comes from interactive content, including `sl-toggle-button`, `sl-menu-button`, `sl-button`, native form controls, `role="button"`, and the `actions` / `menu-button` slots.

A new `Layout/Card / Link With Toggle Button` Storybook story was added to illustrate the issue with a minimal reproduction: a card with a book link, a favorite toggle button, and click counters.


### BEFORE
https://github.com/user-attachments/assets/9c74731b-fa7d-4ffe-be02-7a1c560937d0


### AFTER
https://github.com/user-attachments/assets/6ad790a6-70ea-46ed-b7e6-90202a430e38

