### PR TITLE
fix(button menu): rename "square" shape to "rect"

### DIFF
--- a/.changeset/wild-wombats-glow.md
+++ b/.changeset/wild-wombats-glow.md
@@ -1,6 +1,7 @@
 ---
 '@sl-design-system/button': patch
 '@sl-design-system/menu': patch
+'@sl-design-system/toggle-group': patch
 ---
 
 Rename the "square" shape value to "rect" to match the design

--- a/.changeset/wild-wombats-glow.md
+++ b/.changeset/wild-wombats-glow.md
@@ -1,0 +1,6 @@
+---
+'@sl-design-system/button': patch
+'@sl-design-system/menu': patch
+---
+
+Rename the "square" shape value to "rect" to match the design

--- a/packages/components/button/src/button.stories.ts
+++ b/packages/components/button/src/button.stories.ts
@@ -49,7 +49,7 @@ export default {
     },
     shape: {
       control: 'inline-radio',
-      options: ['square', 'pill']
+      options: ['rect', 'pill']
     },
     size: {
       control: 'inline-radio',
@@ -216,8 +216,8 @@ export const All: Story = {
       </style>
       <section class="sizes">
         <span></span>
-        <span>Square text</span>
-        <span>Square icon</span>
+        <span>Rect text</span>
+        <span>Rect icon</span>
         <span>Pill text</span>
         <span>Pill icon</span>
 

--- a/packages/components/button/src/button.ts
+++ b/packages/components/button/src/button.ts
@@ -19,7 +19,7 @@ declare global {
 
 export type ButtonFill = 'solid' | 'outline' | 'link' | 'ghost';
 
-export type ButtonShape = 'square' | 'pill';
+export type ButtonShape = 'rect' | 'pill';
 
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
@@ -99,14 +99,14 @@ export class Button extends ForwardAriaMixin(LitElement) {
   /**
    * The fill of the button.
    *
-   * @default solid
+   * @default 'solid'
    */
   @property({ reflect: true }) fill?: ButtonFill;
 
   /**
    * The shape of the button.
    *
-   * @default square
+   * @default 'rect'
    */
   @property({ reflect: true }) shape?: ButtonShape;
 

--- a/packages/components/menu/src/menu-button.stories.ts
+++ b/packages/components/menu/src/menu-button.stories.ts
@@ -95,7 +95,7 @@ export default {
     },
     shape: {
       control: 'inline-radio',
-      options: ['square', 'pill']
+      options: ['rect', 'pill']
     },
     size: {
       control: 'inline-radio',

--- a/packages/components/menu/src/menu-button.ts
+++ b/packages/components/menu/src/menu-button.ts
@@ -109,7 +109,7 @@ export class MenuButton extends ForwardAriaMixin(ScopedElementsMixin(LitElement)
   /**
    * The shape of the button.
    *
-   * @default 'square'
+   * @default 'rect'
    */
   @property() shape?: ButtonShape;
 

--- a/packages/components/toggle-button/src/toggle-button.stories.ts
+++ b/packages/components/toggle-button/src/toggle-button.stories.ts
@@ -257,7 +257,7 @@ export const All: Story = {
       </section>
       <p>
         First item on the first row is the default combination of values; subtle, outline, md and
-        square shape.
+        rect shape.
       </p>
     `;
   }

--- a/packages/components/toggle-button/src/toggle-button.stories.ts
+++ b/packages/components/toggle-button/src/toggle-button.stories.ts
@@ -30,7 +30,7 @@ export default {
     },
     shape: {
       control: 'inline-radio',
-      options: ['pill', 'square']
+      options: ['pill', 'rect']
     },
     icons: {
       table: { disable: true }

--- a/packages/components/toggle-group/src/toggle-group.stories.ts
+++ b/packages/components/toggle-group/src/toggle-group.stories.ts
@@ -69,7 +69,7 @@ export default {
     },
     shape: {
       control: 'inline-radio',
-      options: ['pill', 'square']
+      options: ['pill', 'rect']
     },
     slot: {
       table: { disable: true }

--- a/packages/components/toggle-group/src/toggle-group.ts
+++ b/packages/components/toggle-group/src/toggle-group.ts
@@ -18,7 +18,7 @@ declare global {
 }
 
 export type ToggleGroupFill = 'outline' | 'solid';
-export type ToggleGroupShape = 'pill' | 'square';
+export type ToggleGroupShape = 'pill' | 'rect';
 export type ToggleGroupSize = 'sm' | 'md' | 'lg';
 
 /**
@@ -50,7 +50,11 @@ export class ToggleGroup extends LitElement {
     isFocusableElement: (el: ToggleButton) => !el.disabled
   });
 
-  /** If set, will disable all buttons in the group. */
+  /**
+   * If set, will disable all buttons in the group.
+   *
+   * @default false
+   */
   @property({ type: Boolean, reflect: true }) disabled?: boolean;
 
   /**
@@ -60,16 +64,30 @@ export class ToggleGroup extends LitElement {
    * When set to true multiple buttons can be active at the same time. In this case the group does
    * nothing when a button is toggled. Use this mode if you want to handle the toggling of buttons
    * yourself.
+   *
+   * @default false
    */
   @property({ type: Boolean }) multiple?: boolean;
 
-  /** Determines the size of all buttons in the group. */
+  /**
+   * Determines the size of all buttons in the group.
+   *
+   * @default 'md'
+   */
   @property({ reflect: true }) size?: ToggleGroupSize;
 
-  /** The shaoe of the group. */
+  /**
+   * The shape of the group.
+   *
+   * @default 'rect'
+   */
   @property({ reflect: true }) shape?: ToggleGroupShape;
 
-  /** The variant of the toggle-group. */
+  /**
+   * The fill of the group.
+   *
+   * @default 'solid'
+   */
   @property({ reflect: true }) fill?: ToggleGroupFill;
 
   override connectedCallback(): void {


### PR DESCRIPTION
Fixes #3552 

This renames `"square"` to `"rect"` for `<sl-button>`, `<sl-menu-button>` and `<sl-toggle-group>`.

Only place where `shape="square"` is valid is in avatar. There it is actually square :)