### PR TITLE
fix(storybook dialog): register trash icon

### DIFF
--- a/packages/components/dialog/src/dialog.stories.ts
+++ b/packages/components/dialog/src/dialog.stories.ts
@@ -1,4 +1,4 @@
-import { faBurst } from '@fortawesome/pro-regular-svg-icons';
+import { faBurst, faTrash } from '@fortawesome/pro-regular-svg-icons';
 import '@sl-design-system/button/register.js';
 import '@sl-design-system/button-bar/register.js';
 import '@sl-design-system/combobox/register.js';
@@ -31,7 +31,7 @@ type Props = Pick<Dialog, 'closeButton' | 'disableCancel'> & {
 };
 type Story = StoryObj<Props>;
 
-Icon.register(faBurst);
+Icon.register(faBurst, faTrash);
 
 export default {
   title: 'Overlay/Dialog',


### PR DESCRIPTION
### BEFORE
<img width="149" height="144" alt="Screenshot 2026-07-09 at 13 46 59" src="https://github.com/user-attachments/assets/31e6a38a-b167-43ce-8842-168f888d758a" />


### AFTER
<img width="200" height="219" alt="Screenshot 2026-07-09 at 13 45 34" src="https://github.com/user-attachments/assets/a0d54d35-58d3-4f33-ae34-630ca438d2ae" />

