### PR TITLE
fix(grid): header keyboard scroll sync

### DIFF
--- a/.changeset/wicked-heads-call.md
+++ b/.changeset/wicked-heads-call.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Fix horizontal scroll synchronization when keyboard focus moves through sortable grid column headers. The grid now keeps the header and body aligned when the header is scrolled by keyboard navigation.

--- a/packages/components/grid/src/grid.spec.ts
+++ b/packages/components/grid/src/grid.spec.ts
@@ -534,6 +534,36 @@ describe('sl-grid', () => {
     });
   });
 
+  describe('scrolling', () => {
+    beforeEach(async () => {
+      el = await fixture(html`
+        <sl-grid
+          .items=${[
+            { firstName: 'John', lastName: 'Doe' },
+            { firstName: 'Jane', lastName: 'Smith' }
+          ]}
+          style="inline-size: 320px">
+          <sl-grid-selection-column sticky></sl-grid-selection-column>
+          <sl-grid-sort-column grow="0" path="firstName" width="220"></sl-grid-sort-column>
+          <sl-grid-sort-column grow="0" path="lastName" width="220"></sl-grid-sort-column>
+          <sl-grid-sort-column grow="0" path="email" width="220"></sl-grid-sort-column>
+        </sl-grid>
+      `);
+
+      await waitForGridToRenderData(el);
+    });
+
+    it('should sync the body when the header is scrolled', () => {
+      const thead = el.renderRoot.querySelector<HTMLTableSectionElement>('thead')!,
+        tbody = el.renderRoot.querySelector<HTMLTableSectionElement>('tbody')!;
+
+      thead.scrollLeft = 240;
+      thead.dispatchEvent(new Event('scroll'));
+
+      expect(tbody.scrollLeft).to.equal(thead.scrollLeft);
+    });
+  });
+
   describe('row action activate', () => {
     beforeEach(async () => {
       el = await fixture(html`

--- a/packages/components/grid/src/grid.spec.ts
+++ b/packages/components/grid/src/grid.spec.ts
@@ -572,6 +572,7 @@ describe('sl-grid', () => {
 
       expect(thead.scrollLeft).to.equal(tbody.scrollLeft);
     });
+  });
 
   describe('row action activate', () => {
     beforeEach(async () => {

--- a/packages/components/grid/src/grid.spec.ts
+++ b/packages/components/grid/src/grid.spec.ts
@@ -562,7 +562,16 @@ describe('sl-grid', () => {
 
       expect(tbody.scrollLeft).to.equal(thead.scrollLeft);
     });
-  });
+
+    it('should sync the header when the body is scrolled', () => {
+      const thead = el.renderRoot.querySelector<HTMLTableSectionElement>('thead')!,
+        tbody = el.renderRoot.querySelector<HTMLTableSectionElement>('tbody')!;
+
+      tbody.scrollLeft = 240;
+      tbody.dispatchEvent(new Event('scroll'));
+
+      expect(thead.scrollLeft).to.equal(tbody.scrollLeft);
+    });
 
   describe('row action activate', () => {
     beforeEach(async () => {

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -180,6 +180,9 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
   /** The item before the dragged item when dragging started. */
   #itemBeforeDragItem?: ListDataSourceItem<T>;
 
+  /** Prevent recursive scroll syncing between the header and body. */
+  #scrollSyncing = false;
+
   /** Observe the tbody style changes. */
   #mutationObserver = new MutationObserver(() => {
     this.#mutationObserver?.disconnect();
@@ -409,7 +412,8 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
     });
     this.#mutationObserver?.observe(this.tbody, { attributes: true, attributeFilter: ['style'] });
 
-    this.tbody.addEventListener('scroll', () => this.#onScroll(), { passive: true });
+    this.tbody.addEventListener('scroll', () => this.#onBodyScroll(), { passive: true });
+    this.thead.addEventListener('scroll', () => this.#onHeaderScroll(), { passive: true });
     this.tbody.addEventListener('focusin', (event: FocusEvent) => this.#onFocusIn(event));
 
     // Workaround for https://github.com/lit/lit/issues/4232
@@ -1021,11 +1025,21 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
     this.dataSource?.update();
   }
 
+  #onBodyScroll(): void {
+    this.#syncScrollLeft(this.tbody, this.thead);
+    this.#onScroll();
+  }
+
+  #onHeaderScroll(): void {
+    this.#syncScrollLeft(this.thead, this.tbody);
+    this.#onScroll();
+  }
+
   #onScroll(): void {
     const { offsetWidth, scrollLeft, scrollWidth } = this.tbody;
 
     this.scrollbar = scrollWidth > offsetWidth;
-    this.thead.scrollLeft = scrollLeft;
+    this.#syncScrollLeft(this.tbody, this.thead);
 
     this.toggleAttribute('scrollable', this.scrollbar);
     this.toggleAttribute('scrollable-start', this.scrollbar && scrollLeft > 0);
@@ -1033,6 +1047,16 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
       'scrollable-end',
       this.scrollbar && Math.round(scrollLeft) < scrollWidth - offsetWidth
     );
+  }
+
+  #syncScrollLeft(source: HTMLElement, target: HTMLElement): void {
+    if (this.#scrollSyncing || target.scrollLeft === source.scrollLeft) {
+      return;
+    }
+
+    this.#scrollSyncing = true;
+    target.scrollLeft = source.scrollLeft;
+    this.#scrollSyncing = false;
   }
 
   #onSelectionChange = (): void => {

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -1030,6 +1030,10 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
   }
 
   #onHeaderScroll(): void {
+    if (this.thead.scrollLeft === this.tbody.scrollLeft) {
+      return;
+    }
+
     this.#syncScrollLeft(this.thead, this.tbody);
     this.#onScroll();
   }

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -1026,7 +1026,6 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
   }
 
   #onBodyScroll(): void {
-    this.#syncScrollLeft(this.tbody, this.thead);
     this.#onScroll();
   }
 

--- a/packages/components/grid/src/stories/basics.stories.ts
+++ b/packages/components/grid/src/stories/basics.stories.ts
@@ -161,6 +161,23 @@ export const Header: Story = {
   `
 };
 
+export const KeyboardHeaderScroll: Story = {
+  render: (_, { loaded: { students } }) => html`
+    <p>
+      This example shows keyboard navigation through sortable column headers in a horizontally
+      scrollable grid with a sticky selection column.
+    </p>
+    <sl-grid .items=${students} style="inline-size: 320px" no-skip-links>
+      <sl-grid-selection-column sticky></sl-grid-selection-column>
+      <sl-grid-sort-column grow="0" path="firstName" width="220"></sl-grid-sort-column>
+      <sl-grid-sort-column grow="0" path="lastName" width="220"></sl-grid-sort-column>
+      <sl-grid-sort-column grow="0" path="email" width="260"></sl-grid-sort-column>
+      <sl-grid-sort-column grow="0" path="school.name" width="260"></sl-grid-sort-column>
+    </sl-grid>
+    <button type="button">Focus after grid</button>
+  `
+};
+
 export const MenuButton: Story = {
   render: (_, { loaded: { students } }) => {
     const menuButtonRenderer: GridColumnDataRenderer<Student> = () => {


### PR DESCRIPTION
## Summary

Fixes horizontal scroll synchronization in `sl-grid` when keyboard focus moves through sortable column headers.

Previously, the grid only synchronized scroll position from `tbody` to `thead`. When users navigated through sortable headers with `Tab` or `Shift+Tab`, the browser could scroll the `thead` to reveal the focused header control, but the `tbody` stayed at the previous horizontal scroll position. This caused column headers and row cells to become visually misaligned.

This change adds two-way horizontal scroll synchronization between `thead` and `tbody`, with a guard to avoid recursive scroll updates.

### BEFORE

https://github.com/user-attachments/assets/be964c8e-d747-446c-8281-891eebc30382


### AFTER

https://github.com/user-attachments/assets/b930dda7-208f-40d8-8053-d928249b778a




