### PR TITLE
fix(tree): render checkbox node labels

### DIFF
--- a/.changeset/fast-dogs-speak.md
+++ b/.changeset/fast-dogs-speak.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/tree': patch
+---
+
+Fix tree node labels not being visible in multiple-selection trees. Tree node content is now passed to the checkbox `label` slot so labels remain visible when checkbox infotip support is enabled.

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -285,11 +285,12 @@ describe('sl-tree-node', () => {
     });
 
     it('should render the label in the checkbox label slot', () => {
-      const checkbox = el.renderRoot.querySelector('sl-checkbox'),
-        labelSlot = checkbox?.querySelector('slot[slot="label"]');
+      const checkbox = el.renderRoot.querySelector('sl-checkbox') as HTMLElement | null,
+        labelSlot = checkbox?.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="label"]'),
+        labelText = labelSlot?.assignedNodes({ flatten: true }).map(n => n.textContent ?? '').join('').trim();
 
       expect(labelSlot).to.exist;
-    });
+      expect(labelText).to.equal('Lorem');
     it('should toggle the checkbox when clicking the text', async () => {
       el.querySelector('span')?.click();
       await el.updateComplete;

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -287,13 +287,18 @@ describe('sl-tree-node', () => {
     it('should render the label in the checkbox label slot', () => {
       const checkbox = el.renderRoot.querySelector('sl-checkbox') as HTMLElement | null,
         labelSlot = checkbox?.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="label"]'),
-        labelText = labelSlot?.assignedNodes({ flatten: true }).map(n => n.textContent ?? '').join('').trim();
+        labelText = labelSlot
+          ?.assignedNodes({ flatten: true })
+          .map(n => n.textContent ?? '')
+          .join('')
+          .trim();
 
       expect(labelSlot).to.exist;
       expect(labelText).to.equal('Lorem');
     });
 
     it('should toggle the checkbox when clicking the text', async () => {
+      el.querySelector('span')?.click();
       await el.updateComplete;
 
       expect(el).to.have.attribute('aria-selected', 'true');

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -291,8 +291,9 @@ describe('sl-tree-node', () => {
 
       expect(labelSlot).to.exist;
       expect(labelText).to.equal('Lorem');
+    });
+
     it('should toggle the checkbox when clicking the text', async () => {
-      el.querySelector('span')?.click();
       await el.updateComplete;
 
       expect(el).to.have.attribute('aria-selected', 'true');

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -289,7 +289,7 @@ describe('sl-tree-node', () => {
         labelSlot = checkbox?.querySelector('slot[slot="label"]');
 
       expect(labelSlot).to.exist;
-
+    });
     it('should toggle the checkbox when clicking the text', async () => {
       el.querySelector('span')?.click();
       await el.updateComplete;

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -284,6 +284,13 @@ describe('sl-tree-node', () => {
       expect(checkbox).to.exist;
     });
 
+    it('should render the label in the checkbox label slot', () => {
+      const checkbox = el.renderRoot.querySelector('sl-checkbox'),
+        slot = checkbox?.querySelector('slot');
+
+      expect(slot).to.have.attribute('slot', 'label');
+    });
+
     it('should toggle the checkbox when clicking the text', async () => {
       el.querySelector('span')?.click();
       await el.updateComplete;

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -287,13 +287,18 @@ describe('sl-tree-node', () => {
     it('should render the label in the checkbox label slot', () => {
       const checkbox = el.renderRoot.querySelector('sl-checkbox') as HTMLElement | null,
         labelSlot = checkbox?.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="label"]'),
-        labelText = labelSlot
+        input = checkbox?.querySelector<HTMLInputElement>('input[slot="input"]'),
+        label = checkbox?.querySelector<HTMLLabelElement>('label[slot="label"]'),
+        labelText = label
+          ?.querySelector('slot')
           ?.assignedNodes({ flatten: true })
-          .map(n => n.textContent ?? '')
+          .map(node => node.textContent ?? '')
           .join('')
           .trim();
 
       expect(labelSlot).to.exist;
+      expect(label).to.have.property('htmlFor', input?.id);
+      expect(input?.labels?.[0]).to.equal(label);
       expect(labelText).to.equal('Lorem');
     });
 

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -286,10 +286,9 @@ describe('sl-tree-node', () => {
 
     it('should render the label in the checkbox label slot', () => {
       const checkbox = el.renderRoot.querySelector('sl-checkbox'),
-        slot = checkbox?.querySelector('slot');
+        labelSlot = checkbox?.querySelector('slot[slot="label"]');
 
-      expect(slot).to.have.attribute('slot', 'label');
-    });
+      expect(labelSlot).to.exist;
 
     it('should toggle the checkbox when clicking the text', async () => {
       el.querySelector('span')?.click();

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -298,8 +298,20 @@ describe('sl-tree-node', () => {
 
       expect(labelSlot).to.exist;
       expect(label).to.have.property('htmlFor', input?.id);
+      expect(label?.id).to.equal(`${input?.id}-label`);
       expect(input?.labels?.[0]).to.equal(label);
       expect(labelText).to.equal('Lorem');
+    });
+
+    it('should use the checkbox label as the input accessible name', async () => {
+      const checkbox = el.renderRoot.querySelector('sl-checkbox') as HTMLElement | null,
+        input = checkbox?.querySelector<HTMLInputElement>('input[slot="input"]'),
+        label = checkbox?.querySelector<HTMLLabelElement>('label[slot="label"]');
+
+      await new Promise(requestAnimationFrame);
+
+      expect(label?.id).not.to.equal('');
+      expect(input).to.have.attribute('aria-labelledby', label?.id);
     });
 
     it('should toggle the checkbox when clicking the text', async () => {

--- a/packages/components/tree/src/tree-node.ts
+++ b/packages/components/tree/src/tree-node.ts
@@ -223,7 +223,7 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
                       part="checkbox"
                       size="sm">
                       <input slot="input" tabindex="-1" type="checkbox" />
-                      <slot></slot>
+                      <slot slot="label"></slot>
                     </sl-checkbox>
                   `
                 : html`

--- a/packages/components/tree/src/tree-node.ts
+++ b/packages/components/tree/src/tree-node.ts
@@ -39,6 +39,8 @@ export type TreeNodeContextMenu<T> = (node: TreeDataSourceNode<T>) => Menu | und
 
 export type TreeNodeType = 'node' | 'placeholder' | 'skeleton';
 
+let nextCheckboxId = 0;
+
 /**
  * A tree node component. Used to represent a node in a tree. This component is not public API and
  * is used internally by `<sl-tree>`.
@@ -66,6 +68,8 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
     click: this.#onClick,
     keydown: this.#onKeydown
   });
+
+  #checkboxInputId = `sl-tree-node-checkbox-${nextCheckboxId++}`;
 
   /** @internal Emits when the checked state of the checkbox changes. */
   @event({ name: 'sl-change' }) changeEvent!: EventEmitter<SlChangeEvent<boolean>>;
@@ -222,8 +226,12 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
                       exportparts="label"
                       part="checkbox"
                       size="sm">
-                      <input slot="input" tabindex="-1" type="checkbox" />
-                      <slot slot="label"></slot>
+                      <input
+                        id=${this.#checkboxInputId}
+                        slot="input"
+                        tabindex="-1"
+                        type="checkbox" />
+                      <label for=${this.#checkboxInputId} slot="label"><slot></slot></label>
                     </sl-checkbox>
                   `
                 : html`

--- a/packages/components/tree/src/tree-node.ts
+++ b/packages/components/tree/src/tree-node.ts
@@ -231,7 +231,12 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
                         slot="input"
                         tabindex="-1"
                         type="checkbox" />
-                      <label for=${this.#checkboxInputId} slot="label"><slot></slot></label>
+                      <label
+                        id=${`${this.#checkboxInputId}-label`}
+                        for=${this.#checkboxInputId}
+                        slot="label"
+                        ><slot></slot
+                      ></label>
                     </sl-checkbox>
                   `
                 : html`


### PR DESCRIPTION
## Summary

Fixes tree node labels disappearing in multiple-selection trees after checkbox infotip support was added.

Tree nodes in `multiple` mode render their content inside `sl-checkbox`. The checkbox now hides its default slot while synthesizing labels, so the nested tree node slot was no longer visible. This change forwards the tree node content to the checkbox `label` slot directly.

### BEFORE
<img width="906" height="765" alt="Screenshot 2026-07-14 at 13 34 23" src="https://github.com/user-attachments/assets/2e289d35-ba92-4af3-810b-dd6c49f496dc" />


### AFTER
<img width="847" height="744" alt="Screenshot 2026-07-14 at 13 34 42" src="https://github.com/user-attachments/assets/8f3759a1-a5e5-4528-a184-facab21d9955" />
