### PR TITLE
feat(menu-button): emit toggle event from menu button

### DIFF
--- a/.changeset/famous-rockets-stick.md
+++ b/.changeset/famous-rockets-stick.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/menu': minor
+---
+
+Add an `sl-toggle` event to `sl-menu-button` that emits `true` when the menu opens and `false` when it closes.

--- a/packages/components/menu/src/menu-button.spec.ts
+++ b/packages/components/menu/src/menu-button.spec.ts
@@ -136,6 +136,18 @@ describe('sl-menu-button', () => {
           expect(menu).to.match(':popover-open');
         });
 
+        it('should emit an sl-toggle event when the menu opens', async () => {
+          const event = new Promise<CustomEvent<boolean>>(resolve =>
+            el.addEventListener('sl-toggle', event => resolve(event as CustomEvent<boolean>), {
+              once: true
+            })
+          );
+
+          button.click();
+
+          expect((await event).detail).to.be.true;
+        });
+
         it('should not show the menu when the button is clicked while disabled', async () => {
           el.disabled = true;
           await el.updateComplete;
@@ -208,6 +220,18 @@ describe('sl-menu-button', () => {
           button.click();
 
           expect(menu).not.to.match(':popover-open');
+        });
+
+        it('should emit an sl-toggle event when the menu closes', async () => {
+          const event = new Promise<CustomEvent<boolean>>(resolve =>
+            el.addEventListener('sl-toggle', event => resolve(event as CustomEvent<boolean>), {
+              once: true
+            })
+          );
+
+          button.click();
+
+          expect((await event).detail).to.be.false;
         });
 
         it('should hide the menu when the escape key is pressed', async () => {

--- a/packages/components/menu/src/menu-button.stories.ts
+++ b/packages/components/menu/src/menu-button.stories.ts
@@ -166,7 +166,7 @@ export const Basic: Story = {
   }
 };
 
-export const ToggleEvent: Story = {
+export const OpenCloseEvent: Story = {
   render: () => {
     const onToggle = (event: CustomEvent<boolean>): void => {
       const wrapper = (event.currentTarget as HTMLElement).closest('.toggle-event'),

--- a/packages/components/menu/src/menu-button.stories.ts
+++ b/packages/components/menu/src/menu-button.stories.ts
@@ -166,6 +166,64 @@ export const Basic: Story = {
   }
 };
 
+export const ToggleEvent: Story = {
+  render: () => {
+    const onToggle = (event: CustomEvent<boolean>): void => {
+      const wrapper = (event.currentTarget as HTMLElement).closest('.toggle-event'),
+        state = wrapper?.querySelector<HTMLElement>('[data-menu-state]'),
+        value = event.detail ? 'Open' : 'Closed';
+
+      wrapper?.toggleAttribute('data-open', event.detail);
+
+      if (state) {
+        state.textContent = value;
+      }
+    };
+
+    return html`
+      <style>
+        .toggle-event {
+          align-items: center;
+          display: inline-grid;
+          gap: 1rem;
+          grid-template-columns: auto auto;
+        }
+
+        .toggle-event__status {
+          background: var(--sl-color-background-neutral-subtlest);
+          border: 1px solid var(--sl-color-border-neutral-plain);
+          border-radius: var(--sl-size-borderRadius-default);
+          color: var(--sl-color-foreground-neutral-bold);
+          font-weight: var(--sl-text-new-typeset-fontWeight-semiBold);
+          min-inline-size: 6rem;
+          padding: 0.4rem 0.6rem;
+          text-align: center;
+        }
+
+        .toggle-event[data-open] .toggle-event__status {
+          background: var(--sl-color-background-accent-green-subtle);
+          border-color: var(--sl-color-background-accent-green-bold);
+          color: var(--sl-color-foreground-accent-green-bold);
+        }
+      </style>
+      <div class="toggle-event">
+        <sl-menu-button @sl-toggle=${onToggle}>
+          <span slot="button">Actions</span>
+          <sl-menu-item>
+            <sl-icon name="far-pen"></sl-icon>
+            Rename...
+          </sl-menu-item>
+          <sl-menu-item>
+            <sl-icon name="far-trash"></sl-icon>
+            Delete...
+          </sl-menu-item>
+        </sl-menu-button>
+        <output aria-live="polite" class="toggle-event__status" data-menu-state>Closed</output>
+      </div>
+    `;
+  }
+};
+
 export const Disabled: Story = {
   args: {
     ...Basic.args,

--- a/packages/components/menu/src/menu-button.ts
+++ b/packages/components/menu/src/menu-button.ts
@@ -80,9 +80,8 @@ export class MenuButton extends ForwardAriaMixin(ScopedElementsMixin(LitElement)
   /** @internal The button. */
   @query('sl-button') button!: Button;
 
-  /** Emits when the menu opens or closes. The event detail is `true` when open and `false` when closed. */
+  /** @internal Emits when the menu opens or closes. The event detail is `true` when open and `false` when closed. */
   @event({ name: 'sl-toggle' }) toggleEvent!: EventEmitter<SlToggleEvent<boolean>>;
-
   /**
    * Whether the button is disabled; when set no interaction is possible.
    *

--- a/packages/components/menu/src/menu-button.ts
+++ b/packages/components/menu/src/menu-button.ts
@@ -80,7 +80,7 @@ export class MenuButton extends ForwardAriaMixin(ScopedElementsMixin(LitElement)
   /** @internal The button. */
   @query('sl-button') button!: Button;
 
-  /** Emits when the menu opens or closes. The event detail is `true` when open. */
+  /** Emits when the menu opens or closes. The event detail is `true` when open and `false` when closed. */
   @event({ name: 'sl-toggle' }) toggleEvent!: EventEmitter<SlToggleEvent<boolean>>;
 
   /**

--- a/packages/components/menu/src/menu-button.ts
+++ b/packages/components/menu/src/menu-button.ts
@@ -11,7 +11,13 @@ import {
   type ButtonVariant
 } from '@sl-design-system/button';
 import { Icon } from '@sl-design-system/icon';
-import { EventsController, type PopoverPosition } from '@sl-design-system/shared';
+import {
+  type EventEmitter,
+  EventsController,
+  type PopoverPosition,
+  event
+} from '@sl-design-system/shared';
+import { type SlToggleEvent } from '@sl-design-system/shared/events.js';
 import { isForwardedDisabled } from '@sl-design-system/shared/helpers/forward-aria.js';
 import { ForwardAriaMixin } from '@sl-design-system/shared/mixins.js';
 import {
@@ -73,6 +79,9 @@ export class MenuButton extends ForwardAriaMixin(ScopedElementsMixin(LitElement)
 
   /** @internal The button. */
   @query('sl-button') button!: Button;
+
+  /** Emits when the menu opens or closes. The event detail is `true` when open. */
+  @event({ name: 'sl-toggle' }) toggleEvent!: EventEmitter<SlToggleEvent<boolean>>;
 
   /**
    * Whether the button is disabled; when set no interaction is possible.
@@ -232,6 +241,7 @@ export class MenuButton extends ForwardAriaMixin(ScopedElementsMixin(LitElement)
 
   #onToggle(event: ToggleEvent): void {
     this.#popoverState = event.newState;
+    this.toggleEvent.emit(event.newState === 'open');
 
     if (event.newState === 'closed' && this.menu.matches(':focus-within')) {
       this.button.focus();


### PR DESCRIPTION
## Summary

Adds a public `sl-toggle` event to `sl-menu-button`.

The event is emitted whenever the menu popover opens or closes:
- `event.detail === true` when the menu opens
- `event.detail === false` when the menu closes

This allows consumers to react to menu state changes, for example to apply external styling or trigger related UI updates while the menu is open.


### AFTER 

https://github.com/user-attachments/assets/28da1eaf-792c-45b6-8bc5-614d146349b2


