### PR TITLE
fix(paginator): restore focus after selecting page from menu

### DIFF
--- a/.changeset/clean-zebras-retire.md
+++ b/.changeset/clean-zebras-retire.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/paginator': patch
+---
+
+Restore keyboard focus to the selected page button after choosing a page from the paginator page number menu.

--- a/packages/components/paginator/src/paginator.spec.ts
+++ b/packages/components/paginator/src/paginator.spec.ts
@@ -215,13 +215,13 @@ describe('sl-paginator', () => {
 
       menuItem?.click();
       await el.updateComplete;
-      await new Promise(resolve => setTimeout(resolve));
+      await new Promise(resolve => requestAnimationFrame(() => resolve(undefined)));
 
       const currentPage = el.renderRoot.querySelector<Button>('sl-button.current');
 
       expect(el.page).to.equal(11);
       expect(currentPage?.textContent?.trim()).to.equal('12');
-      expect(el.renderRoot.activeElement).to.equal(currentPage);
+      expect((el.renderRoot as ShadowRoot).activeElement).to.equal(currentPage);
     });
 
     it('should update the current page when the page property is changed', async () => {

--- a/packages/components/paginator/src/paginator.spec.ts
+++ b/packages/components/paginator/src/paginator.spec.ts
@@ -213,8 +213,8 @@ describe('sl-paginator', () => {
         item => item.textContent?.trim() === '12'
       );
 
-      menuItem?.click();
-      await el.updateComplete;
+      expect(menuItem).to.exist;
+      menuItem!.click();
       await new Promise(resolve => requestAnimationFrame(() => resolve(undefined)));
 
       const currentPage = el.renderRoot.querySelector<Button>('sl-button.current');

--- a/packages/components/paginator/src/paginator.spec.ts
+++ b/packages/components/paginator/src/paginator.spec.ts
@@ -209,12 +209,45 @@ describe('sl-paginator', () => {
     });
 
     it('should move focus to the selected page when a menu item is clicked', async () => {
-      const menuItem = Array.from(el.renderRoot.querySelectorAll('sl-menu-item')).find(
+      const menuButtons = Array.from(el.renderRoot.querySelectorAll<HTMLElement>('sl-menu-button')),
+        menuButton = menuButtons.find(button =>
+          Array.from(button.querySelectorAll('sl-menu-item')).some(
+            item => item.textContent?.trim() === '12'
+          )
+        ),
+        trigger = menuButton?.shadowRoot?.querySelector<Button>('sl-button');
+
+      expect(menuButton).to.exist;
+      expect(trigger).to.exist;
+
+      const opened = new Promise<CustomEvent<boolean>>(resolve =>
+        menuButton!.addEventListener('sl-toggle', event => resolve(event as CustomEvent<boolean>), {
+          once: true
+        })
+      );
+
+      trigger!.click();
+
+      expect((await opened).detail).to.be.true;
+
+      const menuItem = Array.from(menuButton!.querySelectorAll('sl-menu-item')).find(
         item => item.textContent?.trim() === '12'
       );
 
       expect(menuItem).to.exist;
+
+      menuItem!.focus();
+
+      const closed = new Promise<CustomEvent<boolean>>(resolve =>
+        menuButton!.addEventListener('sl-toggle', event => resolve(event as CustomEvent<boolean>), {
+          once: true
+        })
+      );
+
       menuItem!.click();
+
+      expect((await closed).detail).to.be.false;
+
       await el.updateComplete;
       await new Promise<void>(resolve => requestAnimationFrame(() => resolve(undefined)));
 

--- a/packages/components/paginator/src/paginator.spec.ts
+++ b/packages/components/paginator/src/paginator.spec.ts
@@ -208,6 +208,22 @@ describe('sl-paginator', () => {
       expect(getForwardedAriaAttribute(currentPage!, 'aria-current')).to.equal('page');
     });
 
+    it('should move focus to the selected page when a menu item is clicked', async () => {
+      const menuItem = Array.from(el.renderRoot.querySelectorAll('sl-menu-item')).find(
+        item => item.textContent?.trim() === '12'
+      );
+
+      menuItem?.click();
+      await el.updateComplete;
+      await new Promise(resolve => setTimeout(resolve));
+
+      const currentPage = el.renderRoot.querySelector<Button>('sl-button.current');
+
+      expect(el.page).to.equal(11);
+      expect(currentPage?.textContent?.trim()).to.equal('12');
+      expect(el.renderRoot.activeElement).to.equal(currentPage);
+    });
+
     it('should update the current page when the page property is changed', async () => {
       el.page = 5;
       await el.updateComplete;

--- a/packages/components/paginator/src/paginator.spec.ts
+++ b/packages/components/paginator/src/paginator.spec.ts
@@ -215,7 +215,8 @@ describe('sl-paginator', () => {
 
       expect(menuItem).to.exist;
       menuItem!.click();
-      await new Promise(resolve => requestAnimationFrame(() => resolve(undefined)));
+      await el.updateComplete;
+      await new Promise<void>(resolve => requestAnimationFrame(() => resolve(undefined)));
 
       const currentPage = el.renderRoot.querySelector<Button>('sl-button.current');
 

--- a/packages/components/paginator/src/paginator.ts
+++ b/packages/components/paginator/src/paginator.ts
@@ -390,7 +390,7 @@ export class Paginator<T = any> extends ScopedElementsMixin(LitElement) {
 
   async #focusPageButton(page: number): Promise<void> {
     await this.updateComplete;
-
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
     const buttons = Array.from(this.renderRoot.querySelectorAll<Button>('sl-button.page')),
       findVisible = (target: number): Button | undefined =>
         buttons.find(

--- a/packages/components/paginator/src/paginator.ts
+++ b/packages/components/paginator/src/paginator.ts
@@ -240,7 +240,9 @@ export class Paginator<T = any> extends ScopedElementsMixin(LitElement) {
               <sl-icon name="ellipsis-down" slot="button"></sl-icon>
               ${Array.from({ length: this.windowStart + 1 }).map(
                 (_, i) => html`
-                  <sl-menu-item @click=${() => this.#onPageClick(i + 1)}>${i + 2}</sl-menu-item>
+                  <sl-menu-item @click=${() => this.#onMenuPageClick(i + 1)}>
+                    ${i + 2}
+                  </sl-menu-item>
                 `
               )}
             </sl-menu-button>
@@ -271,7 +273,7 @@ export class Paginator<T = any> extends ScopedElementsMixin(LitElement) {
               <sl-icon name="ellipsis-down" slot="button"></sl-icon>
               ${Array.from({ length: this.pageCount - this.windowEnd - 2 }).map(
                 (_, i) => html`
-                  <sl-menu-item @click=${() => this.#onPageClick(i + this.windowEnd + 1)}>
+                  <sl-menu-item @click=${() => this.#onMenuPageClick(i + this.windowEnd + 1)}>
                     ${i + this.windowEnd + 2}
                   </sl-menu-item>
                 `
@@ -361,6 +363,11 @@ export class Paginator<T = any> extends ScopedElementsMixin(LitElement) {
     this.#onPageClick(Math.min(this.page + 1, this.pageCount - 1), true);
   }
 
+  #onMenuPageClick(page: number): void {
+    this.#onPageClick(page);
+    void this.#focusPageButton(page);
+  }
+
   #onPageClick(page: number, announcePage = false): void {
     this.page = page;
     this.pageChangeEvent.emit(this.page);
@@ -379,6 +386,18 @@ export class Paginator<T = any> extends ScopedElementsMixin(LitElement) {
         })
       );
     }
+  }
+
+  async #focusPageButton(page: number): Promise<void> {
+    await this.updateComplete;
+
+    const button = Array.from(this.renderRoot.querySelectorAll<Button>('sl-button.page')).find(
+      button =>
+        button.textContent?.trim() === String(page + 1) &&
+        getComputedStyle(button).display !== 'none'
+    );
+
+    button?.focus();
   }
 
   #onPrevious() {

--- a/packages/components/paginator/src/paginator.ts
+++ b/packages/components/paginator/src/paginator.ts
@@ -391,13 +391,14 @@ export class Paginator<T = any> extends ScopedElementsMixin(LitElement) {
   async #focusPageButton(page: number): Promise<void> {
     await this.updateComplete;
 
-    const button = Array.from(this.renderRoot.querySelectorAll<Button>('sl-button.page')).find(
-      button =>
-        button.textContent?.trim() === String(page + 1) &&
-        getComputedStyle(button).display !== 'none'
-    );
+    const buttons = Array.from(this.renderRoot.querySelectorAll<Button>('sl-button.page')),
+      findVisible = (target: number): Button | undefined =>
+        buttons.find(
+          button =>
+            button.textContent?.trim() === String(target + 1) && button.style.display !== 'none'
+        );
 
-    button?.focus();
+    (findVisible(this.page) ?? (page !== this.page ? findVisible(page) : undefined))?.focus();
   }
 
   #onPrevious() {

--- a/packages/components/paginator/src/paginator.ts
+++ b/packages/components/paginator/src/paginator.ts
@@ -391,14 +391,19 @@ export class Paginator<T = any> extends ScopedElementsMixin(LitElement) {
   async #focusPageButton(page: number): Promise<void> {
     await this.updateComplete;
     await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
-    const buttons = Array.from(this.renderRoot.querySelectorAll<Button>('sl-button.page')),
-      findVisible = (target: number): Button | undefined =>
-        buttons.find(
-          button =>
-            button.textContent?.trim() === String(target + 1) && button.style.display !== 'none'
-        );
 
-    (findVisible(this.page) ?? (page !== this.page ? findVisible(page) : undefined))?.focus();
+    const current = this.renderRoot.querySelector<Button>('sl-button.current');
+
+    if (current && current.style.display !== 'none') {
+      current.focus();
+      return;
+    }
+
+    Array.from(this.renderRoot.querySelectorAll<Button>('sl-button.page'))
+      .find(
+        button => button.textContent?.trim() === String(page + 1) && button.style.display !== 'none'
+      )
+      ?.focus();
   }
 
   #onPrevious() {


### PR DESCRIPTION
## Summary

Fixes paginator keyboard focus after selecting a page from the “Select page number” menu.

When a user selected a hidden page from the ellipsis menu, the paginator updated the selected page visually, but focus remained on the menu/menu trigger flow. Pressing Tab then skipped ahead unexpectedly, for example to the last page button.

This change restores focus to the newly selected visible page button after the paginator re-renders.

## Changes

- Added a dedicated menu page selection handler.
- After selecting a page from the menu, waits for the paginator update to complete.
- Moves focus to the selected visible page button.
- Added a regression test for selecting page 12 from the menu and checking focus.


### BEFORE

https://github.com/user-attachments/assets/4921c06b-ed35-4d0d-84ad-2b7c321556a4

### AFTER

https://github.com/user-attachments/assets/7af8ca04-e1fe-40f9-aedb-f5dd258d569e

