### PR TITLE
feat(select): add `fill` property

### DIFF
--- a/.changeset/two-dots-happen.md
+++ b/.changeset/two-dots-happen.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/select': minor
+---
+
+Add a fill property and values "outline" (default) and "ghost"

--- a/packages/components/select/src/select-button.scss
+++ b/packages/components/select/src/select-button.scss
@@ -35,6 +35,10 @@
   --_bg-opacity: var(--sl-opacity-interactive-plain-active);
 }
 
+:host([fill='ghost']) {
+  border-color: transparent;
+}
+
 :host([show-validity='invalid']) {
   --_bg-color: var(--sl-color-background-input-plain);
   --_bg-mix-color: var(--sl-color-background-negative-interactive-plain);

--- a/packages/components/select/src/select-button.ts
+++ b/packages/components/select/src/select-button.ts
@@ -16,7 +16,7 @@ import {
 } from 'lit';
 import { property } from 'lit/decorators.js';
 import styles from './select-button.scss.js';
-import { type SelectSize } from './select.js';
+import { type SelectFill, type SelectSize } from './select.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -59,6 +59,13 @@ export class SelectButton extends ScopedElementsMixin(LitElement) {
 
   /** Whether the button is disabled. */
   @property({ type: Boolean, reflect: true }) disabled?: boolean;
+
+  /**
+   * The fill of the select.
+   *
+   * @default 'outline'
+   */
+  @property({ reflect: true }) fill?: SelectFill;
 
   /** The width of the longest option. */
   @property({ type: Number, attribute: 'option-size' }) optionSize?: number;

--- a/packages/components/select/src/select.spec.ts
+++ b/packages/components/select/src/select.spec.ts
@@ -73,6 +73,14 @@ describe('sl-select', () => {
       expect(button.renderRoot).to.have.trimmed.text('Placeholder');
     });
 
+    it('should pass fill="ghost" to the button and reflect it as an attribute', async () => {
+      el.fill = 'ghost';
+      await el.updateComplete;
+
+      expect(button.fill).to.equal('ghost');
+      expect(button).to.have.attribute('fill', 'ghost');
+    });
+
     it('should not be required', () => {
       expect(el).not.to.have.attribute('required');
       expect(el.required).not.to.be.true;

--- a/packages/components/select/src/select.stories.ts
+++ b/packages/components/select/src/select.stories.ts
@@ -19,7 +19,7 @@ import { type Select, type SelectSize } from './select.js';
 
 type Props = Pick<
   Select,
-  'clearable' | 'disabled' | 'placeholder' | 'required' | 'size' | 'value'
+  'clearable' | 'disabled' | 'fill' | 'placeholder' | 'required' | 'size' | 'value'
 > & {
   hint?: string;
   label?: string;
@@ -44,6 +44,10 @@ export default {
     value: null
   },
   argTypes: {
+    fill: {
+      control: 'inline-radio',
+      options: ['ghost', 'outline']
+    },
     size: {
       control: 'inline-radio',
       options: sizes
@@ -73,6 +77,7 @@ export default {
   render: ({
     clearable,
     disabled,
+    fill,
     hint,
     label,
     options,
@@ -102,6 +107,7 @@ export default {
               ?disabled=${disabled}
               ?required=${required}
               .value=${value}
+              fill=${ifDefined(fill)}
               placeholder=${ifDefined(placeholder)}
               size=${ifDefined(size)}>
               ${options?.() ??
@@ -126,6 +132,12 @@ export default {
 } satisfies Meta<Props>;
 
 export const Basic: Story = {};
+
+export const Ghost: Story = {
+  args: {
+    fill: 'ghost'
+  }
+};
 
 export const Clearable: Story = {
   args: {

--- a/packages/components/select/src/select.ts
+++ b/packages/components/select/src/select.ts
@@ -47,6 +47,7 @@ declare global {
   }
 }
 
+export type SelectFill = 'ghost' | 'outline';
 export type SelectSize = 'md' | 'lg';
 
 /**
@@ -182,6 +183,13 @@ export class Select<T = any> extends ObserveAttributesMixin(
   /** Whether the select is disabled; when set no interaction is possible. */
   @property({ type: Boolean, reflect: true }) override disabled?: boolean;
 
+  /**
+   * The fill of the select.
+   *
+   * @default 'outline'
+   */
+  @property() fill?: SelectFill;
+
   /** @internal Emits when the component gains focus. */
   @event({ name: 'sl-focus' }) focusEvent!: EventEmitter<SlFocusEvent>;
 
@@ -248,6 +256,7 @@ export class Select<T = any> extends ObserveAttributesMixin(
       this.button.addEventListener('sl-clear', this.#onButtonClear);
       this.button.clearable = !!this.clearable;
       this.button.disabled = !!this.disabled;
+      this.button.fill = this.fill;
       this.button.placeholder = this.placeholder;
       this.button.required = !!this.required;
       this.button.selected = this.selectedOption;
@@ -305,6 +314,10 @@ export class Select<T = any> extends ObserveAttributesMixin(
       this.button.disabled = this.disabled;
       this.button.tabIndex = this.disabled ? -1 : 0;
       this.#updateAriaKeyShortcuts();
+    }
+
+    if (changes.has('fill')) {
+      this.button.fill = this.fill;
     }
 
     if (changes.has('placeholder')) {


### PR DESCRIPTION
Closes #3519 

This adds a new `fill` property to `<sl-select>` with values `"outline"` (default) and `"ghost"`. When ghost is set, the border becomes transparent.