### PR TITLE
fix(grid): add accessible names to editable cell controls

### DIFF
--- a/.changeset/slimy-parts-study.md
+++ b/.changeset/slimy-parts-study.md
@@ -2,4 +2,4 @@
 '@sl-design-system/grid': patch
 ---
 
-Added accessible names to text field and select controls rendered inside editable grid cells. A new `formControlLabel` property can be used to add row context to the generated label, such as `Zip John Doe` or `Status John Doe`, improving screen reader navigation in editable grids.
+Added accessible names to text field and select controls rendered inside editable grid cells. New `formControlColumnLabel` and `formControlLabel` properties can be used to customize the generated label with column and row context, such as `Zip John Doe` or `Status John Doe`, improving screen reader navigation in editable grids.

--- a/.changeset/slimy-parts-study.md
+++ b/.changeset/slimy-parts-study.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Added accessible names to text field and select controls rendered inside editable grid cells. Labels now include the column label and available row context, such as `Zip John Doe` or `Status John Doe`, improving screen reader navigation in editable grids.

--- a/.changeset/slimy-parts-study.md
+++ b/.changeset/slimy-parts-study.md
@@ -2,4 +2,4 @@
 '@sl-design-system/grid': patch
 ---
 
-Added accessible names to text field and select controls rendered inside editable grid cells. Labels now include the column label and available row context, such as `Zip John Doe` or `Status John Doe`, improving screen reader navigation in editable grids.
+Added accessible names to text field and select controls rendered inside editable grid cells. A new `formControlLabel` property can be used to add row context to the generated label, such as `Zip John Doe` or `Status John Doe`, improving screen reader navigation in editable grids.

--- a/packages/components/grid/src/column.spec.ts
+++ b/packages/components/grid/src/column.spec.ts
@@ -128,6 +128,32 @@ describe('sl-column', () => {
     });
   });
 
+  describe('form control label', () => {
+    it('should fall back to the path label when the header is empty', async () => {
+      el = await fixture(html`
+        <sl-grid>
+          <sl-grid-column header=" " path="address.zip"></sl-grid-column>
+        </sl-grid>
+      `);
+
+      const column = el.querySelector('sl-grid-column')!;
+
+      expect(column.getFormControlLabel({ address: { zip: '12345' } })).to.equal('Zip');
+    });
+
+    it('should add trimmed row context when provided', async () => {
+      el = await fixture(html`
+        <sl-grid>
+          <sl-grid-column path="status" .formControlLabel=${() => ' John Doe '}></sl-grid-column>
+        </sl-grid>
+      `);
+
+      const column = el.querySelector('sl-grid-column')!;
+
+      expect(column.getFormControlLabel({ status: 'Available' })).to.equal('Status John Doe');
+    });
+  });
+
   describe('empty string value', () => {
     beforeEach(async () => {
       el = await fixture(html`

--- a/packages/components/grid/src/column.spec.ts
+++ b/packages/components/grid/src/column.spec.ts
@@ -141,6 +141,18 @@ describe('sl-column', () => {
       expect(column.getFormControlLabel({ address: { zip: '12345' } })).to.equal('Zip');
     });
 
+    it('should use the header renderer result when it is a string', async () => {
+      el = await fixture(html`
+        <sl-grid>
+          <sl-grid-column path="address.zip" .header=${() => 'Postal code'}></sl-grid-column>
+        </sl-grid>
+      `);
+
+      const column = el.querySelector('sl-grid-column')!;
+
+      expect(column.getFormControlLabel({ address: { zip: '12345' } })).to.equal('Postal code');
+    });
+
     it('should add trimmed row context when provided', async () => {
       el = await fixture(html`
         <sl-grid>

--- a/packages/components/grid/src/column.spec.ts
+++ b/packages/components/grid/src/column.spec.ts
@@ -141,10 +141,12 @@ describe('sl-column', () => {
       expect(column.getFormControlLabel({ address: { zip: '12345' } })).to.equal('Zip');
     });
 
-    it('should use the header renderer result when it is a string', async () => {
+    it('should use the form control column label when provided', async () => {
       el = await fixture(html`
         <sl-grid>
-          <sl-grid-column path="address.zip" .header=${() => 'Postal code'}></sl-grid-column>
+          <sl-grid-column
+            form-control-column-label="Postal code"
+            path="address.zip"></sl-grid-column>
         </sl-grid>
       `);
 

--- a/packages/components/grid/src/column.ts
+++ b/packages/components/grid/src/column.ts
@@ -314,14 +314,20 @@ export class GridColumn<T = any> extends LitElement {
 
   /** Returns a label for form controls rendered inside this column. */
   getFormControlLabel(item: T): string {
-    const columnLabel =
-        typeof this.header === 'string' ? this.header : this.path ? getNameByPath(this.path) : '',
-      rowLabel = [
-        this.#getStringValueByKey(item, 'firstName'),
-        this.#getStringValueByKey(item, 'lastName')
-      ]
-        .filter(Boolean)
-        .join(' ');
+    let columnLabel = '';
+
+    if (typeof this.header === 'string') {
+      columnLabel = this.header;
+    } else if (this.path) {
+      columnLabel = getNameByPath(this.path);
+    }
+
+    const rowLabel = [
+      this.#getStringValueByKey(item, 'firstName'),
+      this.#getStringValueByKey(item, 'lastName')
+    ]
+      .filter(Boolean)
+      .join(' ');
 
     return [columnLabel, rowLabel].filter(Boolean).join(' ');
   }

--- a/packages/components/grid/src/column.ts
+++ b/packages/components/grid/src/column.ts
@@ -321,15 +321,9 @@ export class GridColumn<T = any> extends LitElement {
 
   /** Returns a label for form controls rendered inside this column. */
   getFormControlLabel(item: T): string {
-    let columnLabel = '';
-
-    if (typeof this.header === 'string') {
-      columnLabel = this.header;
-    } else if (this.path) {
-      columnLabel = getNameByPath(this.path);
-    }
-
-    const rowLabel = this.formControlLabel?.(item);
+    const headerLabel = typeof this.header === 'string' ? this.header.trim() : '',
+      columnLabel = headerLabel || (this.path ? getNameByPath(this.path) : ''),
+      rowLabel = this.formControlLabel?.(item)?.trim();
 
     return [columnLabel, rowLabel].filter(Boolean).join(' ');
   }

--- a/packages/components/grid/src/column.ts
+++ b/packages/components/grid/src/column.ts
@@ -42,6 +42,10 @@ export type GridColumnDataRenderer<T = any> = (model: T) => string | undefined |
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type GridColumnParts<T = any> = (model: T) => string | undefined;
 
+/** Custom label type for form controls rendered inside a cell. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type GridColumnFormControlLabel<T = any> = (model: T) => string | undefined;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type SlColumnUpdateEvent<T = any> = CustomEvent<{ grid: Grid; column: GridColumn<T> }>;
 
@@ -94,6 +98,9 @@ export class GridColumn<T = any> extends LitElement {
 
   /** This will ellipsize the text in the `<td>` elements when it overflows. */
   @property({ type: Boolean, attribute: 'ellipsize-text' }) ellipsizeText?: boolean;
+
+  /** Optional row context to add to form controls rendered inside a cell. */
+  @property({ attribute: false }) formControlLabel?: GridColumnFormControlLabel<T>;
 
   /** The parent grid instance. */
   @property({ attribute: false })
@@ -322,12 +329,7 @@ export class GridColumn<T = any> extends LitElement {
       columnLabel = getNameByPath(this.path);
     }
 
-    const rowLabel = [
-      this.#getStringValueByKey(item, 'firstName'),
-      this.#getStringValueByKey(item, 'lastName')
-    ]
-      .filter(Boolean)
-      .join(' ');
+    const rowLabel = this.formControlLabel?.(item);
 
     return [columnLabel, rowLabel].filter(Boolean).join(' ');
   }
@@ -355,15 +357,5 @@ export class GridColumn<T = any> extends LitElement {
     }
 
     return parts;
-  }
-
-  #getStringValueByKey(item: T, key: string): string {
-    if (item === ListDataSourcePlaceholder || !item || typeof item !== 'object') {
-      return '';
-    }
-
-    const value = (item as Record<string, unknown>)[key];
-
-    return typeof value === 'string' || typeof value === 'number' ? value.toString() : '';
   }
 }

--- a/packages/components/grid/src/column.ts
+++ b/packages/components/grid/src/column.ts
@@ -312,6 +312,20 @@ export class GridColumn<T = any> extends LitElement {
     }
   }
 
+  /** Returns a label for form controls rendered inside this column. */
+  getFormControlLabel(item: T): string {
+    const columnLabel =
+        typeof this.header === 'string' ? this.header : this.path ? getNameByPath(this.path) : '',
+      rowLabel = [
+        this.#getStringValueByKey(item, 'firstName'),
+        this.#getStringValueByKey(item, 'lastName')
+      ]
+        .filter(Boolean)
+        .join(' ');
+
+    return [columnLabel, rowLabel].filter(Boolean).join(' ');
+  }
+
   /**
    * Returns an array of strings that are set as part attributes on the `<td>` element. This is used
    * for styling the cells externally. Override this method if you want to add custom parts to the
@@ -335,5 +349,15 @@ export class GridColumn<T = any> extends LitElement {
     }
 
     return parts;
+  }
+
+  #getStringValueByKey(item: T, key: string): string {
+    if (item === ListDataSourcePlaceholder || !item || typeof item !== 'object') {
+      return '';
+    }
+
+    const value = (item as Record<string, unknown>)[key];
+
+    return typeof value === 'string' || typeof value === 'number' ? value.toString() : '';
   }
 }

--- a/packages/components/grid/src/column.ts
+++ b/packages/components/grid/src/column.ts
@@ -321,8 +321,7 @@ export class GridColumn<T = any> extends LitElement {
 
   /** Returns a label for form controls rendered inside this column. */
   getFormControlLabel(item: T): string {
-    const headerLabel = typeof this.header === 'string' ? this.header.trim() : '',
-      columnLabel = headerLabel || (this.path ? getNameByPath(this.path) : ''),
+    const columnLabel = this.#getHeaderLabel(),
       rowLabel = this.formControlLabel?.(item)?.trim();
 
     return [columnLabel, rowLabel].filter(Boolean).join(' ');
@@ -351,5 +350,18 @@ export class GridColumn<T = any> extends LitElement {
     }
 
     return parts;
+  }
+
+  #getHeaderLabel(): string {
+    let headerLabel = '';
+
+    if (typeof this.header === 'string') {
+      headerLabel = this.header.trim();
+    } else if (typeof this.header === 'function') {
+      const rendered = this.header(this);
+      headerLabel = typeof rendered === 'string' ? rendered.trim() : '';
+    }
+
+    return headerLabel || (this.path ? getNameByPath(this.path) : '');
   }
 }

--- a/packages/components/grid/src/column.ts
+++ b/packages/components/grid/src/column.ts
@@ -42,7 +42,9 @@ export type GridColumnDataRenderer<T = any> = (model: T) => string | undefined |
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type GridColumnParts<T = any> = (model: T) => string | undefined;
 
-/** Custom label type for form controls rendered inside a cell. */
+/** Callback that returns additional row context appended to the column label for form controls inside a cell.
+ * Return only the row context (e.g. "John Doe"), not the full label.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type GridColumnFormControlLabel<T = any> = (model: T) => string | undefined;
 

--- a/packages/components/grid/src/column.ts
+++ b/packages/components/grid/src/column.ts
@@ -42,8 +42,9 @@ export type GridColumnDataRenderer<T = any> = (model: T) => string | undefined |
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type GridColumnParts<T = any> = (model: T) => string | undefined;
 
-/** Callback that returns additional row context appended to the column label for form controls inside a cell.
- * Return only the row context (e.g. "John Doe"), not the full label.
+/**
+ * Callback that returns additional row context appended to the column label for form controls
+ * inside a cell. Return only the row context (e.g. "John Doe"), not the full label.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type GridColumnFormControlLabel<T = any> = (model: T) => string | undefined;
@@ -100,6 +101,9 @@ export class GridColumn<T = any> extends LitElement {
 
   /** This will ellipsize the text in the `<td>` elements when it overflows. */
   @property({ type: Boolean, attribute: 'ellipsize-text' }) ellipsizeText?: boolean;
+
+  /** Optional column label for form controls rendered inside a cell. */
+  @property({ attribute: 'form-control-column-label' }) formControlColumnLabel?: string;
 
   /** Optional row context to add to form controls rendered inside a cell. */
   @property({ attribute: false }) formControlLabel?: GridColumnFormControlLabel<T>;
@@ -355,15 +359,9 @@ export class GridColumn<T = any> extends LitElement {
   }
 
   #getHeaderLabel(): string {
-    let headerLabel = '';
+    const formControlColumnLabel = this.formControlColumnLabel?.trim(),
+      headerLabel = typeof this.header === 'string' ? this.header.trim() : '';
 
-    if (typeof this.header === 'string') {
-      headerLabel = this.header.trim();
-    } else if (typeof this.header === 'function') {
-      const rendered = this.header(this);
-      headerLabel = typeof rendered === 'string' ? rendered.trim() : '';
-    }
-
-    return headerLabel || (this.path ? getNameByPath(this.path) : '');
+    return formControlColumnLabel || headerLabel || (this.path ? getNameByPath(this.path) : '');
   }
 }

--- a/packages/components/grid/src/select-column.spec.ts
+++ b/packages/components/grid/src/select-column.spec.ts
@@ -1,3 +1,4 @@
+import { type Select } from '@sl-design-system/select';
 import { fixture } from '@sl-design-system/vitest-browser-lit';
 import { html } from 'lit';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -27,7 +28,7 @@ describe('sl-grid-select-column', () => {
   });
 
   it('should add an accessible name to the select button', async () => {
-    const select = el.renderRoot.querySelector('tbody tr:first-of-type sl-select');
+    const select = el.renderRoot.querySelector<Select>('tbody tr:first-of-type sl-select');
 
     await select?.updateComplete;
 

--- a/packages/components/grid/src/select-column.spec.ts
+++ b/packages/components/grid/src/select-column.spec.ts
@@ -30,8 +30,9 @@ describe('sl-grid-select-column', () => {
   it('should add an accessible name to the select button', async () => {
     const select = el.renderRoot.querySelector<Select>('tbody tr:first-of-type sl-select');
 
-    await select?.updateComplete;
+    expect(select).to.exist;
+    await select!.updateComplete;
 
-    expect(select?.button).to.have.attribute('aria-label', 'Status John Doe');
+    expect(select!.button).to.have.attribute('aria-label', 'Status John Doe');
   });
 });

--- a/packages/components/grid/src/select-column.spec.ts
+++ b/packages/components/grid/src/select-column.spec.ts
@@ -6,8 +6,11 @@ import '../register.js';
 import { type Grid } from './grid.js';
 import { waitForGridToRenderData } from './utils.js';
 
+type Person = { firstName: string; lastName: string; status: string };
+
 describe('sl-grid-select-column', () => {
   let el: Grid;
+  const personLabel = ({ firstName, lastName }: Person): string => `${firstName} ${lastName}`;
 
   beforeEach(async () => {
     el = await fixture(html`
@@ -20,6 +23,7 @@ describe('sl-grid-select-column', () => {
         <sl-grid-column path="lastName"></sl-grid-column>
         <sl-grid-select-column
           .options=${['Available', 'Busy']}
+          .formControlLabel=${personLabel}
           path="status"></sl-grid-select-column>
       </sl-grid>
     `);

--- a/packages/components/grid/src/select-column.spec.ts
+++ b/packages/components/grid/src/select-column.spec.ts
@@ -1,0 +1,36 @@
+import { fixture } from '@sl-design-system/vitest-browser-lit';
+import { html } from 'lit';
+import { beforeEach, describe, expect, it } from 'vitest';
+import '../register.js';
+import { type Grid } from './grid.js';
+import { waitForGridToRenderData } from './utils.js';
+
+describe('sl-grid-select-column', () => {
+  let el: Grid;
+
+  beforeEach(async () => {
+    el = await fixture(html`
+      <sl-grid
+        .items=${[
+          { firstName: 'John', lastName: 'Doe', status: 'Available' },
+          { firstName: 'Jane', lastName: 'Smith', status: 'Busy' }
+        ]}>
+        <sl-grid-column path="firstName"></sl-grid-column>
+        <sl-grid-column path="lastName"></sl-grid-column>
+        <sl-grid-select-column
+          .options=${['Available', 'Busy']}
+          path="status"></sl-grid-select-column>
+      </sl-grid>
+    `);
+
+    await waitForGridToRenderData(el);
+  });
+
+  it('should add an accessible name to the select button', async () => {
+    const select = el.renderRoot.querySelector('tbody tr:first-of-type sl-select');
+
+    await select?.updateComplete;
+
+    expect(select?.button).to.have.attribute('aria-label', 'Status John Doe');
+  });
+});

--- a/packages/components/grid/src/select-column.spec.ts
+++ b/packages/components/grid/src/select-column.spec.ts
@@ -4,12 +4,9 @@ import { html } from 'lit';
 import { beforeEach, describe, expect, it } from 'vitest';
 import '../register.js';
 import { type Grid } from './grid.js';
-import { waitForGridToRenderData } from './utils.js';
+import { waitForAriaForwarding, waitForGridToRenderData } from './utils.js';
 
 type Person = { firstName: string; lastName: string; status: string };
-
-const waitForAriaForwarding = (): Promise<void> =>
-  new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
 
 describe('sl-grid-select-column', () => {
   let el: Grid;

--- a/packages/components/grid/src/select-column.spec.ts
+++ b/packages/components/grid/src/select-column.spec.ts
@@ -8,6 +8,9 @@ import { waitForGridToRenderData } from './utils.js';
 
 type Person = { firstName: string; lastName: string; status: string };
 
+const waitForAriaForwarding = (): Promise<void> =>
+  new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
 describe('sl-grid-select-column', () => {
   let el: Grid;
   const personLabel = ({ firstName, lastName }: Person): string => `${firstName} ${lastName}`;
@@ -36,6 +39,7 @@ describe('sl-grid-select-column', () => {
 
     expect(select).to.exist;
     await select!.updateComplete;
+    await waitForAriaForwarding();
 
     expect(select!.button).to.have.attribute('aria-label', 'Status John Doe');
   });

--- a/packages/components/grid/src/select-column.ts
+++ b/packages/components/grid/src/select-column.ts
@@ -32,8 +32,8 @@ export class GridSelectColumn<T = any> extends GridColumn<T> {
       <td part="data select delegate-focus">
         <sl-select
           @sl-change=${(event: SlChangeEvent) => this.#onChange(event, item.data)}
-          .value=${getValueByPath(item.data, this.path!)}
-        >
+          aria-label=${this.getFormControlLabel(item.data)}
+          .value=${getValueByPath(item.data, this.path!)}>
           ${this.options?.map(option =>
             typeof option === 'string'
               ? html`<sl-option .value=${option}>${option}</sl-option>`

--- a/packages/components/grid/src/stories/editing.stories.ts
+++ b/packages/components/grid/src/stories/editing.stories.ts
@@ -1,9 +1,11 @@
-import { getPeople } from '@sl-design-system/example-data';
+import { type Person, getPeople } from '@sl-design-system/example-data';
 import { type Meta, type StoryObj } from '@storybook/web-components-vite';
 import { html } from 'lit';
 import '../../register.js';
 
 type Story = StoryObj;
+
+const personLabel = ({ firstName, lastName }: Person): string => `${firstName} ${lastName}`;
 
 export default {
   title: 'Grid/Editing',
@@ -19,7 +21,9 @@ export const TextField: Story = {
     <sl-grid .items=${people}>
       <sl-grid-column path="firstName"></sl-grid-column>
       <sl-grid-column path="lastName"></sl-grid-column>
-      <sl-grid-text-field-column path="address.zip"></sl-grid-text-field-column>
+      <sl-grid-text-field-column
+        path="address.zip"
+        .formControlLabel=${personLabel}></sl-grid-text-field-column>
     </sl-grid>
   `
 };
@@ -31,6 +35,7 @@ export const Select: Story = {
       <sl-grid-column path="lastName"></sl-grid-column>
       <sl-grid-select-column
         .options=${['Available', 'Busy']}
+        .formControlLabel=${personLabel}
         path="status"></sl-grid-select-column>
     </sl-grid>
   `

--- a/packages/components/grid/src/text-field-column.spec.ts
+++ b/packages/components/grid/src/text-field-column.spec.ts
@@ -4,12 +4,9 @@ import { html } from 'lit';
 import { beforeEach, describe, expect, it } from 'vitest';
 import '../register.js';
 import { type Grid } from './grid.js';
-import { waitForGridToRenderData } from './utils.js';
+import { waitForAriaForwarding, waitForGridToRenderData } from './utils.js';
 
 type Person = { firstName: string; lastName: string; address: { zip: string } };
-
-const waitForAriaForwarding = (): Promise<void> =>
-  new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
 
 describe('sl-grid-text-field-column', () => {
   let el: Grid;

--- a/packages/components/grid/src/text-field-column.spec.ts
+++ b/packages/components/grid/src/text-field-column.spec.ts
@@ -8,6 +8,9 @@ import { waitForGridToRenderData } from './utils.js';
 
 type Person = { firstName: string; lastName: string; address: { zip: string } };
 
+const waitForAriaForwarding = (): Promise<void> =>
+  new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
 describe('sl-grid-text-field-column', () => {
   let el: Grid;
   const personLabel = ({ firstName, lastName }: Person): string => `${firstName} ${lastName}`;
@@ -37,6 +40,7 @@ describe('sl-grid-text-field-column', () => {
 
     expect(textField).to.exist;
     await textField!.updateComplete;
+    await waitForAriaForwarding();
 
     expect(textField!.input).to.have.attribute('aria-label', 'Zip John Doe');
   });

--- a/packages/components/grid/src/text-field-column.spec.ts
+++ b/packages/components/grid/src/text-field-column.spec.ts
@@ -1,0 +1,34 @@
+import { fixture } from '@sl-design-system/vitest-browser-lit';
+import { html } from 'lit';
+import { beforeEach, describe, expect, it } from 'vitest';
+import '../register.js';
+import { type Grid } from './grid.js';
+import { waitForGridToRenderData } from './utils.js';
+
+describe('sl-grid-text-field-column', () => {
+  let el: Grid;
+
+  beforeEach(async () => {
+    el = await fixture(html`
+      <sl-grid
+        .items=${[
+          { firstName: 'John', lastName: 'Doe', address: { zip: '12345' } },
+          { firstName: 'Jane', lastName: 'Smith', address: { zip: '54321' } }
+        ]}>
+        <sl-grid-column path="firstName"></sl-grid-column>
+        <sl-grid-column path="lastName"></sl-grid-column>
+        <sl-grid-text-field-column path="address.zip"></sl-grid-text-field-column>
+      </sl-grid>
+    `);
+
+    await waitForGridToRenderData(el);
+  });
+
+  it('should add an accessible name to the text field', async () => {
+    const textField = el.renderRoot.querySelector('tbody tr:first-of-type sl-text-field');
+
+    await textField?.updateComplete;
+
+    expect(textField?.input).to.have.attribute('aria-label', 'Zip John Doe');
+  });
+});

--- a/packages/components/grid/src/text-field-column.spec.ts
+++ b/packages/components/grid/src/text-field-column.spec.ts
@@ -1,3 +1,4 @@
+import { type TextField } from '@sl-design-system/text-field';
 import { fixture } from '@sl-design-system/vitest-browser-lit';
 import { html } from 'lit';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -25,7 +26,9 @@ describe('sl-grid-text-field-column', () => {
   });
 
   it('should add an accessible name to the text field', async () => {
-    const textField = el.renderRoot.querySelector('tbody tr:first-of-type sl-text-field');
+    const textField = el.renderRoot.querySelector<TextField>(
+      'tbody tr:first-of-type sl-text-field'
+    );
 
     await textField?.updateComplete;
 

--- a/packages/components/grid/src/text-field-column.spec.ts
+++ b/packages/components/grid/src/text-field-column.spec.ts
@@ -6,8 +6,11 @@ import '../register.js';
 import { type Grid } from './grid.js';
 import { waitForGridToRenderData } from './utils.js';
 
+type Person = { firstName: string; lastName: string; address: { zip: string } };
+
 describe('sl-grid-text-field-column', () => {
   let el: Grid;
+  const personLabel = ({ firstName, lastName }: Person): string => `${firstName} ${lastName}`;
 
   beforeEach(async () => {
     el = await fixture(html`
@@ -18,7 +21,9 @@ describe('sl-grid-text-field-column', () => {
         ]}>
         <sl-grid-column path="firstName"></sl-grid-column>
         <sl-grid-column path="lastName"></sl-grid-column>
-        <sl-grid-text-field-column path="address.zip"></sl-grid-text-field-column>
+        <sl-grid-text-field-column
+          path="address.zip"
+          .formControlLabel=${personLabel}></sl-grid-text-field-column>
       </sl-grid>
     `);
 

--- a/packages/components/grid/src/text-field-column.spec.ts
+++ b/packages/components/grid/src/text-field-column.spec.ts
@@ -30,8 +30,9 @@ describe('sl-grid-text-field-column', () => {
       'tbody tr:first-of-type sl-text-field'
     );
 
-    await textField?.updateComplete;
+    expect(textField).to.exist;
+    await textField!.updateComplete;
 
-    expect(textField?.input).to.have.attribute('aria-label', 'Zip John Doe');
+    expect(textField!.input).to.have.attribute('aria-label', 'Zip John Doe');
   });
 });

--- a/packages/components/grid/src/text-field-column.ts
+++ b/packages/components/grid/src/text-field-column.ts
@@ -23,8 +23,8 @@ export class GridTextFieldColumn<T = any> extends GridColumn<T> {
       <td part="data text-field">
         <sl-text-field
           @sl-change=${(event: SlChangeEvent<string>) => this.#onChange(event, item.data)}
-          .value=${getValueByPath(item.data, this.path!)}
-        ></sl-text-field>
+          aria-label=${this.getFormControlLabel(item.data)}
+          .value=${getValueByPath(item.data, this.path!)}></sl-text-field>
       </td>
     `;
   }

--- a/packages/components/grid/src/utils.ts
+++ b/packages/components/grid/src/utils.ts
@@ -13,3 +13,9 @@ export function waitForGridToRenderData(grid: Grid): Promise<void> {
     checkForTd();
   });
 }
+
+export function waitForAriaForwarding(): Promise<void> {
+  return new Promise(resolve =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+  );
+}


### PR DESCRIPTION
## Summary

Fixes missing accessible names for form controls rendered inside editable grid cells.

Editable grid text fields and selects now receive an `aria-label` based on the column label and row context, for example `Zip John Doe` or `Status John Doe`. This makes tab navigation more useful for screen reader users in larger editable grids.

## Changes

- Added a shared grid column helper for building form control labels.
- Added `aria-label` to `sl-grid-text-field-column` controls.
- Added `aria-label` to `sl-grid-select-column` controls.
- Added regression tests for text field and select editable columns.


### BEFORE

https://github.com/user-attachments/assets/b980f109-c0e5-428c-8d84-2c8fd43f2ba8

### AFTER

https://github.com/user-attachments/assets/891156b9-f3d7-41b9-85fe-d62a48f24b49

