### PR TITLE
fix(storybook select): make sticky header background opaque in story

### DIFF
--- a/packages/components/select/src/select.stories.ts
+++ b/packages/components/select/src/select.stories.ts
@@ -487,7 +487,9 @@ export const HideWhenOutOfView: StoryObj = {
         }
 
         header {
-          background: var(--sl-color-background-subtle);
+          background:
+            linear-gradient(var(--sl-color-background-subtle), var(--sl-color-background-subtle)),
+            var(--sl-elevation-surface-base-default);
           position: sticky;
           top: 0;
           padding: 24px;


### PR DESCRIPTION
### BEFORE

https://github.com/user-attachments/assets/0fd91d7b-8cf0-42a4-a1b5-81abe4cfc6c1

### AFTER 

https://github.com/user-attachments/assets/c0a44717-2919-4137-92cc-321b1adfec52

