### PR TITLE
feat(select): add ability to customize the width of the dropdown

### DIFF
--- a/.changeset/khaki-terms-nail.md
+++ b/.changeset/khaki-terms-nail.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/select': minor
+---
+
+Add ability to change the width of the dropdown

--- a/packages/components/select/src/select.scss
+++ b/packages/components/select/src/select.scss
@@ -77,6 +77,7 @@ sl-listbox {
   box-shadow: var(--sl-elevation-shadow-overlay);
   box-sizing: border-box;
   display: none;
+  inline-size: var(--_select-listbox-width, auto);
   margin: 0;
   opacity: 0;
 

--- a/packages/components/select/src/select.spec.ts
+++ b/packages/components/select/src/select.spec.ts
@@ -949,6 +949,27 @@ describe('sl-select', () => {
       button = el.querySelector('sl-select-button')!;
       expect(button.getBoundingClientRect().width).to.equal(400);
     });
+
+    it('should set the listbox width custom property to the button width when opening', async () => {
+      el = await fixture(html`
+        <sl-select>
+          <sl-option value="1">Option 1</sl-option>
+          <sl-option value="2">Option 2</sl-option>
+          <sl-option value="3">Option 3</sl-option>
+        </sl-select>
+      `);
+
+      button = el.querySelector('sl-select-button')!;
+
+      expect(el.listbox!.style.getPropertyValue('--_select-listbox-width')).to.equal('');
+
+      button.click();
+      await el.updateComplete;
+
+      expect(el.listbox!.style.getPropertyValue('--_select-listbox-width')).to.equal(
+        `${button.getBoundingClientRect().width}px`
+      );
+    });
   });
 
   describe('selected content rendering', () => {

--- a/packages/components/select/src/select.stories.ts
+++ b/packages/components/select/src/select.stories.ts
@@ -26,6 +26,7 @@ type Props = Pick<
   options?(): TemplateResult;
   reportValidity?: boolean;
   slot?(): TemplateResult;
+  styles?(): string;
 };
 type Story = StoryObj<Props>;
 
@@ -47,6 +48,11 @@ export default {
     size: {
       control: 'inline-radio',
       options: sizes
+    },
+    styles: {
+      table: {
+        disable: true
+      }
     },
     value: {
       control: 'text'
@@ -81,6 +87,7 @@ export default {
     required,
     size,
     slot,
+    styles,
     value
   }) => {
     const onClick = (event: Event & { target: HTMLElement }): void => {
@@ -92,6 +99,7 @@ export default {
         #storybook-root {
           max-width: calc(100vw - 2rem);
         }
+        ${styles?.()}
       </style>
       <sl-form>
         <sl-form-field .hint=${hint} .label=${label}>
@@ -388,6 +396,15 @@ export const TextOverflow: Story = {
         Culpa cillum nulla aute non quis deserunt minim sit magna. Consectetur in laborum mollit ea
         cillum dolor est ut deserunt qui nostrud deserunt. Labore adipisicing anim non sint.
       </sl-option>
+    `,
+    styles: () => `
+      sl-select {
+        inline-size: 200px;
+
+        &::part(listbox) {
+          inline-size: 400px;
+        }
+      }
     `
   }
 };

--- a/packages/components/select/src/select.ts
+++ b/packages/components/select/src/select.ts
@@ -53,7 +53,7 @@ export type SelectSize = 'md' | 'lg';
  * A form control that allows users to select one option from a list of options.
  *
  * @slot default - Place for `sl-option` and `sl-option-group` elements
- * @csspart listbox - Set `--sl-popover-max-block-size` and/or `--sl-popover-min-block-size` to control the minimum and maximum height of the dropdown (within the limits of the available screen real estate)
+ * @csspart listbox - Set `--sl-popover-max-block-size` and/or `--sl-popover-min-block-size` to control the minimum and maximum height of the dropdown (within the limits of the available screen real estate). Set `width` to override the default width (which matches the button width)
  * @csspart selected - The selected option element within the select's internal `sl-select-button`, exposed for styling via `<sl-select>`
  * @csspart selected-option - The container for the selected option within the select's internal `sl-select-button`, exposed for styling via `<sl-select>`
  * @csspart placeholder - The placeholder text when no option is selected within the select's internal `sl-select-button`, exposed for styling via `<sl-select>`
@@ -490,7 +490,14 @@ export class Select<T = any> extends ObserveAttributesMixin(
   #onBeforetoggle({ newState }: ToggleEvent): void {
     if (newState === 'open') {
       this.button.setAttribute('aria-expanded', 'true');
-      this.listbox!.style.width = `${this.button.getBoundingClientRect().width}px`;
+
+      // Expose the button width as a custom property instead of setting `width` inline directly.
+      // This way the width can still be overridden from outside via `sl-select::part(listbox)`,
+      // since an inline `width` would take precedence over the `::part()` rule.
+      this.listbox!.style.setProperty(
+        '--_select-listbox-width',
+        `${this.button.getBoundingClientRect().width}px`
+      );
 
       this.currentOption = this.selectedOption ?? this.options[0];
     } else {


### PR DESCRIPTION
Closes #3547 

This changes the select internals so you can override the width of the `<sl-listbox>` by using `sl-select::part(listbox) { inline-size: 123px }` from outside the component.