### PR TITLE
fix(panel): avoid rendering empty actions toolbar

### DIFF
--- a/.changeset/late-baboons-guess.md
+++ b/.changeset/late-baboons-guess.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/panel': patch
+---
+
+Fix an accessibility issue where panels without actions rendered an empty toolbar in the header. The toolbar is now only rendered when the actions slot contains elements, preventing screen readers from announcing an empty toolbar.

--- a/packages/components/panel/src/panel.spec.ts
+++ b/packages/components/panel/src/panel.spec.ts
@@ -325,9 +325,12 @@ describe('sl-panel', () => {
       expect(el).to.have.attribute('has-actions');
     });
 
-    it('should render a tool bar for actions', () => {
-      const toolBar = el.renderRoot.querySelector('sl-tool-bar');
+    it('should render a tool bar for actions', async () => {
+      // Slot distribution happens async; the toolbar is rendered on the subsequent update.
+      await new Promise(resolve => requestAnimationFrame(resolve));
+      await el.updateComplete;
 
+      const toolBar = el.renderRoot.querySelector('sl-tool-bar');
       expect(toolBar).to.exist;
     });
 

--- a/packages/components/panel/src/panel.spec.ts
+++ b/packages/components/panel/src/panel.spec.ts
@@ -35,6 +35,12 @@ describe('sl-panel', () => {
       expect(el).not.to.have.attribute('has-actions');
     });
 
+    it('should not render an empty tool bar', () => {
+      const toolBar = el.renderRoot.querySelector('sl-tool-bar');
+
+      expect(toolBar).not.to.exist;
+    });
+
     it('should not render the wrapper as a button', () => {
       const wrapper = el.renderRoot.querySelector('[part="wrapper"]');
 
@@ -317,6 +323,23 @@ describe('sl-panel', () => {
 
     it('should have has-actions attribute', () => {
       expect(el).to.have.attribute('has-actions');
+    });
+
+    it('should render a tool bar for actions', () => {
+      const toolBar = el.renderRoot.querySelector('sl-tool-bar');
+
+      expect(toolBar).to.exist;
+    });
+
+    it('should remove the tool bar when actions are removed', async () => {
+      el.querySelector('[slot="actions"]')?.remove();
+      await new Promise(resolve => requestAnimationFrame(resolve));
+      await el.updateComplete;
+
+      const toolBar = el.renderRoot.querySelector('sl-tool-bar');
+
+      expect(toolBar).not.to.exist;
+      expect(el).not.to.have.attribute('has-actions');
     });
 
     it('should slot the content into the default slot', () => {

--- a/packages/components/panel/src/panel.ts
+++ b/packages/components/panel/src/panel.ts
@@ -15,7 +15,7 @@ import {
   type TemplateResult,
   html
 } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './panel.scss.js';
 
@@ -124,6 +124,9 @@ export class Panel extends ScopedElementsMixin(LitElement) {
    */
   #addedNoTransitionInternally = false;
 
+  /** @internal Whether the actions slot has slotted elements. */
+  @state() private accessor hasActions = false;
+
   override connectedCallback(): void {
     super.connectedCallback();
 
@@ -191,9 +194,13 @@ export class Panel extends ScopedElementsMixin(LitElement) {
             `
           : html`<div part="wrapper">${this.#renderHeading()}</div>`}
         <slot name="aside">
-          <sl-tool-bar align="end" fill=${ifDefined(this.fill)}>
-            <slot @slotchange=${this.#onActionsSlotChange} name="actions"></slot>
-          </sl-tool-bar>
+          ${this.hasActions
+            ? html`
+                <sl-tool-bar align="end" fill=${ifDefined(this.fill)}>
+                  <slot @slotchange=${this.#onActionsSlotChange} name="actions"></slot>
+                </sl-tool-bar>
+              `
+            : html`<slot @slotchange=${this.#onActionsSlotChange} hidden name="actions"></slot>`}
         </slot>
       </div>
       <div
@@ -298,6 +305,7 @@ export class Panel extends ScopedElementsMixin(LitElement) {
       }
     });
 
-    this.toggleAttribute('has-actions', elements.length > 0);
+    this.hasActions = elements.length > 0;
+    this.toggleAttribute('has-actions', this.hasActions);
   }
 }

--- a/packages/components/panel/src/panel.ts
+++ b/packages/components/panel/src/panel.ts
@@ -125,7 +125,7 @@ export class Panel extends ScopedElementsMixin(LitElement) {
   #addedNoTransitionInternally = false;
 
   /** @internal Whether the actions slot has slotted elements. */
-  @state() private accessor hasActions = false;
+  @state() private hasActions = false;
 
   override connectedCallback(): void {
     super.connectedCallback();


### PR DESCRIPTION
## Summary

Fixes an a11y issue in `sl-panel` where an empty `sl-tool-bar` was rendered in the header even when no `actions` were slotted. Because `sl-tool-bar` exposes `role="toolbar"`, screen readers could announce an invisible empty toolbar in stories such as `Layout/Panel/Toggle Externally`.

The panel now renders the toolbar only when the `actions` slot has assigned elements. When there are no actions, it keeps a hidden actions slot only for slotchange detection, so dynamically added actions still work.
