### PR TITLE
fix(data-source): type filters in fetch list callback options

### DIFF
--- a/.changeset/typed-fetch-list-filters.md
+++ b/.changeset/typed-fetch-list-filters.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/data-source': patch
+---
+
+Add a typed `filters` property to `FetchListDataSourceCallbackOptions`.

--- a/packages/components/data-source/src/fetch-list-data-source.spec.ts
+++ b/packages/components/data-source/src/fetch-list-data-source.spec.ts
@@ -1,7 +1,9 @@
 import { spy } from 'sinon';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
+import { type DataSourceFilter } from './data-source.js';
 import {
   FetchListDataSource,
+  type FetchListDataSourceCallback,
   type FetchListDataSourceCallbackOptions
 } from './fetch-list-data-source.js';
 import { type ListDataSourceDataItem, ListDataSourcePlaceholder } from './list-data-source.js';
@@ -9,6 +11,19 @@ import { type Person, people } from './list-data-source.spec.js';
 
 describe('FetchListDataSource', () => {
   let ds: FetchListDataSource<Person>;
+
+  it('should provide typed filter options to the fetchPage callback', () => {
+    const fetchPage: FetchListDataSourceCallback<Person> = options => {
+      expectTypeOf(options.filters).toEqualTypeOf<Array<DataSourceFilter<Person>> | undefined>();
+      expectTypeOf(options.filters?.[0]?.by).toEqualTypeOf<
+        DataSourceFilter<Person>['by'] | undefined
+      >();
+
+      return Promise.resolve({ items: [] });
+    };
+
+    expectTypeOf(fetchPage).toEqualTypeOf<FetchListDataSourceCallback<Person>>();
+  });
 
   describe('defaults', () => {
     beforeEach(() => {

--- a/packages/components/data-source/src/fetch-list-data-source.ts
+++ b/packages/components/data-source/src/fetch-list-data-source.ts
@@ -1,4 +1,4 @@
-import { type DataSourceSort } from './data-source.js';
+import { type DataSourceFilter, type DataSourceSort } from './data-source.js';
 import {
   ListDataSource,
   type ListDataSourceDataItem,
@@ -11,6 +11,7 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface FetchListDataSourceCallbackOptions<T = any> {
+  filters?: Array<DataSourceFilter<T>>;
   group: FetchListDataSourceGroupItem<T>['id'];
   page: number;
   pageSize: number;
@@ -24,7 +25,7 @@ export interface FetchListDataSourceCallbackResult<T> {
 }
 
 export type FetchListDataSourceCallback<T> = (
-  options: FetchListDataSourceCallbackOptions
+  options: FetchListDataSourceCallbackOptions<T>
 ) => Promise<FetchListDataSourceCallbackResult<T>>;
 
 export type FetchListDataSourcePlaceholder<T> = (n: number) => T;
@@ -66,7 +67,8 @@ export interface FetchListDataSourceOptions<T> extends ListDataSourceOptions<T> 
   size?: number;
 }
 
-export type FetchListDataSourceEvent = CustomEvent<FetchListDataSourceCallbackOptions>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type FetchListDataSourceEvent<T = any> = CustomEvent<FetchListDataSourceCallbackOptions<T>>;
 
 export class FetchListDataSourceError extends Error {
   constructor(
@@ -212,7 +214,7 @@ export class FetchListDataSource<T = any> extends ListDataSource<T> {
     group: FetchListDataSourceGroupItem<T>,
     page: number,
     pageSize: number
-  ): FetchListDataSourceCallbackOptions {
+  ): FetchListDataSourceCallbackOptions<T> {
     return {
       filters: Array.from(this.filters.values()),
       group: group.id,


### PR DESCRIPTION
## Summary

Add a typed `filters` property to `FetchListDataSourceCallbackOptions` so `fetchPage` callbacks can access filter values without casting.

The callback options now preserve the `FetchListDataSource` model generic, which exposes `options.filters` as `DataSourceFilter<T>[] | undefined`.

## Changes

- Add `filters?: Array<DataSourceFilter<T>>` to `FetchListDataSourceCallbackOptions<T>`
- Preserve the generic type in `FetchListDataSourceCallback<T>`
- Make `FetchListDataSourceEvent` and `getFetchOptions` use typed callback options
- Add a compile-time type assertion covering typed filter options in `fetchPage`


### BEFORE

```
new FetchListDataSource<Person>({
  pageSize: 10,
  fetchPage: async options => {
    // Before: Property 'find' does not exist on type 'unknown'
    const titleFilter = options.filters?.find(filter => filter.id === 'titleFilter')?.value;

    return { items: [] };
  }
});
```

### WORKAROUND BEFORE

```
new FetchListDataSource<Person>({
  pageSize: 10,
  fetchPage: async options => {
    const filters = (options.filters as Array<DataSourceFilter<Person>> | undefined) ?? [];
    const titleFilter = filters.find(filter => filter.id === 'titleFilter')?.value;

    return { items: [] };
  }
});
```

### AFTER
```
new FetchListDataSource<Person>({
  pageSize: 10,
  fetchPage: async options => {
    const titleFilter = options.filters?.find(filter => filter.id === 'titleFilter')?.value;

    return { items: [] };
  }
});
```