### PR TITLE
feat(tree): add isSelectable for mixed-selectable nodes

### DIFF
--- a/.changeset/happy-garlics-invent.md
+++ b/.changeset/happy-garlics-invent.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/tree': patch
+---
+
+Increase gap between tree-node icon and label to match figma

--- a/.changeset/slow-needles-repeat.md
+++ b/.changeset/slow-needles-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/tree': minor
+---
+
+Whether or not a tree node is selectable is now determined by the `isSelectable` function, which defaults to returning true. This means that all nodes are selectable by default, and only an explicit `isSelectable` returning false opts out.

--- a/packages/components/tree/src/flat-tree-data-source.spec.ts
+++ b/packages/components/tree/src/flat-tree-data-source.spec.ts
@@ -590,6 +590,26 @@ describe('FlatTreeDataSource', () => {
       expect(ds.items.every(n => n.selectable === true)).to.be.true;
     });
 
+    it('should mark all nodes as selectable by default in single-select mode', () => {
+      ds = new FlatTreeDataSource<TestItem>(items, {
+        getId: ({ id }) => id,
+        getLabel: ({ name }) => name,
+        getLevel: ({ level }) => level,
+        isExpandable: ({ expandable }) => expandable,
+        isExpanded: () => true,
+        isSelected: ({ id }) => id === 111
+      });
+      ds.update();
+
+      // All nodes selectable by default (no isSelectable, single-select mode).
+      expect(ds.items.every(n => n.selectable === true)).to.be.true;
+
+      // The initial isSelected state must be honored for selectable nodes.
+      const leaf = ds.items.find(n => n.id === 111)!;
+      expect(leaf.selected).to.be.true;
+      expect(ds.selection.has(leaf)).to.be.true;
+    });
+
     it('should reflect the isSelectable mapping on the nodes', () => {
       ds = createDataSource();
       ds.update();

--- a/packages/components/tree/src/flat-tree-data-source.spec.ts
+++ b/packages/components/tree/src/flat-tree-data-source.spec.ts
@@ -1,6 +1,6 @@
 import { spy } from 'sinon';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { FlatTreeDataSource } from './flat-tree-data-source.js';
+import { FlatTreeDataSource, type FlatTreeDataSourceOptions } from './flat-tree-data-source.js';
 
 type TestItem = {
   id: number | string;
@@ -542,6 +542,149 @@ describe('FlatTreeDataSource', () => {
       ds.update();
 
       expect(parent.selected).to.be.true;
+    });
+  });
+
+  describe('selectable', () => {
+    /*
+      Parent (selectable)
+      ├─ Sub A (selectable)
+      │  ├─ Leaf 1 (not selectable)
+      │  └─ Leaf 2 (not selectable)
+      └─ Sub B (selectable)
+         └─ Leaf 3 (not selectable)
+    */
+    const items: TestItem[] = [
+      { id: 1, name: 'Parent', level: 0, expandable: true },
+      { id: 11, name: 'Sub A', level: 1, expandable: true },
+      { id: 111, name: 'Leaf 1', level: 2, expandable: false },
+      { id: 112, name: 'Leaf 2', level: 2, expandable: false },
+      { id: 12, name: 'Sub B', level: 1, expandable: true },
+      { id: 121, name: 'Leaf 3', level: 2, expandable: false }
+    ];
+
+    // Only the expandable nodes (the parent nodes) are selectable, the leaf nodes are not.
+    const createDataSource = (overrides: Partial<FlatTreeDataSourceOptions<TestItem>> = {}) =>
+      new FlatTreeDataSource<TestItem>(items, {
+        getId: ({ id }) => id,
+        getLabel: ({ name }) => name,
+        getLevel: ({ level }) => level,
+        isExpandable: ({ expandable }) => expandable,
+        isExpanded: () => true,
+        isSelectable: ({ expandable }) => expandable,
+        multiple: true,
+        ...overrides
+      });
+
+    it('should mark all nodes as selectable by default', () => {
+      ds = new FlatTreeDataSource<TestItem>(items, {
+        getId: ({ id }) => id,
+        getLabel: ({ name }) => name,
+        getLevel: ({ level }) => level,
+        isExpandable: ({ expandable }) => expandable,
+        isExpanded: () => true,
+        multiple: true
+      });
+      ds.update();
+
+      expect(ds.items.every(n => n.selectable === true)).to.be.true;
+    });
+
+    it('should reflect the isSelectable mapping on the nodes', () => {
+      ds = createDataSource();
+      ds.update();
+
+      const selectable = ds.items.map(n => n.selectable);
+
+      // Parent, Sub A, Leaf 1, Leaf 2, Sub B, Leaf 3
+      expect(selectable).to.deep.equal([true, true, false, false, true, false]);
+    });
+
+    it('should not select non-selectable nodes based on isSelected', () => {
+      ds = createDataSource({ isSelected: () => true });
+      ds.update();
+
+      const leaf = ds.items.find(n => n.id === 111)!;
+
+      expect(leaf.selected).to.be.false;
+      expect(ds.selection.has(leaf)).to.be.false;
+    });
+
+    it('should not select a node that is not selectable', () => {
+      ds = createDataSource();
+      ds.update();
+
+      const leaf = ds.items.find(n => n.id === 111)!;
+      ds.select(leaf);
+
+      expect(leaf.selected).not.to.be.true;
+      expect(ds.selection.has(leaf)).to.be.false;
+    });
+
+    it('should only select the selectable children when selecting a parent', () => {
+      ds = createDataSource();
+      ds.update();
+
+      const parent = ds.items.find(n => n.id === 1)!;
+      ds.select(parent);
+
+      const subA = ds.items.find(n => n.id === 11)!,
+        subB = ds.items.find(n => n.id === 12)!,
+        leaves = ds.items.filter(n => [111, 112, 121].includes(n.id as number));
+
+      expect(parent.selected).to.be.true;
+      expect(subA.selected).to.be.true;
+      expect(subB.selected).to.be.true;
+      expect(leaves.every(n => !n.selected)).to.be.true;
+
+      // Only the three selectable nodes should be in the selection.
+      expect(ds.selection.size).to.equal(3);
+    });
+
+    it('should keep a node selected when all of its children are non-selectable', () => {
+      ds = createDataSource();
+      ds.update();
+
+      const subA = ds.items.find(n => n.id === 11)!;
+      ds.select(subA);
+
+      // syncSelection runs on update; Sub A has only non-selectable children, so its
+      // selection state must be preserved rather than derived from its children.
+      ds.update();
+
+      expect(subA.selected).to.be.true;
+      expect(ds.selection.has(subA)).to.be.true;
+    });
+
+    it('should derive the parent state from its selectable children only', () => {
+      ds = createDataSource();
+      ds.update();
+
+      const parent = ds.items.find(n => n.id === 1)!,
+        subA = ds.items.find(n => n.id === 11)!;
+
+      ds.select(subA);
+
+      expect(parent.selected).to.be.false;
+      expect(parent.indeterminate).to.be.true;
+
+      const subB = ds.items.find(n => n.id === 12)!;
+      ds.select(subB);
+
+      expect(parent.selected).to.be.true;
+      expect(parent.indeterminate).to.be.false;
+    });
+
+    it('should only select selectable nodes when calling selectAll', () => {
+      ds = createDataSource();
+      ds.update();
+
+      ds.selectAll();
+
+      const leaves = ds.items.filter(n => [111, 112, 121].includes(n.id as number));
+
+      expect(leaves.every(n => !n.selected)).to.be.true;
+      expect(ds.selection.size).to.equal(3);
     });
   });
 });

--- a/packages/components/tree/src/flat-tree-data-source.ts
+++ b/packages/components/tree/src/flat-tree-data-source.ts
@@ -63,6 +63,10 @@ export class FlatTreeDataSource<T = any> extends TreeDataSource<T> {
       };
     }
 
+    if (options.multiple) {
+      options.isSelectable ??= () => true;
+    }
+
     super({ ...options, loadChildren });
 
     this.#mapping = {
@@ -152,7 +156,7 @@ export class FlatTreeDataSource<T = any> extends TreeDataSource<T> {
     } = this.#mapping;
 
     const expandable = isExpandable(item),
-      selectable = isSelectable?.(item) ?? true;
+      selectable = isSelectable?.(item);
 
     const treeNode: TreeDataSourceNode<T> = {
       id: getId(item),

--- a/packages/components/tree/src/flat-tree-data-source.ts
+++ b/packages/components/tree/src/flat-tree-data-source.ts
@@ -63,10 +63,6 @@ export class FlatTreeDataSource<T = any> extends TreeDataSource<T> {
       };
     }
 
-    if (options.multiple) {
-      options.isSelectable ??= () => true;
-    }
-
     super({ ...options, loadChildren });
 
     this.#mapping = {
@@ -156,7 +152,8 @@ export class FlatTreeDataSource<T = any> extends TreeDataSource<T> {
     } = this.#mapping;
 
     const expandable = isExpandable(item),
-      selectable = isSelectable?.(item);
+      // Nodes are selectable by default; only an explicit `isSelectable` returning false opts out.
+      selectable = isSelectable?.(item) ?? true;
 
     const treeNode: TreeDataSourceNode<T> = {
       id: getId(item),

--- a/packages/components/tree/src/flat-tree-data-source.ts
+++ b/packages/components/tree/src/flat-tree-data-source.ts
@@ -74,6 +74,7 @@ export class FlatTreeDataSource<T = any> extends TreeDataSource<T> {
       getLevel: options.getLevel ?? (() => 0),
       isExpandable: options.isExpandable ?? (() => false),
       isExpanded: options.isExpanded,
+      isSelectable: options.isSelectable,
       isSelected: options.isSelected
     };
 
@@ -146,10 +147,12 @@ export class FlatTreeDataSource<T = any> extends TreeDataSource<T> {
       getLevel,
       isExpandable,
       isExpanded,
+      isSelectable,
       isSelected
     } = this.#mapping;
 
-    const expandable = isExpandable(item);
+    const expandable = isExpandable(item),
+      selectable = isSelectable?.(item) ?? true;
 
     const treeNode: TreeDataSourceNode<T> = {
       id: getId(item),
@@ -164,7 +167,8 @@ export class FlatTreeDataSource<T = any> extends TreeDataSource<T> {
       lastNodeInLevel,
       level: getLevel(item),
       parent,
-      selected: isSelected?.(item),
+      selectable,
+      selected: selectable ? isSelected?.(item) : false,
       type: 'node'
     };
 

--- a/packages/components/tree/src/nested-tree-data-source.spec.ts
+++ b/packages/components/tree/src/nested-tree-data-source.spec.ts
@@ -1,11 +1,12 @@
 import { spy } from 'sinon';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { NestedTreeDataSource } from './nested-tree-data-source';
+import { NestedTreeDataSource, type NestedTreeDataSourceOptions } from './nested-tree-data-source';
 
 type TestItem = {
   id: number | string;
   name: string;
   expanded?: boolean;
+  selectable?: boolean;
   selected?: boolean;
   children?: TestItem[];
 };
@@ -566,6 +567,158 @@ describe('NestedTreeDataSource', () => {
 
       expect(parent.selected).to.be.true;
       expect(parent.indeterminate).to.be.false;
+    });
+  });
+
+  describe('selectable', () => {
+    /**
+     * Parent (selectable) ├─ Sub A (selectable) │ ├─ Leaf 1 (not selectable) │ └─ Leaf 2 (not
+     * selectable) └─ Sub B (selectable) └─ Leaf 3 (not selectable)
+     */
+    const items: TestItem[] = [
+      {
+        id: 1,
+        name: 'Parent',
+        children: [
+          {
+            id: 11,
+            name: 'Sub A',
+            children: [
+              { id: 111, name: 'Leaf 1' },
+              { id: 112, name: 'Leaf 2' }
+            ]
+          },
+          {
+            id: 12,
+            name: 'Sub B',
+            children: [{ id: 121, name: 'Leaf 3' }]
+          }
+        ]
+      }
+    ];
+
+    // Only nodes with children (the parent nodes) are selectable, the leaf nodes are not.
+    const createDataSource = (overrides: Partial<NestedTreeDataSourceOptions<TestItem>> = {}) =>
+      new NestedTreeDataSource<TestItem>(items, {
+        getId: ({ id }) => id,
+        getLabel: ({ name }) => name,
+        getChildren: ({ children }) => children,
+        isExpandable: ({ children }) => !!children?.length,
+        isExpanded: () => true,
+        isSelectable: ({ children }) => !!children?.length,
+        multiple: true,
+        ...overrides
+      });
+
+    it('should mark all nodes as selectable by default', () => {
+      ds = new NestedTreeDataSource<TestItem>(items, {
+        getId: ({ id }) => id,
+        getLabel: ({ name }) => name,
+        getChildren: ({ children }) => children,
+        isExpandable: ({ children }) => !!children?.length,
+        isExpanded: () => true,
+        multiple: true
+      });
+      ds.update();
+
+      expect(ds.items.every(n => n.selectable === true)).to.be.true;
+    });
+
+    it('should reflect the isSelectable mapping on the nodes', () => {
+      ds = createDataSource();
+      ds.update();
+
+      const selectable = ds.items.map(n => n.selectable);
+
+      // Parent, Sub A, Leaf 1, Leaf 2, Sub B, Leaf 3
+      expect(selectable).to.deep.equal([true, true, false, false, true, false]);
+    });
+
+    it('should not select non-selectable nodes based on isSelected', () => {
+      ds = createDataSource({ isSelected: () => true });
+      ds.update();
+
+      const leaf = ds.items.find(n => n.id === 111)!;
+
+      expect(leaf.selected).to.be.false;
+      expect(ds.selection.has(leaf)).to.be.false;
+    });
+
+    it('should not select a node that is not selectable', () => {
+      ds = createDataSource();
+      ds.update();
+
+      const leaf = ds.items.find(n => n.id === 111)!;
+      ds.select(leaf);
+
+      expect(leaf.selected).not.to.be.true;
+      expect(ds.selection.has(leaf)).to.be.false;
+    });
+
+    it('should only select the selectable children when selecting a parent', () => {
+      ds = createDataSource();
+      ds.update();
+
+      const parent = ds.items.find(n => n.id === 1)!;
+      ds.select(parent);
+
+      const subA = ds.items.find(n => n.id === 11)!,
+        subB = ds.items.find(n => n.id === 12)!,
+        leaves = ds.items.filter(n => [111, 112, 121].includes(n.id as number));
+
+      expect(parent.selected).to.be.true;
+      expect(subA.selected).to.be.true;
+      expect(subB.selected).to.be.true;
+      expect(leaves.every(n => !n.selected)).to.be.true;
+
+      // Only the three selectable nodes should be in the selection.
+      expect(ds.selection.size).to.equal(3);
+    });
+
+    it('should keep a node selected when all of its children are non-selectable', () => {
+      ds = createDataSource();
+      ds.update();
+
+      const subA = ds.items.find(n => n.id === 11)!;
+      ds.select(subA);
+
+      // syncSelection runs on update; Sub A has only non-selectable children, so its
+      // selection state must be preserved rather than derived from its children.
+      ds.update();
+
+      expect(subA.selected).to.be.true;
+      expect(ds.selection.has(subA)).to.be.true;
+    });
+
+    it('should derive the parent state from its selectable children only', () => {
+      ds = createDataSource();
+      ds.update();
+
+      const parent = ds.items.find(n => n.id === 1)!,
+        subA = ds.items.find(n => n.id === 11)!;
+
+      ds.select(subA);
+
+      expect(parent.selected).to.be.false;
+      expect(parent.indeterminate).to.be.true;
+
+      const subB = ds.items.find(n => n.id === 12)!;
+      ds.select(subB);
+
+      expect(parent.selected).to.be.true;
+      expect(parent.indeterminate).to.be.false;
+    });
+
+    it('should only select selectable nodes when calling selectAll', () => {
+      ds = createDataSource();
+      ds.update();
+
+      ds.selectAll();
+
+      const leaves = ds.items.filter(n => [111, 112, 121].includes(n.id as number));
+
+      expect(leaves.every(n => !n.selected)).to.be.true;
+      expect(ds.selection.size).to.equal(3);
     });
   });
 });

--- a/packages/components/tree/src/nested-tree-data-source.spec.ts
+++ b/packages/components/tree/src/nested-tree-data-source.spec.ts
@@ -1,6 +1,9 @@
 import { spy } from 'sinon';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { NestedTreeDataSource, type NestedTreeDataSourceOptions } from './nested-tree-data-source';
+import {
+  NestedTreeDataSource,
+  type NestedTreeDataSourceOptions
+} from './nested-tree-data-source.js';
 
 type TestItem = {
   id: number | string;

--- a/packages/components/tree/src/nested-tree-data-source.spec.ts
+++ b/packages/components/tree/src/nested-tree-data-source.spec.ts
@@ -571,10 +571,14 @@ describe('NestedTreeDataSource', () => {
   });
 
   describe('selectable', () => {
-    /**
-     * Parent (selectable) ├─ Sub A (selectable) │ ├─ Leaf 1 (not selectable) │ └─ Leaf 2 (not
-     * selectable) └─ Sub B (selectable) └─ Leaf 3 (not selectable)
-     */
+    /*
+      Parent (selectable)
+      ├─ Sub A (selectable)
+      │  ├─ Leaf 1 (not selectable)
+      │  └─ Leaf 2 (not selectable)
+      └─ Sub B (selectable)
+         └─ Leaf 3 (not selectable)
+    */
     const items: TestItem[] = [
       {
         id: 1,

--- a/packages/components/tree/src/nested-tree-data-source.spec.ts
+++ b/packages/components/tree/src/nested-tree-data-source.spec.ts
@@ -631,6 +631,26 @@ describe('NestedTreeDataSource', () => {
       expect(ds.items.every(n => n.selectable === true)).to.be.true;
     });
 
+    it('should mark all nodes as selectable by default in single-select mode', () => {
+      ds = new NestedTreeDataSource<TestItem>(items, {
+        getId: ({ id }) => id,
+        getLabel: ({ name }) => name,
+        getChildren: ({ children }) => children,
+        isExpandable: ({ children }) => !!children?.length,
+        isExpanded: () => true,
+        isSelected: ({ id }) => id === 111
+      });
+      ds.update();
+
+      // All nodes selectable by default (no isSelectable, single-select mode).
+      expect(ds.items.every(n => n.selectable === true)).to.be.true;
+
+      // The initial isSelected state must be honored for selectable nodes.
+      const leaf = ds.items.find(n => n.id === 111)!;
+      expect(leaf.selected).to.be.true;
+      expect(ds.selection.has(leaf)).to.be.true;
+    });
+
     it('should reflect the isSelectable mapping on the nodes', () => {
       ds = createDataSource();
       ds.update();

--- a/packages/components/tree/src/nested-tree-data-source.ts
+++ b/packages/components/tree/src/nested-tree-data-source.ts
@@ -63,6 +63,10 @@ export class NestedTreeDataSource<T = any> extends TreeDataSource<T> {
       };
     }
 
+    if (options.multiple) {
+      options.isSelectable ??= () => true;
+    }
+
     super({ ...options, loadChildren });
 
     this.#mapping = {
@@ -114,7 +118,7 @@ export class NestedTreeDataSource<T = any> extends TreeDataSource<T> {
     } = this.#mapping;
 
     const expandable = isExpandable(item),
-      selectable = isSelectable?.(item) ?? true;
+      selectable = isSelectable?.(item);
 
     const treeNode: TreeDataSourceNode<T> = {
       id: getId(item),

--- a/packages/components/tree/src/nested-tree-data-source.ts
+++ b/packages/components/tree/src/nested-tree-data-source.ts
@@ -74,6 +74,7 @@ export class NestedTreeDataSource<T = any> extends TreeDataSource<T> {
       getLabel: options.getLabel ?? (() => ''),
       isExpandable: options.isExpandable ?? (() => false),
       isExpanded: options.isExpanded,
+      isSelectable: options.isSelectable,
       isSelected: options.isSelected
     };
 
@@ -108,10 +109,12 @@ export class NestedTreeDataSource<T = any> extends TreeDataSource<T> {
       getLabel,
       isExpandable,
       isExpanded,
+      isSelectable,
       isSelected
     } = this.#mapping;
 
-    const expandable = isExpandable(item);
+    const expandable = isExpandable(item),
+      selectable = isSelectable?.(item) ?? true;
 
     const treeNode: TreeDataSourceNode<T> = {
       id: getId(item),
@@ -126,7 +129,8 @@ export class NestedTreeDataSource<T = any> extends TreeDataSource<T> {
       lastNodeInLevel,
       level: parent ? parent.level + 1 : 0,
       parent,
-      selected: isSelected?.(item),
+      selectable,
+      selected: selectable ? isSelected?.(item) : false,
       type: 'node'
     };
 

--- a/packages/components/tree/src/nested-tree-data-source.ts
+++ b/packages/components/tree/src/nested-tree-data-source.ts
@@ -63,10 +63,6 @@ export class NestedTreeDataSource<T = any> extends TreeDataSource<T> {
       };
     }
 
-    if (options.multiple) {
-      options.isSelectable ??= () => true;
-    }
-
     super({ ...options, loadChildren });
 
     this.#mapping = {
@@ -118,7 +114,8 @@ export class NestedTreeDataSource<T = any> extends TreeDataSource<T> {
     } = this.#mapping;
 
     const expandable = isExpandable(item),
-      selectable = isSelectable?.(item);
+      // Nodes are selectable by default; only an explicit `isSelectable` returning false opts out.
+      selectable = isSelectable?.(item) ?? true;
 
     const treeNode: TreeDataSourceNode<T> = {
       id: getId(item),

--- a/packages/components/tree/src/tree-data-source.ts
+++ b/packages/components/tree/src/tree-data-source.ts
@@ -600,7 +600,7 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
     }
 
     // Only selectable children influence the selected/indeterminate state of the parent.
-    const selectableChildren = node.children.filter(child => child.selectable !== false);
+    const selectableChildren = node.children.filter(child => !!child.selectable);
 
     // If a node has no selectable children (for example a node whose only children are
     // non-selectable leaf nodes), its selection state is independent of its children.

--- a/packages/components/tree/src/tree-data-source.ts
+++ b/packages/components/tree/src/tree-data-source.ts
@@ -362,7 +362,7 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
   /** Selects all selectable nodes in the tree. */
   selectAll(): void {
     const traverse = (node: TreeDataSourceNode<T>): void => {
-      if (node.selectable) {
+      if (node.selectable !== false) {
         node.indeterminate = false;
         node.selected = true;
         this.#selection.add(node);
@@ -600,7 +600,7 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
     }
 
     // Only selectable children influence the selected/indeterminate state of the parent.
-    const selectableChildren = node.children.filter(child => !!child.selectable);
+    const selectableChildren = node.children.filter(child => child.selectable !== false);
 
     // If a node has no selectable children (for example a node whose only children are
     // non-selectable leaf nodes), its selection state is independent of its children.

--- a/packages/components/tree/src/tree-data-source.ts
+++ b/packages/components/tree/src/tree-data-source.ts
@@ -26,6 +26,7 @@ export interface TreeDataSourceNode<T> {
   level: number;
   levelGuides?: number[];
   parent?: TreeDataSourceNode<T>;
+  selectable?: boolean;
   selected?: boolean;
   type: TreeNodeType;
 }
@@ -55,6 +56,13 @@ export interface TreeDataSourceMapping<T> {
 
   /** Returns whether the given node is expandable. */
   isExpandable(item: T): boolean;
+
+  /**
+   * Returns whether the given node can be selected. If not provided, all nodes are selectable by
+   * default. Use this to create a tree where only some nodes can be selected, for example a tree
+   * where the parent nodes are selectable, but the leaf nodes are not.
+   */
+  isSelectable?(item: T): boolean;
 
   /**
    * Returns whether the given node is expanded. This is only used for the initial expanded state of
@@ -274,6 +282,11 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
 
   /** Selects the given node and any children. */
   select(node: TreeDataSourceNode<T>, emitEvent = true): void {
+    // Nodes that aren't selectable cannot be selected.
+    if (node.selectable === false) {
+      return;
+    }
+
     if (!this.multiple) {
       this.deselectAll();
     }
@@ -283,12 +296,14 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
     this.#selection.add(node);
 
     if (this.multiple) {
-      // Select all children
+      // Select all selectable children
       if (node.expandable) {
         const traverse = (node: TreeDataSourceNode<T>): void => {
-          node.indeterminate = false;
-          node.selected = true;
-          this.#selection.add(node);
+          if (node.selectable !== false) {
+            node.indeterminate = false;
+            node.selected = true;
+            this.#selection.add(node);
+          }
 
           if (node.expandable) {
             (node.children || []).forEach(traverse);
@@ -344,12 +359,14 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
     }
   }
 
-  /** Selects all nodes in the tree. */
+  /** Selects all selectable nodes in the tree. */
   selectAll(): void {
     const traverse = (node: TreeDataSourceNode<T>): void => {
-      node.indeterminate = false;
-      node.selected = true;
-      this.#selection.add(node);
+      if (node.selectable !== false) {
+        node.indeterminate = false;
+        node.selected = true;
+        this.#selection.add(node);
+      }
 
       if (node.expandable) {
         (node.children || []).forEach(traverse);
@@ -582,9 +599,24 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
       return;
     }
 
-    node.selected = node.children.length > 0 && node.children.every(child => child.selected);
+    // Only selectable children influence the selected/indeterminate state of the parent.
+    const selectableChildren = node.children.filter(child => child.selectable !== false);
+
+    // If a node has no selectable children (for example a node whose only children are
+    // non-selectable leaf nodes), its selection state is independent of its children.
+    if (selectableChildren.length === 0) {
+      if (node.selected) {
+        this.#selection.add(node);
+      } else {
+        this.#selection.delete(node);
+      }
+
+      return;
+    }
+
+    node.selected = selectableChildren.every(child => child.selected);
     node.indeterminate =
-      !node.selected && node.children.some(child => child.indeterminate || child.selected);
+      !node.selected && selectableChildren.some(child => child.indeterminate || child.selected);
 
     if (node.selected) {
       this.#selection.add(node);

--- a/packages/components/tree/src/tree-data-source.ts
+++ b/packages/components/tree/src/tree-data-source.ts
@@ -283,7 +283,7 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
   /** Selects the given node and any children. */
   select(node: TreeDataSourceNode<T>, emitEvent = true): void {
     // Nodes that aren't selectable cannot be selected.
-    if (node.selectable === false) {
+    if (!node.selectable) {
       return;
     }
 
@@ -299,7 +299,7 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
       // Select all selectable children
       if (node.expandable) {
         const traverse = (node: TreeDataSourceNode<T>): void => {
-          if (node.selectable !== false) {
+          if (node.selectable) {
             node.indeterminate = false;
             node.selected = true;
             this.#selection.add(node);
@@ -362,7 +362,7 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
   /** Selects all selectable nodes in the tree. */
   selectAll(): void {
     const traverse = (node: TreeDataSourceNode<T>): void => {
-      if (node.selectable !== false) {
+      if (node.selectable) {
         node.indeterminate = false;
         node.selected = true;
         this.#selection.add(node);

--- a/packages/components/tree/src/tree-data-source.ts
+++ b/packages/components/tree/src/tree-data-source.ts
@@ -283,7 +283,7 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
   /** Selects the given node and any children. */
   select(node: TreeDataSourceNode<T>, emitEvent = true): void {
     // Nodes that aren't selectable cannot be selected.
-    if (!node.selectable) {
+    if (node.selectable === false) {
       return;
     }
 
@@ -299,7 +299,7 @@ export abstract class TreeDataSource<T = any> extends DataSource<T, TreeDataSour
       // Select all selectable children
       if (node.expandable) {
         const traverse = (node: TreeDataSourceNode<T>): void => {
-          if (node.selectable) {
+          if (node.selectable !== false) {
             node.indeterminate = false;
             node.selected = true;
             this.#selection.add(node);

--- a/packages/components/tree/src/tree-node.scss
+++ b/packages/components/tree/src/tree-node.scss
@@ -143,7 +143,7 @@ sl-icon {
 [part='content'] {
   align-items: center;
   display: flex;
-  gap: var(--sl-size-025);
+  gap: var(--sl-size-050);
   padding-block: var(--sl-size-075);
 }
 

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -346,4 +346,61 @@ describe('sl-tree-node', () => {
       expect(onChange.lastCall.firstArg).to.not.be.true;
     });
   });
+
+  describe('not selectable', () => {
+    beforeEach(async () => {
+      el = await fixture(html`
+        <sl-tree-node multiple .selectable=${false} .node=${{ hello: true }}>
+          <span>Lorem</span>
+        </sl-tree-node>
+      `);
+    });
+
+    it('should not have an aria-selected attribute', () => {
+      expect(el).not.to.have.attribute('aria-selected');
+    });
+
+    it('should not render a checkbox', () => {
+      expect(el.renderRoot.querySelector('sl-checkbox')).to.not.exist;
+    });
+
+    it('should not select when clicking the text', async () => {
+      el.querySelector('span')?.click();
+      await el.updateComplete;
+
+      expect(el.selected).to.not.be.true;
+      expect(el).not.to.have.attribute('aria-selected');
+    });
+
+    it('should not select when pressing enter or space', async () => {
+      el.focus();
+
+      await userEvent.keyboard('{Enter}');
+      expect(el.selected).to.not.be.true;
+
+      await userEvent.keyboard('{Space}');
+      expect(el.selected).to.not.be.true;
+    });
+
+    it('should not emit a change event when clicking the text', () => {
+      const onChange = spy();
+
+      el.addEventListener('sl-change', (event: SlChangeEvent) => {
+        onChange(event.detail);
+      });
+      el.querySelector('span')?.click();
+
+      expect(onChange).not.to.have.been.called;
+    });
+
+    it('should still toggle the expanded state when expandable', async () => {
+      el.expandable = true;
+      await el.updateComplete;
+
+      el.click();
+      await el.updateComplete;
+
+      expect(el).to.have.attribute('aria-expanded', 'true');
+    });
+  });
 });

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -64,8 +64,12 @@ describe('sl-tree-node', () => {
       expect(el.level).to.equal(0);
     });
 
+    it('should not be selectable', () => {
+      expect(el.selectable).to.not.be.true;
+    });
+
     it('should not be selected', () => {
-      expect(el).to.have.attribute('aria-selected', 'false');
+      expect(el).not.to.have.attribute('aria-selected');
       expect(el.selected).to.not.be.true;
     });
 
@@ -109,7 +113,7 @@ describe('sl-tree-node', () => {
   describe('expandable', () => {
     beforeEach(async () => {
       el = await fixture(html`
-        <sl-tree-node expandable>
+        <sl-tree-node expandable .selectable=${true}>
           <span>Lorem</span>
         </sl-tree-node>
       `);
@@ -213,7 +217,7 @@ describe('sl-tree-node', () => {
   describe('single select', () => {
     beforeEach(async () => {
       el = await fixture(html`
-        <sl-tree-node .node=${{ hello: true }}>
+        <sl-tree-node .selectable=${true} .node=${{ hello: true }}>
           <span>Lorem</span>
         </sl-tree-node>
       `);
@@ -268,7 +272,7 @@ describe('sl-tree-node', () => {
   describe('multiple select', () => {
     beforeEach(async () => {
       el = await fixture(html`
-        <sl-tree-node multiple>
+        <sl-tree-node multiple .selectable=${true}>
           <span>Lorem</span>
         </sl-tree-node>
       `);

--- a/packages/components/tree/src/tree-node.spec.ts
+++ b/packages/components/tree/src/tree-node.spec.ts
@@ -113,7 +113,7 @@ describe('sl-tree-node', () => {
   describe('expandable', () => {
     beforeEach(async () => {
       el = await fixture(html`
-        <sl-tree-node expandable .selectable=${true}>
+        <sl-tree-node expandable selectable>
           <span>Lorem</span>
         </sl-tree-node>
       `);
@@ -217,7 +217,7 @@ describe('sl-tree-node', () => {
   describe('single select', () => {
     beforeEach(async () => {
       el = await fixture(html`
-        <sl-tree-node .selectable=${true} .node=${{ hello: true }}>
+        <sl-tree-node selectable .node=${{ hello: true }}>
           <span>Lorem</span>
         </sl-tree-node>
       `);
@@ -272,7 +272,7 @@ describe('sl-tree-node', () => {
   describe('multiple select', () => {
     beforeEach(async () => {
       el = await fixture(html`
-        <sl-tree-node multiple .selectable=${true}>
+        <sl-tree-node multiple selectable>
           <span>Lorem</span>
         </sl-tree-node>
       `);
@@ -354,7 +354,7 @@ describe('sl-tree-node', () => {
   describe('not selectable', () => {
     beforeEach(async () => {
       el = await fixture(html`
-        <sl-tree-node multiple .selectable=${false} .node=${{ hello: true }}>
+        <sl-tree-node multiple .node=${{ hello: true }}>
           <span>Lorem</span>
         </sl-tree-node>
       `);

--- a/packages/components/tree/src/tree-node.ts
+++ b/packages/components/tree/src/tree-node.ts
@@ -130,6 +130,14 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
   @property({ attribute: false }) node?: TreeDataSourceNode<T>;
 
   /**
+   * Whether the node can be selected. When false, the node does not render a checkbox and cannot be
+   * selected by the user.
+   *
+   * @default true
+   */
+  @property({ type: Boolean }) selectable = true;
+
+  /**
    * Determines whether the node is selected or not.
    *
    * @default false
@@ -177,8 +185,12 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
       }
     }
 
-    if (changes.has('indeterminate') || changes.has('selected')) {
-      this.setAttribute('aria-selected', Boolean(this.selected).toString());
+    if (changes.has('indeterminate') || changes.has('selectable') || changes.has('selected')) {
+      if (this.selectable) {
+        this.setAttribute('aria-selected', Boolean(this.selected).toString());
+      } else {
+        this.removeAttribute('aria-selected');
+      }
     }
   }
 
@@ -217,7 +229,7 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
               ]
             ],
             () =>
-              this.multiple
+              this.multiple && this.selectable
                 ? html`
                     <sl-checkbox
                       @sl-change=${this.#onChange}
@@ -281,7 +293,7 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
       .filter((el): el is HTMLElement => el instanceof HTMLElement)
       .find(el => el === wrapper);
 
-    if (insideWrapper) {
+    if (insideWrapper && this.selectable) {
       event.preventDefault();
 
       this.selected = !this.selected;
@@ -301,6 +313,10 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
   #onKeydown(event: KeyboardEvent): void {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
+
+      if (!this.selectable) {
+        return;
+      }
 
       this.selected = !this.selected;
       this.indeterminate = false;

--- a/packages/components/tree/src/tree-node.ts
+++ b/packages/components/tree/src/tree-node.ts
@@ -133,9 +133,9 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
    * Whether the node can be selected. When false, the node does not render a checkbox and cannot be
    * selected by the user.
    *
-   * @default true
+   * @default false
    */
-  @property({ type: Boolean }) selectable = true;
+  @property({ type: Boolean }) selectable?: boolean;
 
   /**
    * Determines whether the node is selected or not.
@@ -167,7 +167,9 @@ export class TreeNode<T = any> extends ScopedElementsMixin(LitElement) {
      */
     this.setAttribute('role', 'row');
 
-    this.setAttribute('aria-selected', Boolean(this.selected).toString());
+    if (this.selectable) {
+      this.setAttribute('aria-selected', Boolean(this.selected).toString());
+    }
 
     if (!this.hasAttribute('tabindex')) {
       this.tabIndex = 0;

--- a/packages/components/tree/src/tree.stories.ts
+++ b/packages/components/tree/src/tree.stories.ts
@@ -195,9 +195,77 @@ export const nestedData: NestedDataNode[] = [
   }
 ];
 
+export const curriculumData: NestedDataNode[] = [
+  {
+    id: 0,
+    name: 'Curriculum',
+    children: [
+      {
+        id: 1,
+        name: 'Mathematics',
+        children: [
+          {
+            id: 2,
+            name: 'Algebra I',
+            children: [
+              { id: 3, name: 'Linear Equations' },
+              { id: 4, name: 'Quadratic Functions' },
+              { id: 5, name: 'Systems of Equations' }
+            ]
+          },
+          {
+            id: 6,
+            name: 'Geometry',
+            children: [
+              { id: 7, name: 'Triangles & Angles' },
+              { id: 8, name: 'Circle Theorems' }
+            ]
+          }
+        ]
+      },
+      {
+        id: 9,
+        name: 'Science',
+        children: [
+          {
+            id: 10,
+            name: 'Biology',
+            children: [
+              { id: 11, name: 'Cell Structure' },
+              { id: 12, name: 'Photosynthesis' }
+            ]
+          },
+          {
+            id: 13,
+            name: 'Chemistry',
+            children: [
+              { id: 14, name: 'The Periodic Table' },
+              { id: 15, name: 'Chemical Bonding' }
+            ]
+          }
+        ]
+      },
+      {
+        id: 16,
+        name: 'Languages',
+        children: [
+          {
+            id: 17,
+            name: 'Spanish',
+            children: [
+              { id: 18, name: 'Basic Greetings' },
+              { id: 19, name: 'Verb Conjugation' }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+];
+
 export default {
   title: 'Navigation/Tree',
-  excludeStories: ['flatData', 'nestedData'],
+  excludeStories: ['curriculumData', 'flatData', 'nestedData'],
   parameters: {
     a11y: {
       config: {
@@ -474,6 +542,23 @@ export const Multiple: Story = {
       multiple: true
     }),
     hideGuides: true
+  }
+};
+
+export const MultipleWithoutLeafs: Story = {
+  args: {
+    dataSource: new NestedTreeDataSource(curriculumData, {
+      getChildren: ({ children }) => children,
+      getId: item => item.id,
+      getLabel: ({ name }) => name,
+      isExpandable: ({ children }) => !!children,
+      isExpanded: () => true,
+      // Only the parent nodes are selectable, the leaf nodes are not.
+      isSelectable: ({ children }) => !!children,
+      multiple: true
+    }),
+    hideGuides: true,
+    maxWidth: '350px'
   }
 };
 

--- a/packages/components/tree/src/tree.stories.ts
+++ b/packages/components/tree/src/tree.stories.ts
@@ -1,8 +1,28 @@
 import {
+  faAtom,
+  faCalculator,
+  faChartArea,
+  faChartLine,
+  faCircle,
+  faComments,
+  faDna,
+  faDrawPolygon,
   faFileLines,
+  faFlask,
   faFolder,
   faFolderOpen,
+  faGraduationCap,
+  faHand,
+  faLanguage,
+  faLeaf,
+  faLink,
+  faListOl,
+  faMicroscope,
   faPen,
+  faShapes,
+  faSpellCheck,
+  faSquareRootVariable,
+  faTableCells,
   faTrash
 } from '@fortawesome/pro-regular-svg-icons';
 import { Badge } from '@sl-design-system/badge';
@@ -51,7 +71,33 @@ export interface LazyNestedDataNode {
     | Array<Promise<LazyNestedDataNode>>;
 }
 
-Icon.register(faFileLines, faFolder, faFolderOpen, faPen, faTrash);
+Icon.register(
+  faAtom,
+  faCalculator,
+  faChartArea,
+  faChartLine,
+  faCircle,
+  faComments,
+  faDna,
+  faDrawPolygon,
+  faFileLines,
+  faFlask,
+  faFolder,
+  faFolderOpen,
+  faGraduationCap,
+  faHand,
+  faLanguage,
+  faLeaf,
+  faLink,
+  faListOl,
+  faMicroscope,
+  faPen,
+  faShapes,
+  faSpellCheck,
+  faSquareRootVariable,
+  faTableCells,
+  faTrash
+);
 
 export const flatData: FlatDataNode[] = [
   {
@@ -382,12 +428,34 @@ export const HideGuides: Story = {
   }
 };
 
+const curriculumIcons: Record<string, string> = {
+  Curriculum: 'far-graduation-cap',
+  Mathematics: 'far-calculator',
+  'Algebra I': 'far-square-root-variable',
+  'Linear Equations': 'far-chart-line',
+  'Quadratic Functions': 'far-chart-area',
+  'Systems of Equations': 'far-list-ol',
+  Geometry: 'far-draw-polygon',
+  'Triangles & Angles': 'far-shapes',
+  'Circle Theorems': 'far-circle',
+  Science: 'far-flask',
+  Biology: 'far-dna',
+  'Cell Structure': 'far-microscope',
+  Photosynthesis: 'far-leaf',
+  Chemistry: 'far-atom',
+  'The Periodic Table': 'far-table-cells',
+  'Chemical Bonding': 'far-link',
+  Languages: 'far-language',
+  Spanish: 'far-comments',
+  'Basic Greetings': 'far-hand',
+  'Verb Conjugation': 'far-spell-check'
+};
+
 export const Icons: Story = {
   args: {
     dataSource: new NestedTreeDataSource(nestedData, {
       getChildren: ({ children }) => children,
-      getIcon: ({ children }, expanded) =>
-        children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',
+      getIcon: ({ name }) => curriculumIcons[name] ?? 'far-file-lines',
       getId: item => item.id,
       getLabel: ({ name }) => name,
       isExpandable: ({ children }) => !!children,
@@ -420,8 +488,7 @@ export const Filter: Story = {
 
       return new NestedTreeDataSource(data, {
         getChildren: ({ children }) => children,
-        getIcon: ({ children }, expanded) =>
-          children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',
+        getIcon: ({ name }) => curriculumIcons[name] ?? 'far-file-lines',
         getId: item => item.id,
         getLabel: ({ name }) => name,
         isExpandable: ({ children }) => !!children,
@@ -516,8 +583,6 @@ export const Multiple: Story = {
   args: {
     dataSource: new NestedTreeDataSource(nestedData, {
       getChildren: ({ children }) => children,
-      getIcon: ({ children }, expanded) =>
-        children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',
       getId: item => item.id,
       getLabel: ({ name }) => name,
       isExpanded: ({ name }) => ['Curriculum', 'Science', 'Biology'].includes(name),
@@ -643,8 +708,6 @@ export const Sorting: Story = {
   render: () => {
     const ds = new NestedTreeDataSource(nestedData, {
       getChildren: ({ children }) => children,
-      getIcon: ({ children }, expanded) =>
-        children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',
       getId: item => item.id,
       getLabel: ({ name }) => name,
       isExpandable: ({ children }) => !!children,

--- a/packages/components/tree/src/tree.stories.ts
+++ b/packages/components/tree/src/tree.stories.ts
@@ -537,7 +537,8 @@ export const MultipleWithoutLeafs: Story = {
       getId: item => item.id,
       getLabel: ({ name }) => name,
       isExpandable: ({ children }) => !!children,
-      isExpanded: () => true,
+      // Expand the path down to "Algebra I" so its leaf nodes are visible by default.
+      isExpanded: ({ name }) => ['Curriculum', 'Mathematics', 'Algebra I'].includes(name),
       // Only the parent nodes are selectable, the leaf nodes are not.
       isSelectable: ({ children }) => !!children,
       multiple: true

--- a/packages/components/tree/src/tree.stories.ts
+++ b/packages/components/tree/src/tree.stories.ts
@@ -152,49 +152,6 @@ export const flatData: FlatDataNode[] = [
   }
 ];
 
-export const nestedData: NestedDataNode[] = [
-  {
-    id: -1,
-    name: 'components',
-    children: [
-      {
-        id: 0,
-        name: 'textarea',
-        children: [{ id: 1, name: 'package.json' }]
-      },
-      {
-        id: 2,
-        name: 'tooltip',
-        children: [{ id: 3, name: 'package.json' }]
-      },
-      {
-        id: 4,
-        name: 'tree',
-        children: [
-          {
-            id: 5,
-            name: 'src',
-            children: [
-              { id: 6, name: 'flat-tree-model.ts' },
-              { id: 7, name: 'nested-tree-model.ts' },
-              { id: 8, name: 'tree-model.ts' },
-              { id: 9, name: 'tree-node.scss' },
-              { id: 10, name: 'tree-node.ts' },
-              { id: 11, name: 'tree.ts' },
-              { id: 12, name: 'utils.ts' }
-            ]
-          },
-          { id: 13, name: 'index.ts' },
-          { id: 14, name: 'package.json' },
-          { id: 15, name: 'register.ts' }
-        ]
-      },
-      { id: 16, name: 'eslint.config.mjs' },
-      { id: 17, name: 'stylelint.config.mjs' }
-    ]
-  }
-];
-
 export const curriculumData: NestedDataNode[] = [
   {
     id: 0,
@@ -265,7 +222,7 @@ export const curriculumData: NestedDataNode[] = [
 
 export default {
   title: 'Navigation/Tree',
-  excludeStories: ['curriculumData', 'flatData', 'nestedData'],
+  excludeStories: ['curriculumData', 'flatData'],
   parameters: {
     a11y: {
       config: {
@@ -402,14 +359,14 @@ export const HideGuides: Story = {
 
 export const Icons: Story = {
   args: {
-    dataSource: new NestedTreeDataSource(nestedData, {
+    dataSource: new NestedTreeDataSource(curriculumData, {
       getChildren: ({ children }) => children,
-      getIcon: ({ name }, expanded) =>
-        name.includes('.') ? 'far-file-lines' : `far-folder${expanded ? '-open' : ''}`,
+      getIcon: ({ children }, expanded) =>
+        children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',
       getId: item => item.id,
       getLabel: ({ name }) => name,
       isExpandable: ({ children }) => !!children,
-      isExpanded: ({ name }) => ['components', 'tree', 'src'].includes(name)
+      isExpanded: ({ name }) => ['Curriculum', 'Mathematics', 'Algebra I'].includes(name)
     })
   }
 };
@@ -434,16 +391,18 @@ export const Filter: Story = {
     };
 
     const createDataSource = (filter?: string) => {
-      const data = filter ? filterTree(nestedData, new RegExp(filter, 'i')) : nestedData;
+      const data = filter ? filterTree(curriculumData, new RegExp(filter, 'i')) : curriculumData;
 
       return new NestedTreeDataSource(data, {
         getChildren: ({ children }) => children,
-        getIcon: ({ name }, expanded) =>
-          name.includes('.') ? 'far-file-lines' : `far-folder${expanded ? '-open' : ''}`,
+        getIcon: ({ children }, expanded) =>
+          children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',
         getId: item => item.id,
         getLabel: ({ name }) => name,
         isExpandable: ({ children }) => !!children,
-        isExpanded: filter ? () => true : ({ name }) => ['components', 'tree', 'src'].includes(name)
+        isExpanded: filter
+          ? () => true
+          : ({ name }) => ['Curriculum', 'Mathematics', 'Algebra I'].includes(name)
       });
     };
 
@@ -530,15 +489,15 @@ export const LazyLoad: Story = {
 
 export const Multiple: Story = {
   args: {
-    dataSource: new NestedTreeDataSource(nestedData, {
+    dataSource: new NestedTreeDataSource(curriculumData, {
       getChildren: ({ children }) => children,
-      getIcon: ({ name }, expanded) =>
-        name.includes('.') ? 'far-file-lines' : `far-folder${expanded ? '-open' : ''}`,
+      getIcon: ({ children }, expanded) =>
+        children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',
       getId: item => item.id,
       getLabel: ({ name }) => name,
-      isExpanded: ({ name }) => ['components', 'tree', 'src'].includes(name),
+      isExpanded: ({ name }) => ['Curriculum', 'Science', 'Biology'].includes(name),
       isExpandable: ({ children }) => !!children,
-      isSelected: ({ name }) => ['tree-node.scss', 'tree-node.ts'].includes(name),
+      isSelected: ({ name }) => ['Cell Structure', 'Photosynthesis'].includes(name),
       multiple: true
     }),
     hideGuides: true
@@ -639,14 +598,14 @@ export const Skeleton: Story = {
 
 export const Sorting: Story = {
   render: () => {
-    const ds = new NestedTreeDataSource(nestedData, {
+    const ds = new NestedTreeDataSource(curriculumData, {
       getChildren: ({ children }) => children,
-      getIcon: ({ name }, expanded) =>
-        name.includes('.') ? 'far-file-lines' : `far-folder${expanded ? '-open' : ''}`,
+      getIcon: ({ children }, expanded) =>
+        children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',
       getId: item => item.id,
       getLabel: ({ name }) => name,
       isExpandable: ({ children }) => !!children,
-      isExpanded: ({ name }) => ['components', 'tree', 'src'].includes(name)
+      isExpanded: ({ name }) => ['Curriculum', 'Mathematics', 'Algebra I'].includes(name)
     });
 
     ds.setSort('name', 'asc');

--- a/packages/components/tree/src/tree.stories.ts
+++ b/packages/components/tree/src/tree.stories.ts
@@ -38,6 +38,7 @@ export interface FlatDataNode {
 export interface NestedDataNode {
   id: number;
   name: string;
+  description?: string;
   children?: NestedDataNode[];
 }
 
@@ -152,7 +153,7 @@ export const flatData: FlatDataNode[] = [
   }
 ];
 
-export const curriculumData: NestedDataNode[] = [
+export const nestedData: NestedDataNode[] = [
   {
     id: 0,
     name: 'Curriculum',
@@ -165,17 +166,33 @@ export const curriculumData: NestedDataNode[] = [
             id: 2,
             name: 'Algebra I',
             children: [
-              { id: 3, name: 'Linear Equations' },
-              { id: 4, name: 'Quadratic Functions' },
-              { id: 5, name: 'Systems of Equations' }
+              {
+                id: 3,
+                name: 'Linear Equations',
+                description: 'Solving equations of the first degree'
+              },
+              {
+                id: 4,
+                name: 'Quadratic Functions',
+                description: 'Parabolas and the quadratic formula'
+              },
+              {
+                id: 5,
+                name: 'Systems of Equations',
+                description: 'Solving multiple equations at once'
+              }
             ]
           },
           {
             id: 6,
             name: 'Geometry',
             children: [
-              { id: 7, name: 'Triangles & Angles' },
-              { id: 8, name: 'Circle Theorems' }
+              {
+                id: 7,
+                name: 'Triangles & Angles',
+                description: 'Angle sums and triangle congruence'
+              },
+              { id: 8, name: 'Circle Theorems', description: 'Chords, tangents and arcs' }
             ]
           }
         ]
@@ -188,16 +205,24 @@ export const curriculumData: NestedDataNode[] = [
             id: 10,
             name: 'Biology',
             children: [
-              { id: 11, name: 'Cell Structure' },
-              { id: 12, name: 'Photosynthesis' }
+              { id: 11, name: 'Cell Structure', description: 'Organelles and their functions' },
+              {
+                id: 12,
+                name: 'Photosynthesis',
+                description: 'How plants convert light into energy'
+              }
             ]
           },
           {
             id: 13,
             name: 'Chemistry',
             children: [
-              { id: 14, name: 'The Periodic Table' },
-              { id: 15, name: 'Chemical Bonding' }
+              {
+                id: 14,
+                name: 'The Periodic Table',
+                description: 'Elements, groups and periods'
+              },
+              { id: 15, name: 'Chemical Bonding', description: 'Ionic and covalent bonds' }
             ]
           }
         ]
@@ -210,8 +235,8 @@ export const curriculumData: NestedDataNode[] = [
             id: 17,
             name: 'Spanish',
             children: [
-              { id: 18, name: 'Basic Greetings' },
-              { id: 19, name: 'Verb Conjugation' }
+              { id: 18, name: 'Basic Greetings', description: 'Everyday words and phrases' },
+              { id: 19, name: 'Verb Conjugation', description: 'Present tense regular verbs' }
             ]
           }
         ]
@@ -222,7 +247,7 @@ export const curriculumData: NestedDataNode[] = [
 
 export default {
   title: 'Navigation/Tree',
-  excludeStories: ['curriculumData', 'flatData'],
+  excludeStories: ['flatData', 'nestedData'],
   parameters: {
     a11y: {
       config: {
@@ -359,7 +384,7 @@ export const HideGuides: Story = {
 
 export const Icons: Story = {
   args: {
-    dataSource: new NestedTreeDataSource(curriculumData, {
+    dataSource: new NestedTreeDataSource(nestedData, {
       getChildren: ({ children }) => children,
       getIcon: ({ children }, expanded) =>
         children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',
@@ -391,7 +416,7 @@ export const Filter: Story = {
     };
 
     const createDataSource = (filter?: string) => {
-      const data = filter ? filterTree(curriculumData, new RegExp(filter, 'i')) : curriculumData;
+      const data = filter ? filterTree(nestedData, new RegExp(filter, 'i')) : nestedData;
 
       return new NestedTreeDataSource(data, {
         getChildren: ({ children }) => children,
@@ -489,7 +514,7 @@ export const LazyLoad: Story = {
 
 export const Multiple: Story = {
   args: {
-    dataSource: new NestedTreeDataSource(curriculumData, {
+    dataSource: new NestedTreeDataSource(nestedData, {
       getChildren: ({ children }) => children,
       getIcon: ({ children }, expanded) =>
         children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',
@@ -506,7 +531,8 @@ export const Multiple: Story = {
 
 export const MultipleWithoutLeafs: Story = {
   args: {
-    dataSource: new NestedTreeDataSource(curriculumData, {
+    dataSource: new NestedTreeDataSource(nestedData, {
+      getAriaDescription: ({ description }) => description,
       getChildren: ({ children }) => children,
       getId: item => item.id,
       getLabel: ({ name }) => name,
@@ -516,6 +542,22 @@ export const MultipleWithoutLeafs: Story = {
       isSelectable: ({ children }) => !!children,
       multiple: true
     }),
+    renderer: ({ dataNode, label }: TreeDataSourceNode<NestedDataNode>) => {
+      // Only the leaf nodes have a description; other nodes use the default rendering.
+      if (!dataNode?.description) {
+        return undefined;
+      }
+
+      return html`
+        <span style="display: flex; flex-direction: column">
+          <span>${label}</span>
+          <span
+            style="color: var(--sl-color-foreground-subtlest); font: var(--sl-text-new-body-sm)">
+            ${dataNode.description}
+          </span>
+        </span>
+      `;
+    },
     hideGuides: true,
     maxWidth: '350px'
   }
@@ -598,7 +640,7 @@ export const Skeleton: Story = {
 
 export const Sorting: Story = {
   render: () => {
-    const ds = new NestedTreeDataSource(curriculumData, {
+    const ds = new NestedTreeDataSource(nestedData, {
       getChildren: ({ children }) => children,
       getIcon: ({ children }, expanded) =>
         children ? `far-folder${expanded ? '-open' : ''}` : 'far-file-lines',

--- a/packages/components/tree/src/tree.stories.ts
+++ b/packages/components/tree/src/tree.stories.ts
@@ -529,41 +529,6 @@ export const Multiple: Story = {
   }
 };
 
-export const MultipleWithoutLeafs: Story = {
-  args: {
-    dataSource: new NestedTreeDataSource(nestedData, {
-      getAriaDescription: ({ description }) => description,
-      getChildren: ({ children }) => children,
-      getId: item => item.id,
-      getLabel: ({ name }) => name,
-      isExpandable: ({ children }) => !!children,
-      // Expand the path down to "Algebra I" so its leaf nodes are visible by default.
-      isExpanded: ({ name }) => ['Curriculum', 'Mathematics', 'Algebra I'].includes(name),
-      // Only the parent nodes are selectable, the leaf nodes are not.
-      isSelectable: ({ children }) => !!children,
-      multiple: true
-    }),
-    renderer: ({ dataNode, label }: TreeDataSourceNode<NestedDataNode>) => {
-      // Only the leaf nodes have a description; other nodes use the default rendering.
-      if (!dataNode?.description) {
-        return undefined;
-      }
-
-      return html`
-        <span style="display: flex; flex-direction: column">
-          <span>${label}</span>
-          <span
-            style="color: var(--sl-color-foreground-subtlest); font: var(--sl-text-new-body-sm)">
-            ${dataNode.description}
-          </span>
-        </span>
-      `;
-    },
-    hideGuides: true,
-    maxWidth: '350px'
-  }
-};
-
 export const Overflow: Story = {
   args: {
     ...Basic.args,
@@ -603,6 +568,41 @@ export const PageScrolling: Story = {
         isSelected: ({ id }) => id === 2010
       }
     )
+  }
+};
+
+export const Selectable: Story = {
+  args: {
+    dataSource: new NestedTreeDataSource(nestedData, {
+      getAriaDescription: ({ description }) => description,
+      getChildren: ({ children }) => children,
+      getId: item => item.id,
+      getLabel: ({ name }) => name,
+      isExpandable: ({ children }) => !!children,
+      // Expand the path down to "Algebra I" so its leaf nodes are visible by default.
+      isExpanded: ({ name }) => ['Curriculum', 'Mathematics', 'Algebra I'].includes(name),
+      // Only the parent nodes are selectable, the leaf nodes are not.
+      isSelectable: ({ children }) => !!children,
+      multiple: true
+    }),
+    renderer: ({ dataNode, label }: TreeDataSourceNode<NestedDataNode>) => {
+      // Only the leaf nodes have a description; other nodes use the default rendering.
+      if (!dataNode?.description) {
+        return undefined;
+      }
+
+      return html`
+        <span style="display: flex; flex-direction: column">
+          <span
+            style="color: var(--sl-color-foreground-bold); font-weight: var(--sl-text-new-typeset-fontWeight-semiBold);">
+            ${label}
+          </span>
+          <span style="color: var(--sl-color-foreground-subtlest)"> ${dataNode.description} </span>
+        </span>
+      `;
+    },
+    hideGuides: true,
+    maxWidth: '350px'
   }
 };
 

--- a/packages/components/tree/src/tree.ts
+++ b/packages/components/tree/src/tree.ts
@@ -203,11 +203,11 @@ export class Tree<T = any> extends ObserveAttributesMixin(ScopedElementsMixin(Li
                   ?indeterminate=${item.indeterminate}
                   ?last-node-in-level=${item.lastNodeInLevel}
                   ?multiple=${this.dataSource?.multiple}
+                  ?selectable=${item.selectable}
+                  ?selected=${item.selected}
                   .level=${item.level}
                   .levelGuides=${this.hideGuides ? undefined : item.levelGuides}
                   .node=${item}
-                  .selectable=${item.selectable !== false}
-                  .selected=${item.selected}
                   .type=${item.type}
                   aria-controls=${ifDefined(
                     item.children?.map(child => String(child.id)).join(' ')

--- a/packages/components/tree/src/tree.ts
+++ b/packages/components/tree/src/tree.ts
@@ -206,6 +206,7 @@ export class Tree<T = any> extends ObserveAttributesMixin(ScopedElementsMixin(Li
                   .level=${item.level}
                   .levelGuides=${this.hideGuides ? undefined : item.levelGuides}
                   .node=${item}
+                  .selectable=${item.selectable !== false}
                   .selected=${item.selected}
                   .type=${item.type}
                   aria-controls=${ifDefined(


### PR DESCRIPTION
Closes #3541
Closes #3545 

Adds an optional `isSelectable` mapping function to the tree data sources, so a tree can have some nodes selectable and others not (e.g. selectable parent categories with non-selectable leaves).

### Data source
- `isSelectable?(item)` on `TreeDataSourceMapping`; defaults to `true` when omitted.
- `select`/`selectAll` skip non-selectable nodes; a parent's selected/indeterminate state is derived from its selectable children only. A node whose children are all non-selectable keeps an independent selection state.

### Component
- Non-selectable tree nodes render no checkbox, ignore click/Enter/Space selection, and omit `aria-selected`.
- `TreeNode.selectable` now defaults to falsy (opt-in), consistent with the component's other boolean properties; the tree always passes an explicit value derived from `isSelectable`.

### Stories & tests
- Replaced the old file-tree example data with a curriculum data set that better fits the design system domain.
- New `Selectable` story demonstrates selectable categories with non-selectable leaves, including per-leaf descriptions (shown in the row and exposed as an aria description).
- Added unit tests for the data source selection logic and the tree node rendering/interaction.
