### PR TITLE
fix(combobox): limit combobox examples to recommended max width of 500px

### DIFF
--- a/packages/angular/stories/forms.stories.ts
+++ b/packages/angular/stories/forms.stories.ts
@@ -76,7 +76,10 @@ import { DateFieldDirective } from '../src/forms/date-field.directive';
       </sl-form-field>
 
       <sl-form-field label="Combobox - single select">
-        <sl-combobox formControlName="comboboxSingle" placeholder="Select an option">
+        <sl-combobox
+          formControlName="comboboxSingle"
+          placeholder="Select an option"
+          style="max-width: 500px">
           <sl-listbox>
             @for (option of options(); track option.value) {
               <sl-option>{{ option.label }}</sl-option>
@@ -89,7 +92,8 @@ import { DateFieldDirective } from '../src/forms/date-field.directive';
         <sl-combobox
           formControlName="comboboxMultiple"
           multiple
-          placeholder="Select one or more options">
+          placeholder="Select one or more options"
+          style="max-width: 500px">
           <sl-listbox>
             @for (option of options(); track option.value) {
               <sl-option>{{ option.label }}</sl-option>
@@ -203,7 +207,7 @@ export class AllFormControlsReactiveComponent {
       </sl-form-field>
 
       <sl-form-field label="Combobox - single select">
-        <sl-combobox formControlName="comboboxSingle" required>
+        <sl-combobox formControlName="comboboxSingle" required style="max-width: 500px">
           <sl-listbox>
             @for (option of options(); track option.value) {
               <sl-option>{{ option.label }}</sl-option>
@@ -213,7 +217,7 @@ export class AllFormControlsReactiveComponent {
       </sl-form-field>
 
       <sl-form-field label="Combobox - multiple select">
-        <sl-combobox formControlName="comboboxMultiple" multiple required>
+        <sl-combobox formControlName="comboboxMultiple" multiple required style="max-width: 500px">
           <sl-listbox>
             @for (option of options(); track option.value) {
               <sl-option>{{ option.label }}</sl-option>
@@ -339,7 +343,7 @@ export class AllFormControlsEmptyReactiveComponent {
       </sl-form-field>
 
       <sl-form-field label="Combobox - single select">
-        <sl-combobox [(ngModel)]="formGroup.comboboxSingle">
+        <sl-combobox [(ngModel)]="formGroup.comboboxSingle" style="max-width: 500px">
           <sl-listbox>
             <sl-option>Option 1</sl-option>
             <sl-option>Option 2</sl-option>
@@ -349,7 +353,7 @@ export class AllFormControlsEmptyReactiveComponent {
       </sl-form-field>
 
       <sl-form-field label="Combobox - multiple select">
-        <sl-combobox [(ngModel)]="formGroup.comboboxMultiple" multiple>
+        <sl-combobox [(ngModel)]="formGroup.comboboxMultiple" multiple style="max-width: 500px">
           <sl-listbox>
             <sl-option>Option 1</sl-option>
             <sl-option>Option 2</sl-option>
@@ -455,7 +459,7 @@ export class AllFormControlsTemplateComponent {
       </sl-form-field>
 
       <sl-form-field label="Combobox - single select">
-        <sl-combobox [(ngModel)]="formGroup.comboboxSingle" required>
+        <sl-combobox [(ngModel)]="formGroup.comboboxSingle" required style="max-width: 500px">
           <sl-listbox>
             <sl-option>Option 1</sl-option>
             <sl-option>Option 2</sl-option>
@@ -465,7 +469,11 @@ export class AllFormControlsTemplateComponent {
       </sl-form-field>
 
       <sl-form-field label="Combobox - multiple select">
-        <sl-combobox [(ngModel)]="formGroup.comboboxMultiple" multiple required>
+        <sl-combobox
+          [(ngModel)]="formGroup.comboboxMultiple"
+          multiple
+          required
+          style="max-width: 500px">
           <sl-listbox>
             <sl-option>Option 1</sl-option>
             <sl-option>Option 2</sl-option>

--- a/packages/angular/stories/wrappers-form.stories.ts
+++ b/packages/angular/stories/wrappers-form.stories.ts
@@ -61,7 +61,10 @@ export const Combobox: StoryObj = {
       action: (event: Event) => console.log('Combobox changed, current value:', event)
     },
     template: `
-      <sl-combobox placeholder="Select an option" (sl-change)="action($event)">
+      <sl-combobox
+        placeholder="Select an option"
+        style="max-width: 500px"
+        (sl-change)="action($event)">
         <sl-listbox>
           <sl-option>Option 1</sl-option>
           <sl-option>Option 2</sl-option>

--- a/packages/components/combobox/src/combobox.stories.ts
+++ b/packages/components/combobox/src/combobox.stories.ts
@@ -60,10 +60,6 @@ export const All: Story = {
         span {
           justify-self: center;
         }
-
-        sl-combobox {
-          max-width: 500px;
-        }
       }
     </style>
     <div class="container">

--- a/packages/components/combobox/src/combobox.stories.ts
+++ b/packages/components/combobox/src/combobox.stories.ts
@@ -60,6 +60,10 @@ export const All: Story = {
         span {
           justify-self: center;
         }
+
+        sl-combobox {
+          max-width: 500px;
+        }
       }
     </style>
     <div class="container">

--- a/packages/components/combobox/src/multiple.stories.ts
+++ b/packages/components/combobox/src/multiple.stories.ts
@@ -39,6 +39,7 @@ export default {
     filterResults: false,
     label: 'Component',
     hint: '',
+    maxWidth: '500px',
     placeholder: '',
     selectOnly: false,
     virtualList: false
@@ -87,7 +88,7 @@ export default {
             option-label-path=${ifDefined(optionLabelPath)}
             option-value-path=${ifDefined(optionValuePath)}
             placeholder=${ifDefined(placeholder)}
-            style=${`max-width: ${maxWidth ?? 'none'}`}>
+            style=${`max-width: ${maxWidth}`}>
             ${virtualList
               ? nothing
               : html`
@@ -223,7 +224,6 @@ export const Selected: Story = {
 export const Stacked: Story = {
   args: {
     ...Basic.args,
-    maxWidth: '700px',
     value: [
       'Switch',
       'Card',

--- a/packages/components/combobox/src/multiple.stories.ts
+++ b/packages/components/combobox/src/multiple.stories.ts
@@ -88,7 +88,7 @@ export default {
             option-label-path=${ifDefined(optionLabelPath)}
             option-value-path=${ifDefined(optionValuePath)}
             placeholder=${ifDefined(placeholder)}
-            style=${`max-width: ${maxWidth}`}>
+            style=${`max-width: ${maxWidth || '500px'}`}>
             ${virtualList
               ? nothing
               : html`

--- a/packages/components/combobox/src/single.stories.ts
+++ b/packages/components/combobox/src/single.stories.ts
@@ -86,7 +86,7 @@ export default {
             option-label-path=${ifDefined(optionLabelPath)}
             option-value-path=${ifDefined(optionValuePath)}
             placeholder=${ifDefined(placeholder)}
-            style=${`max-width: ${maxWidth}`}>
+            style=${`max-width: ${maxWidth || '500px'}`}>
             ${virtualList
               ? nothing
               : html`

--- a/packages/components/combobox/src/single.stories.ts
+++ b/packages/components/combobox/src/single.stories.ts
@@ -39,6 +39,7 @@ export default {
     disabled: false,
     filterResults: false,
     label: 'Component',
+    maxWidth: '500px',
     placeholder: '',
     selectOnly: false,
     virtualList: false
@@ -85,7 +86,7 @@ export default {
             option-label-path=${ifDefined(optionLabelPath)}
             option-value-path=${ifDefined(optionValuePath)}
             placeholder=${ifDefined(placeholder)}
-            style=${`max-width: ${maxWidth ?? 'none'}`}>
+            style=${`max-width: ${maxWidth}`}>
             ${virtualList
               ? nothing
               : html`

--- a/packages/components/form/src/form-field.stories.ts
+++ b/packages/components/form/src/form-field.stories.ts
@@ -74,7 +74,7 @@ export const CheckboxGroup: Story = {
 export const Combobox: Story = {
   args: {
     slot: () => html`
-      <sl-combobox required>
+      <sl-combobox required style="max-width: 500px">
         <sl-listbox>
           <sl-option>Option 1</sl-option>
           <sl-option>Option 2</sl-option>

--- a/website/src/categories/components/combobox/code.md
+++ b/website/src/categories/components/combobox/code.md
@@ -84,7 +84,7 @@ There is no difference in behavior of the combobox between the two methods.
 Use this method if you have a small to medium number of options and you want to define them directly in your HTML.
 
 ```html
-<sl-combobox aria-label="Subjects">
+<sl-combobox aria-label="Subjects" style="inline-size: min(100%, 500px)">
   <sl-listbox>
     <sl-option value="0">Mathematics</sl-option>
     <sl-option value="1">Geography</sl-option>
@@ -115,6 +115,7 @@ const options = [
   .options=${options}
   option-label-path="label"
   option-value-path="value"
+  style="inline-size: min(100%, 500px)"
 ></sl-combobox>
 ```
 
@@ -131,7 +132,7 @@ If you only specify a string array as the `options` property, the combobox will 
 You can group options using the `sl-option-group` element. This element can contain `sl-option` elements. It is not recommended to have nested `sl-option-group` elements.
 
 ```html
-<sl-combobox aria-label="Subjects">
+<sl-combobox aria-label="Subjects" style="inline-size: min(100%, 500px)">
   <sl-listbox>
     <sl-option-group label="Math">
       <sl-option value="0">Algebra</sl-option>
@@ -171,6 +172,7 @@ const options = [
   option-group-path="group"
   option-label-path="label"
   option-value-path="value"
+  style="inline-size: min(100%, 500px)"
 ></sl-combobox>
 ```
 

--- a/website/src/categories/components/combobox/code.md
+++ b/website/src/categories/components/combobox/code.md
@@ -13,7 +13,7 @@ eleventyNavigation:
 
 <div class="ds-example">
 
-<sl-combobox aria-label="Subjects" multiple style="inline-size: 100%; max-inline-size: min(30vw, 500px)" value='["0","3"]'>
+<sl-combobox aria-label="Subjects" multiple style="inline-size: min(100%, 500px)" value='["0","3"]'>
   <sl-listbox>
     <sl-option-group label="Math">
       <sl-option value="0">Algebra</sl-option>
@@ -35,7 +35,7 @@ eleventyNavigation:
 <div class="ds-code">
 
   ```html
-  <sl-combobox aria-label="Subjects" multiple value='["0","1"]'>
+  <sl-combobox aria-label="Subjects" multiple style="inline-size: min(100%, 500px)" value='["0","3"]'>
     <sl-listbox>
       <sl-option-group label="Math">
         <sl-option value="0">Algebra</sl-option>

--- a/website/src/categories/components/combobox/code.md
+++ b/website/src/categories/components/combobox/code.md
@@ -35,7 +35,7 @@ eleventyNavigation:
 <div class="ds-code">
 
   ```html
-  <sl-combobox aria-label="Subjects" multiple style="inline-size: min(100%, 500px)" value='["0","3"]'>
+  <sl-combobox aria-label="Subjects" multiple value='["0","3"]'>
     <sl-listbox>
       <sl-option-group label="Math">
         <sl-option value="0">Algebra</sl-option>
@@ -84,7 +84,7 @@ There is no difference in behavior of the combobox between the two methods.
 Use this method if you have a small to medium number of options and you want to define them directly in your HTML.
 
 ```html
-<sl-combobox aria-label="Subjects" style="inline-size: min(100%, 500px)">
+<sl-combobox aria-label="Subjects">
   <sl-listbox>
     <sl-option value="0">Mathematics</sl-option>
     <sl-option value="1">Geography</sl-option>
@@ -115,7 +115,6 @@ const options = [
   .options=${options}
   option-label-path="label"
   option-value-path="value"
-  style="inline-size: min(100%, 500px)"
 ></sl-combobox>
 ```
 
@@ -132,7 +131,7 @@ If you only specify a string array as the `options` property, the combobox will 
 You can group options using the `sl-option-group` element. This element can contain `sl-option` elements. It is not recommended to have nested `sl-option-group` elements.
 
 ```html
-<sl-combobox aria-label="Subjects" style="inline-size: min(100%, 500px)">
+<sl-combobox aria-label="Subjects">
   <sl-listbox>
     <sl-option-group label="Math">
       <sl-option value="0">Algebra</sl-option>
@@ -172,7 +171,6 @@ const options = [
   option-group-path="group"
   option-label-path="label"
   option-value-path="value"
-  style="inline-size: min(100%, 500px)"
 ></sl-combobox>
 ```
 

--- a/website/src/categories/components/combobox/usage.md
+++ b/website/src/categories/components/combobox/usage.md
@@ -66,6 +66,22 @@ When the options range from 5 to 15 items or when screen space is limited, using
 
 </section>
 
+<section>
+
+## Layout Guidelines
+To maintain optimal readability and visual hierarchy, consider the following constraints when implementing the Combobox:
+
+### Optimal Width
+Aim for an input width that reflects the expected content length. Extremely wide fields can break the user's scanning rhythm.
+
+### Maximum Width
+We recommend a max-width of 500px for the Combobox component. This ensures the component remains manageable within various layouts and prevents the input field from becoming disproportionately wide, which can negatively affect UX and readability.
+
+### Avoid Full-Width
+While the component is responsive, avoid forcing it to full-width in wide containers unless necessary for the specific use case. If a full-width container is unavoidable, apply the max-width constraint to keep the input focused.
+
+</section>
+
 
 <section>
 

--- a/website/src/categories/components/combobox/usage.md
+++ b/website/src/categories/components/combobox/usage.md
@@ -75,7 +75,7 @@ To maintain optimal readability and visual hierarchy, size a Combobox according 
 Aim for an input width that reflects the expected content length. Extremely wide fields can break the user's scanning rhythm.
 
 ### Maximum Width
-We recommend a max-width of 500px for the Combobox component. This keeps group labels, selected groups and tags easier to scan, and prevents the input field from becoming disproportionately wide.
+We recommend a max-width of 500px for the Combobox component. This makes group labels, selected groups, and tags easier to scan and prevents the input field from becoming disproportionately wide.
 
 ### Avoid Full-Width
 While the component is responsive, avoid forcing it to full-width in wide containers. If a full-width container is unavoidable, apply the max-width constraint to keep the input focused.

--- a/website/src/categories/components/combobox/usage.md
+++ b/website/src/categories/components/combobox/usage.md
@@ -24,7 +24,7 @@ eleventyNavigation:
 <div class="ds-code">
 
   ```html
-  <sl-combobox aria-label="Subjects" multiple style="inline-size: min(100%, 500px)" value='["0","1"]'>
+  <sl-combobox aria-label="Subjects" multiple value='["0","1"]'>
     <sl-listbox>
       <sl-option value="0">Mathematics</sl-option>
       <sl-option value="1">Geography</sl-option>

--- a/website/src/categories/components/combobox/usage.md
+++ b/website/src/categories/components/combobox/usage.md
@@ -24,7 +24,7 @@ eleventyNavigation:
 <div class="ds-code">
 
   ```html
-  <sl-combobox aria-label="Subjects" multiple value='["0","1"]'>
+  <sl-combobox aria-label="Subjects" multiple style="inline-size: min(100%, 500px)" value='["0","1"]'>
     <sl-listbox>
       <sl-option value="0">Mathematics</sl-option>
       <sl-option value="1">Geography</sl-option>
@@ -69,16 +69,16 @@ When the options range from 5 to 15 items or when screen space is limited, using
 <section>
 
 ## Layout Guidelines
-To maintain optimal readability and visual hierarchy, consider the following constraints when implementing the Combobox:
+To maintain optimal readability and visual hierarchy, size a Combobox according to the expected amount of information.
 
 ### Optimal Width
 Aim for an input width that reflects the expected content length. Extremely wide fields can break the user's scanning rhythm.
 
 ### Maximum Width
-We recommend a max-width of 500px for the Combobox component. This ensures the component remains manageable within various layouts and prevents the input field from becoming disproportionately wide, which can negatively affect UX and readability.
+We recommend a max-width of 500px for the Combobox component. This keeps group labels, selected groups and tags easier to scan, and prevents the input field from becoming disproportionately wide.
 
 ### Avoid Full-Width
-While the component is responsive, avoid forcing it to full-width in wide containers unless necessary for the specific use case. If a full-width container is unavoidable, apply the max-width constraint to keep the input focused.
+While the component is responsive, avoid forcing it to full-width in wide containers. If a full-width container is unavoidable, apply the max-width constraint to keep the input focused.
 
 </section>
 

--- a/website/src/categories/components/component-table.njk
+++ b/website/src/categories/components/component-table.njk
@@ -23,7 +23,7 @@
                   Properties
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0"><table class="ds-table">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="Properties table"><table class="ds-table">
                   <thead>
                   <tr>
                     <th>Name</th>
@@ -67,7 +67,7 @@
                   Methods
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="Methods table">
                 <table class="ds-table">
                   <thead>
                   <tr>
@@ -106,7 +106,7 @@
                   Events
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="Events table">
                 <table class="ds-table">
                   <thead>
                   <tr>
@@ -139,7 +139,7 @@
                   Slots
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="Slots table">
                 <table class="ds-table">
                   <thead>
                   <tr>
@@ -164,7 +164,7 @@
                   CSS Properties
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="CSS Properties table">
                 <table class="ds-table">
                   <thead>
                     <tr>
@@ -189,7 +189,7 @@
                   CSS Parts
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="CSS Parts table">
                 <table class="ds-table">
                   <thead>
                     <tr>

--- a/website/src/categories/components/component-table.njk
+++ b/website/src/categories/components/component-table.njk
@@ -23,7 +23,7 @@
                   Properties
                 </a>
               </h3>
-              <div class="ds-table-wrapper"><table class="ds-table">
+              <div class="ds-table-wrapper" tabindex="0"><table class="ds-table">
                   <thead>
                   <tr>
                     <th>Name</th>
@@ -67,7 +67,7 @@
                   Methods
                 </a>
               </h3>
-              <div class="ds-table-wrapper">
+              <div class="ds-table-wrapper" tabindex="0">
                 <table class="ds-table">
                   <thead>
                   <tr>
@@ -106,7 +106,7 @@
                   Events
                 </a>
               </h3>
-              <div class="ds-table-wrapper">
+              <div class="ds-table-wrapper" tabindex="0">
                 <table class="ds-table">
                   <thead>
                   <tr>
@@ -139,7 +139,7 @@
                   Slots
                 </a>
               </h3>
-              <div class="ds-table-wrapper">
+              <div class="ds-table-wrapper" tabindex="0">
                 <table class="ds-table">
                   <thead>
                   <tr>
@@ -164,7 +164,7 @@
                   CSS Properties
                 </a>
               </h3>
-              <div class="ds-table-wrapper">
+              <div class="ds-table-wrapper" tabindex="0">
                 <table class="ds-table">
                   <thead>
                     <tr>
@@ -189,7 +189,7 @@
                   CSS Parts
                 </a>
               </h3>
-              <div class="ds-table-wrapper">
+              <div class="ds-table-wrapper" tabindex="0">
                 <table class="ds-table">
                   <thead>
                     <tr>

--- a/website/src/categories/components/component-table.njk
+++ b/website/src/categories/components/component-table.njk
@@ -23,7 +23,7 @@
                   Properties
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="Properties table"><table class="ds-table">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="{{ tagName.selector }} properties table"><table class="ds-table">
                   <thead>
                   <tr>
                     <th>Name</th>
@@ -67,7 +67,7 @@
                   Methods
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="Methods table">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="{{ tagName.selector }} methods table">
                 <table class="ds-table">
                   <thead>
                   <tr>
@@ -106,7 +106,7 @@
                   Events
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="Events table">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="{{ tagName.selector }} events table">
                 <table class="ds-table">
                   <thead>
                   <tr>
@@ -139,7 +139,7 @@
                   Slots
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="Slots table">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="{{ tagName.selector }} slots table">
                 <table class="ds-table">
                   <thead>
                   <tr>
@@ -164,7 +164,7 @@
                   CSS Properties
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="CSS Properties table">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="{{ tagName.selector }} CSS Properties table">
                 <table class="ds-table">
                   <thead>
                     <tr>
@@ -189,7 +189,7 @@
                   CSS Parts
                 </a>
               </h3>
-              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="CSS Parts table">
+              <div class="ds-table-wrapper" tabindex="0" role="region" aria-label="{{ tagName.selector }} CSS Parts table">
                 <table class="ds-table">
                   <thead>
                     <tr>

--- a/website/src/styles/tokens-light.scss
+++ b/website/src/styles/tokens-light.scss
@@ -85,8 +85,8 @@
     --control-color-visuals-guide-text: var(--colors-neutral-base-white);
     --control-color-code-text-neutral: var(--sl-color-palette-grey-500);
     --control-color-code-text-accent: var(--sl-color-palette-blue-500);
-    --control-color-code-text-danger: var(--sl-color-palette-red-500);
+    --control-color-code-text-danger: var(--sl-color-palette-red-800);
     --control-color-code-text-warning: var(--sl-color-palette-orange-500);
-    --control-color-code-text-success: var(--sl-color-palette-green-500);
+    --control-color-code-text-success: var(--sl-color-palette-green-800);
   }
 }


### PR DESCRIPTION
## Summary
- Apply the recommended 500px max width to Combobox examples without changing selected-group or badge positioning.
- Keep Combobox docs live examples constrained, while leaving copied code snippets concise to avoid scrollable code blocks.
- Restore the Storybook `maxWidth` fallback so clearing the control still renders valid CSS.
- Improve website a11y by making generated API table wrappers keyboard-focusable and increasing light-theme syntax highlighting contrast.

### BEFORE
<img width="1722" height="794" alt="Screenshot 2026-07-20 at 18 06 48" src="https://github.com/user-attachments/assets/cd32cae5-204f-4bbf-850d-07fa5af2e918" />

### AFTER
<img width="1108" height="769" alt="Screenshot 2026-07-20 at 18 07 12" src="https://github.com/user-attachments/assets/796c7168-d7d4-44fa-8a9f-f878a5224c85" />
