### PR TITLE
docs(color): temporarily exclude color page from navigation

### DIFF
--- a/website/src/categories/design-tokens/color/color.md
+++ b/website/src/categories/design-tokens/color/color.md
@@ -1,5 +1,6 @@
 ---
 title: Color
+eleventyExcludeFromCollections: true
 eleventyNavigation:
   parent: Design Tokens
   key: Color


### PR DESCRIPTION
This pull request makes a small documentation update to the `website/src/categories/design-tokens/color/color.md` file. The change ensures that the Color documentation page is excluded from Eleventy's navigation (collections).