### PR TITLE
fix(calendar): focus active view after selecting year

### DIFF
--- a/.changeset/sharp-results-type.md
+++ b/.changeset/sharp-results-type.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/calendar': patch
+---
+
+Fix focus management when selecting a year from the year view after opening it from the month view. Focus now returns to the active month selector instead of the hidden day selector, so keyboard users land on the first selectable month.

--- a/packages/components/calendar/src/calendar.spec.ts
+++ b/packages/components/calendar/src/calendar.spec.ts
@@ -383,6 +383,40 @@ describe('sl-calendar', () => {
       expect(el.mode).to.equal('month');
     });
 
+    it('should focus select-month after returning from year selector to month mode', async () => {
+      // Start in day mode, go to month mode
+      el.renderRoot
+        .querySelector<SelectDay>('sl-select-day')
+        ?.renderRoot.querySelector<HTMLElement>('.current-month')
+        ?.click();
+      await el.updateComplete;
+
+      // From month mode, go to year mode
+      el.renderRoot
+        .querySelector<SelectMonth>('sl-select-month')
+        ?.renderRoot.querySelector<HTMLElement>('.current-year')
+        ?.click();
+      await el.updateComplete;
+
+      // Select a year - should return to month mode
+      el.renderRoot
+        .querySelector<SelectYear>('sl-select-year')
+        ?.renderRoot.querySelector<HTMLElement>('button')
+        ?.click();
+      await el.updateComplete;
+
+      await new Promise(resolve => requestAnimationFrame(resolve));
+
+      const selectMonth = el.renderRoot.querySelector<SelectMonth>('sl-select-month'),
+        firstSelectableMonth = selectMonth?.renderRoot.querySelector<HTMLButtonElement>(
+          'table button:not(:disabled)'
+        );
+
+      expect(el.mode).to.equal('month');
+      expect(el.shadowRoot?.activeElement).to.match('sl-select-month');
+      expect(selectMonth?.shadowRoot?.activeElement).to.equal(firstSelectableMonth);
+    });
+
     it('should focus select-day after returning from month selector', async () => {
       // Switch to month mode
       el.renderRoot

--- a/packages/components/calendar/src/calendar.spec.ts
+++ b/packages/components/calendar/src/calendar.spec.ts
@@ -407,14 +407,17 @@ describe('sl-calendar', () => {
 
       await new Promise(resolve => requestAnimationFrame(resolve));
 
-      const selectMonth = el.renderRoot.querySelector<SelectMonth>('sl-select-month'),
-        firstSelectableMonth = selectMonth?.renderRoot.querySelector<HTMLButtonElement>(
-          'table button:not(:disabled)'
-        );
+      const selectMonth = el.renderRoot.querySelector<SelectMonth>('sl-select-month');
+      expect(selectMonth).to.exist;
+
+      const firstSelectableMonth = selectMonth!.renderRoot.querySelector<HTMLButtonElement>(
+        'table button:not(:disabled)'
+      );
+      expect(firstSelectableMonth).to.exist;
 
       expect(el.mode).to.equal('month');
       expect(el.shadowRoot?.activeElement).to.match('sl-select-month');
-      expect(selectMonth?.shadowRoot?.activeElement).to.equal(firstSelectableMonth);
+      expect(selectMonth!.shadowRoot?.activeElement).to.equal(firstSelectableMonth);
     });
 
     it('should focus select-day after returning from month selector', async () => {

--- a/packages/components/calendar/src/calendar.spec.ts
+++ b/packages/components/calendar/src/calendar.spec.ts
@@ -746,6 +746,51 @@ describe('sl-calendar', () => {
       expect(monthButton?.ariaDescribedByElements).to.include(helperText);
     });
 
+    it('should set ariaDescribedByElements after returning from year selector to month mode', async () => {
+      el = await fixture(html`
+        <sl-calendar
+          locale="en-GB"
+          min=${new Date(Date.UTC(2023, 0, 1)).toISOString()}
+          max=${new Date(Date.UTC(2023, 11, 31)).toISOString()}></sl-calendar>
+      `);
+
+      // Switch to month mode
+      el.renderRoot
+        .querySelector<SelectDay>('sl-select-day')
+        ?.renderRoot.querySelector<HTMLElement>('.current-month')
+        ?.click();
+      await el.updateComplete;
+
+      // From month mode, go to year mode
+      el.renderRoot
+        .querySelector<SelectMonth>('sl-select-month')
+        ?.renderRoot.querySelector<HTMLElement>('.current-year')
+        ?.click();
+      await el.updateComplete;
+
+      // Select a year - should return to month mode
+      el.renderRoot
+        .querySelector<SelectYear>('sl-select-year')
+        ?.renderRoot.querySelector<HTMLElement>('button:not(:disabled)')
+        ?.click();
+      await el.updateComplete;
+      await new Promise(resolve => requestAnimationFrame(resolve));
+
+      const selectMonth = el.renderRoot.querySelector<SelectMonth>('sl-select-month');
+      expect(selectMonth).to.exist;
+
+      const firstSelectableMonth = selectMonth!.renderRoot.querySelector<HTMLButtonElement>(
+        'table button:not(:disabled)'
+      );
+      expect(firstSelectableMonth).to.exist;
+
+      const helperText = el.renderRoot.querySelector('.helper-text');
+
+      expect(helperText).to.exist;
+      expect(selectMonth!.shadowRoot?.activeElement).to.equal(firstSelectableMonth);
+      expect(firstSelectableMonth!.ariaDescribedByElements).to.include(helperText);
+    });
+
     it('should set ariaDescribedByElements on a focused year button', async () => {
       el = await fixture(html`
         <sl-calendar

--- a/packages/components/calendar/src/calendar.ts
+++ b/packages/components/calendar/src/calendar.ts
@@ -353,9 +353,13 @@ export class Calendar extends LocaleMixin(ScopedElementsMixin(LitElement)) {
   }
 
   #focusActiveMode(): void {
-    const subComponent = this.renderRoot.querySelector(
-      this.mode === 'month' ? 'sl-select-month' : 'sl-select-day'
-    );
+    const selector =
+        this.mode === 'month'
+          ? 'sl-select-month'
+          : this.mode === 'year'
+            ? 'sl-select-year'
+            : 'sl-select-day',
+      subComponent = this.renderRoot.querySelector(selector);
 
     if (subComponent) {
       subComponent.focus();

--- a/packages/components/calendar/src/calendar.ts
+++ b/packages/components/calendar/src/calendar.ts
@@ -303,7 +303,7 @@ export class Calendar extends LocaleMixin(ScopedElementsMixin(LitElement)) {
     this.mode = this.#previousMode ?? 'day';
 
     requestAnimationFrame(() => {
-      this.renderRoot.querySelector('sl-select-day')?.focus();
+      this.#focusActiveMode();
     });
   }
 
@@ -350,5 +350,13 @@ export class Calendar extends LocaleMixin(ScopedElementsMixin(LitElement)) {
 
       button.ariaDescribedByElements = [...existingDescription, helperText];
     }
+  }
+
+  #focusActiveMode(): void {
+    const subComponent = this.renderRoot.querySelector(
+      this.mode === 'month' ? 'sl-select-month' : 'sl-select-day'
+    );
+
+    subComponent?.focus();
   }
 }

--- a/packages/components/calendar/src/calendar.ts
+++ b/packages/components/calendar/src/calendar.ts
@@ -357,6 +357,9 @@ export class Calendar extends LocaleMixin(ScopedElementsMixin(LitElement)) {
       this.mode === 'month' ? 'sl-select-month' : 'sl-select-day'
     );
 
-    subComponent?.focus();
+    if (subComponent) {
+      subComponent.focus();
+      this.#setHelperTextOnFirstButton(subComponent);
+    }
   }
 }


### PR DESCRIPTION
## Summary:

Fixes focus management when returning from the year selector to the month selector in sl-calendar, which affects the date-field calendar popover.
Previously, selecting a year from the year view always moved focus back to sl-select-day. When the previous view was the month selector, sl-select-day was hidden, so keyboard focus landed on an invisible element. Now the calendar focuses the active view after selecting a year, so returning to month view places focus on the first selectable month

### BEFORE

https://github.com/user-attachments/assets/0128d0d7-4dfa-42a1-bdc8-6c5e914de597



### AFTER

https://github.com/user-attachments/assets/3f4c0110-b468-4d10-9f47-7b785f6b93cb

