### PR TITLE
fix(select): handle non-document roots when cloning selected content

### DIFF
--- a/.changeset/moody-sloths-work.md
+++ b/.changeset/moody-sloths-work.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/select': patch
+---
+
+Fix `sl-select` selected content rendering when projected option content temporarily has a non-document root, such as during Angular light DOM updates. The component now preserves scoped custom element importing when available and falls back to the node owner document otherwise.

--- a/packages/components/select/src/select.spec.ts
+++ b/packages/components/select/src/select.spec.ts
@@ -1290,6 +1290,31 @@ describe('sl-select', () => {
       expect(container).to.have.trimmed.text('Bold text');
     });
 
+    it('should render selected content when a slotted node root is not a document', async () => {
+      el = await fixture(html`
+        <sl-select>
+          <sl-option value="1"><span>Option 1</span></sl-option>
+          <sl-option value="2">Option 2</sl-option>
+        </sl-select>
+      `);
+
+      button = el.querySelector('sl-select-button')!;
+
+      const node = el.querySelector('sl-option[value="1"] span')!;
+      Object.defineProperty(node, 'getRootNode', {
+        configurable: true,
+        value: () => document.createDocumentFragment()
+      });
+
+      el.value = '1';
+      await el.updateComplete;
+
+      const container = button.querySelector('[slot="selected-content"]');
+
+      expect(container).to.exist;
+      expect(container).to.have.trimmed.text('Option 1');
+    });
+
     it('should handle options with multiple slotted nodes', async () => {
       el = await fixture(html`
         <sl-select>

--- a/packages/components/select/src/select.ts
+++ b/packages/components/select/src/select.ts
@@ -445,14 +445,14 @@ export class Select<T = any> extends ObserveAttributesMixin(
         const scopedImportNode = (rootNode as Partial<Pick<Document, 'importNode'>>).importNode;
         const ownerDocument = node.ownerDocument ?? document;
 
+        // Use a scoped importNode() implementation when available so cloned custom
+        // elements are upgraded; otherwise fall back to the owner document for
+        // non-document roots such as DocumentFragment.
         const clone =
           typeof scopedImportNode === 'function'
             ? scopedImportNode.call(rootNode, node, true)
             : ownerDocument.importNode(node, true);
 
-        // Unlike node.cloneNode(), importNode() is implemented in the
-        // scoped custom element registry polyfill, so it will upgrade
-        // the cloned node if it's a custom element.
         clones.push(clone);
       });
 

--- a/packages/components/select/src/select.ts
+++ b/packages/components/select/src/select.ts
@@ -442,11 +442,17 @@ export class Select<T = any> extends ObserveAttributesMixin(
 
       slotNodes.forEach(node => {
         const rootNode = node.getRootNode();
+        const scopedImportNode = (rootNode as Partial<Pick<Document, 'importNode'>>).importNode;
+        const ownerDocument = node.ownerDocument ?? document;
+        const importNode =
+          typeof scopedImportNode === 'function'
+            ? scopedImportNode.bind(rootNode)
+            : ownerDocument.importNode.bind(ownerDocument);
 
         // Unlike node.cloneNode(), importNode() is implemented in the
         // scoped custom element registry polyfill, so it will upgrade
         // the cloned node if it's a custom element.
-        clones.push((rootNode as Document).importNode(node, true));
+        clones.push(importNode(node, true));
       });
 
       container.replaceChildren(...clones);

--- a/packages/components/select/src/select.ts
+++ b/packages/components/select/src/select.ts
@@ -444,15 +444,16 @@ export class Select<T = any> extends ObserveAttributesMixin(
         const rootNode = node.getRootNode();
         const scopedImportNode = (rootNode as Partial<Pick<Document, 'importNode'>>).importNode;
         const ownerDocument = node.ownerDocument ?? document;
-        const importNode =
+
+        const clone =
           typeof scopedImportNode === 'function'
-            ? scopedImportNode.bind(rootNode)
-            : ownerDocument.importNode.bind(ownerDocument);
+            ? scopedImportNode.call(rootNode, node, true)
+            : ownerDocument.importNode(node, true);
 
         // Unlike node.cloneNode(), importNode() is implemented in the
         // scoped custom element registry polyfill, so it will upgrade
         // the cloned node if it's a custom element.
-        clones.push(importNode(node, true));
+        clones.push(clone);
       });
 
       container.replaceChildren(...clones);


### PR DESCRIPTION
## Summary

Fixes a crash in `sl-select` when rendering selected option content while projected option light DOM is being updated.

`renderSelectedContent()` assumed that `node.getRootNode()` always returns a `Document` and called `importNode()` on it. During framework-driven light DOM churn, such as Angular remounting or updating projected `sl-option` content, the root can be a `DocumentFragment`, which does not implement `importNode()`.

The fix keeps the scoped custom element registry behavior when available, but falls back to the node’s owner document when the current root cannot import nodes.

## Changes

- Use root-level `importNode()` only when the current root supports it.
- Fall back to `ownerDocument.importNode()` for non-document roots.
- Add a regression test for selected content rendering when a slotted node root is not a document.

### BEFORE

https://github.com/user-attachments/assets/fd630277-a117-48ba-985d-a119c9865a40

### AFTER 

https://github.com/user-attachments/assets/fe35fc62-797a-445c-96f3-08c4640c5a1a

