### PR TITLE
fix(tree): show selectable states in tree node story

### DIFF
--- a/packages/components/tree/src/tree-node.stories.ts
+++ b/packages/components/tree/src/tree-node.stories.ts
@@ -19,6 +19,7 @@ type Props = Pick<
   | 'level'
   | 'levelGuides'
   | 'multiple'
+  | 'selectable'
   | 'selected'
   | 'type'
 > & { text: string };
@@ -34,6 +35,7 @@ export default {
     lastNodeInLevel: false,
     level: 0,
     multiple: false,
+    selectable: false,
     selected: false,
     text: 'Tree node',
     type: 'node'
@@ -52,6 +54,7 @@ export default {
     lastNodeInLevel,
     level,
     multiple,
+    selectable,
     selected,
     text,
     type
@@ -67,6 +70,7 @@ export default {
         ?last-node-in-level=${lastNodeInLevel}
         level=${level}
         ?multiple=${multiple}
+        ?selectable=${selectable}
         ?selected=${selected}
         type=${ifDefined(type)}>
         ${text}
@@ -97,23 +101,23 @@ export const All: Story = {
         <sl-tree-node disabled>Disabled</sl-tree-node>
 
         <sl-tree-node>Level 0</sl-tree-node>
-        <sl-tree-node selected>Level 0 (selected)</sl-tree-node>
+        <sl-tree-node selectable selected>Level 0 (selected)</sl-tree-node>
         <sl-tree-node expandable>Level 0 (expandable)</sl-tree-node>
         <sl-tree-node expandable expanded>Level 0 (expandable, expanded)</sl-tree-node>
         <sl-tree-node level="1">Level 1</sl-tree-node>
-        <sl-tree-node level="1" selected>Level 1 (selected)</sl-tree-node>
+        <sl-tree-node level="1" selectable selected>Level 1 (selected)</sl-tree-node>
         <sl-tree-node expandable level="1">Level 1 (expandable)</sl-tree-node>
         <sl-tree-node expandable expanded level="1">Level 1 (expandable, expanded)</sl-tree-node>
         <sl-tree-node level="2">Level 2</sl-tree-node>
-        <sl-tree-node level="2" selected>Level 2 (selected)</sl-tree-node>
+        <sl-tree-node level="2" selectable selected>Level 2 (selected)</sl-tree-node>
         <sl-tree-node expandable level="2">Level 2 (expandable)</sl-tree-node>
         <sl-tree-node expandable expanded level="2">Level 2 (expandable, expanded)</sl-tree-node>
         <sl-tree-node level="3">Level 3</sl-tree-node>
-        <sl-tree-node level="3" selected>Level 3 (selected)</sl-tree-node>
+        <sl-tree-node level="3" selectable selected>Level 3 (selected)</sl-tree-node>
         <sl-tree-node expandable level="3">Level 3 (expandable)</sl-tree-node>
         <sl-tree-node expandable expanded level="3">Level 3 (expandable, expanded)</sl-tree-node>
         <sl-tree-node level="4">Level 4</sl-tree-node>
-        <sl-tree-node level="4" selected>Level 4 (selected)</sl-tree-node>
+        <sl-tree-node level="4" selectable selected>Level 4 (selected)</sl-tree-node>
         <sl-tree-node expandable level="4">Level 4 (expandable)</sl-tree-node>
         <sl-tree-node expandable expanded level="4">Level 4 (expandable, expanded)</sl-tree-node>
 
@@ -135,29 +139,39 @@ export const All: Story = {
           >Level 4 (last node in level, guides)</sl-tree-node
         >
 
-        <sl-tree-node multiple>Level 0 (multiple)</sl-tree-node>
-        <sl-tree-node multiple indeterminate>Level 0 (multiple, indeterminate)</sl-tree-node>
-        <sl-tree-node multiple selected>Level 0 (multiple, selected)</sl-tree-node>
-        <sl-tree-node level="1" multiple>Level 1 (multiple)</sl-tree-node>
-        <sl-tree-node level="1" multiple indeterminate
+        <sl-tree-node multiple selectable>Level 0 (multiple)</sl-tree-node>
+        <sl-tree-node multiple selectable indeterminate
+          >Level 0 (multiple, indeterminate)</sl-tree-node
+        >
+        <sl-tree-node multiple selectable selected>Level 0 (multiple, selected)</sl-tree-node>
+        <sl-tree-node level="1" multiple selectable>Level 1 (multiple)</sl-tree-node>
+        <sl-tree-node level="1" multiple selectable indeterminate
           >Level 1 (multiple, indeterminate)</sl-tree-node
         >
-        <sl-tree-node level="1" multiple selected>Level 1 (multiple, selected)</sl-tree-node>
-        <sl-tree-node level="2" multiple>Level 2 (multiple)</sl-tree-node>
-        <sl-tree-node level="2" multiple indeterminate
+        <sl-tree-node level="1" multiple selectable selected
+          >Level 1 (multiple, selected)</sl-tree-node
+        >
+        <sl-tree-node level="2" multiple selectable>Level 2 (multiple)</sl-tree-node>
+        <sl-tree-node level="2" multiple selectable indeterminate
           >Level 2 (multiple, indeterminate)</sl-tree-node
         >
-        <sl-tree-node level="2" multiple selected>Level 2 (multiple, selected)</sl-tree-node>
-        <sl-tree-node level="3" multiple>Level 3 (multiple)</sl-tree-node>
-        <sl-tree-node level="3" multiple indeterminate
+        <sl-tree-node level="2" multiple selectable selected
+          >Level 2 (multiple, selected)</sl-tree-node
+        >
+        <sl-tree-node level="3" multiple selectable>Level 3 (multiple)</sl-tree-node>
+        <sl-tree-node level="3" multiple selectable indeterminate
           >Level 3 (multiple, indeterminate)</sl-tree-node
         >
-        <sl-tree-node level="3" multiple selected>Level 3 (multiple, selected)</sl-tree-node>
-        <sl-tree-node level="4" multiple>Level 4 (multiple)</sl-tree-node>
-        <sl-tree-node level="4" multiple indeterminate
+        <sl-tree-node level="3" multiple selectable selected
+          >Level 3 (multiple, selected)</sl-tree-node
+        >
+        <sl-tree-node level="4" multiple selectable>Level 4 (multiple)</sl-tree-node>
+        <sl-tree-node level="4" multiple selectable indeterminate
           >Level 4 (multiple, indeterminate)</sl-tree-node
         >
-        <sl-tree-node level="4" multiple selected>Level 4 (multiple, selected)</sl-tree-node>
+        <sl-tree-node level="4" multiple selectable selected
+          >Level 4 (multiple, selected)</sl-tree-node
+        >
       </div>
     `;
   }

--- a/packages/components/tree/src/tree-node.stories.ts
+++ b/packages/components/tree/src/tree-node.stories.ts
@@ -135,9 +135,9 @@ export const All: Story = {
           Level 3 (last node in level, guides)
         </sl-tree-node>
         <sl-tree-node level="4" show-guides>Level 4 (guides)</sl-tree-node>
-        <sl-tree-node level="4" last-node-in-level show-guides
-          >Level 4 (last node in level, guides)</sl-tree-node
-        >
+        <sl-tree-node level="4" last-node-in-level show-guides>
+          Level 4 (last node in level, guides)
+        </sl-tree-node>
 
         <sl-tree-node multiple selectable>Level 0 (multiple)</sl-tree-node>
         <sl-tree-node multiple selectable indeterminate
@@ -145,30 +145,30 @@ export const All: Story = {
         >
         <sl-tree-node multiple selectable selected>Level 0 (multiple, selected)</sl-tree-node>
         <sl-tree-node level="1" multiple selectable>Level 1 (multiple)</sl-tree-node>
-        <sl-tree-node level="1" multiple selectable indeterminate
-          >Level 1 (multiple, indeterminate)</sl-tree-node
-        >
+        <sl-tree-node level="1" multiple selectable indeterminate>
+          Level 1 (multiple, indeterminate)
+        </sl-tree-node>
         <sl-tree-node level="1" multiple selectable selected
           >Level 1 (multiple, selected)</sl-tree-node
         >
         <sl-tree-node level="2" multiple selectable>Level 2 (multiple)</sl-tree-node>
-        <sl-tree-node level="2" multiple selectable indeterminate
-          >Level 2 (multiple, indeterminate)</sl-tree-node
-        >
+        <sl-tree-node level="2" multiple selectable indeterminate>
+          Level 2 (multiple, indeterminate)
+        </sl-tree-node>
         <sl-tree-node level="2" multiple selectable selected
           >Level 2 (multiple, selected)</sl-tree-node
         >
         <sl-tree-node level="3" multiple selectable>Level 3 (multiple)</sl-tree-node>
-        <sl-tree-node level="3" multiple selectable indeterminate
-          >Level 3 (multiple, indeterminate)</sl-tree-node
-        >
+        <sl-tree-node level="3" multiple selectable indeterminate>
+          Level 3 (multiple, indeterminate)
+        </sl-tree-node>
         <sl-tree-node level="3" multiple selectable selected
           >Level 3 (multiple, selected)</sl-tree-node
         >
         <sl-tree-node level="4" multiple selectable>Level 4 (multiple)</sl-tree-node>
-        <sl-tree-node level="4" multiple selectable indeterminate
-          >Level 4 (multiple, indeterminate)</sl-tree-node
-        >
+        <sl-tree-node level="4" multiple selectable indeterminate>
+          Level 4 (multiple, indeterminate)
+        </sl-tree-node>
         <sl-tree-node level="4" multiple selectable selected
           >Level 4 (multiple, selected)</sl-tree-node
         >

--- a/packages/components/tree/src/tree-node.stories.ts
+++ b/packages/components/tree/src/tree-node.stories.ts
@@ -53,14 +53,13 @@ export default {
     indeterminate,
     lastNodeInLevel,
     level,
+    levelGuides,
     multiple,
     selectable,
     selected,
     text,
     type
   }) => {
-    console.log({ text });
-
     return html`
       <sl-tree-node
         ?disabled=${disabled}
@@ -68,6 +67,7 @@ export default {
         ?expanded=${expanded}
         ?indeterminate=${indeterminate}
         ?last-node-in-level=${lastNodeInLevel}
+        .levelGuides=${levelGuides}
         level=${level}
         ?multiple=${multiple}
         ?selectable=${selectable}
@@ -121,21 +121,21 @@ export const All: Story = {
         <sl-tree-node expandable level="4">Level 4 (expandable)</sl-tree-node>
         <sl-tree-node expandable expanded level="4">Level 4 (expandable, expanded)</sl-tree-node>
 
-        <sl-tree-node expandable expanded show-guides>Level 0 (guides)</sl-tree-node>
-        <sl-tree-node level="1" show-guides>Level 1 (guides)</sl-tree-node>
-        <sl-tree-node expandable expanded level="1" last-node-in-level show-guides>
+        <sl-tree-node expandable expanded>Level 0 (guides)</sl-tree-node>
+        <sl-tree-node .levelGuides=${[0]} level="1">Level 1 (guides)</sl-tree-node>
+        <sl-tree-node .levelGuides=${[0]} expandable expanded level="1" last-node-in-level>
           Level 1 (last node in level, guides)
         </sl-tree-node>
-        <sl-tree-node level="2" show-guides>Level 2 (guides)</sl-tree-node>
-        <sl-tree-node expandable expanded level="2" last-node-in-level show-guides>
+        <sl-tree-node .levelGuides=${[1]} level="2">Level 2 (guides)</sl-tree-node>
+        <sl-tree-node .levelGuides=${[1]} expandable expanded level="2" last-node-in-level>
           Level 2 (last node in level, guides)
         </sl-tree-node>
-        <sl-tree-node level="3" show-guides>Level 3 (guides)</sl-tree-node>
-        <sl-tree-node expandable expanded level="3" last-node-in-level show-guides>
+        <sl-tree-node .levelGuides=${[2]} level="3">Level 3 (guides)</sl-tree-node>
+        <sl-tree-node .levelGuides=${[2]} expandable expanded level="3" last-node-in-level>
           Level 3 (last node in level, guides)
         </sl-tree-node>
-        <sl-tree-node level="4" show-guides>Level 4 (guides)</sl-tree-node>
-        <sl-tree-node level="4" last-node-in-level show-guides>
+        <sl-tree-node .levelGuides=${[3]} level="4">Level 4 (guides)</sl-tree-node>
+        <sl-tree-node .levelGuides=${[3]} level="4" last-node-in-level>
           Level 4 (last node in level, guides)
         </sl-tree-node>
 

--- a/packages/components/tree/src/tree-node.stories.ts
+++ b/packages/components/tree/src/tree-node.stories.ts
@@ -96,6 +96,12 @@ export const All: Story = {
           flex-direction: column;
           gap: var(--sl-size-100);
         }
+
+        .guides {
+          display: flex;
+          flex-direction: column;
+          gap: var(--sl-size-025);
+        }
       </style>
       <div class="container">
         <sl-tree-node disabled>Disabled</sl-tree-node>
@@ -121,23 +127,25 @@ export const All: Story = {
         <sl-tree-node expandable level="4">Level 4 (expandable)</sl-tree-node>
         <sl-tree-node expandable expanded level="4">Level 4 (expandable, expanded)</sl-tree-node>
 
-        <sl-tree-node expandable expanded>Level 0 (guides)</sl-tree-node>
-        <sl-tree-node .levelGuides=${[0]} level="1">Level 1 (guides)</sl-tree-node>
-        <sl-tree-node .levelGuides=${[0]} expandable expanded level="1" last-node-in-level>
-          Level 1 (last node in level, guides)
-        </sl-tree-node>
-        <sl-tree-node .levelGuides=${[1]} level="2">Level 2 (guides)</sl-tree-node>
-        <sl-tree-node .levelGuides=${[1]} expandable expanded level="2" last-node-in-level>
-          Level 2 (last node in level, guides)
-        </sl-tree-node>
-        <sl-tree-node .levelGuides=${[2]} level="3">Level 3 (guides)</sl-tree-node>
-        <sl-tree-node .levelGuides=${[2]} expandable expanded level="3" last-node-in-level>
-          Level 3 (last node in level, guides)
-        </sl-tree-node>
-        <sl-tree-node .levelGuides=${[3]} level="4">Level 4 (guides)</sl-tree-node>
-        <sl-tree-node .levelGuides=${[3]} level="4" last-node-in-level>
-          Level 4 (last node in level, guides)
-        </sl-tree-node>
+        <div class="guides">
+          <sl-tree-node expandable expanded>Level 0 (guides)</sl-tree-node>
+          <sl-tree-node .levelGuides=${[0]} level="1">Level 1 (guides)</sl-tree-node>
+          <sl-tree-node .levelGuides=${[0]} expandable expanded level="1" last-node-in-level>
+            Level 1 (last node in level, guides)
+          </sl-tree-node>
+          <sl-tree-node .levelGuides=${[1]} level="2">Level 2 (guides)</sl-tree-node>
+          <sl-tree-node .levelGuides=${[1]} expandable expanded level="2" last-node-in-level>
+            Level 2 (last node in level, guides)
+          </sl-tree-node>
+          <sl-tree-node .levelGuides=${[2]} level="3">Level 3 (guides)</sl-tree-node>
+          <sl-tree-node .levelGuides=${[2]} expandable expanded level="3" last-node-in-level>
+            Level 3 (last node in level, guides)
+          </sl-tree-node>
+          <sl-tree-node .levelGuides=${[3]} level="4">Level 4 (guides)</sl-tree-node>
+          <sl-tree-node .levelGuides=${[3]} level="4" last-node-in-level>
+            Level 4 (last node in level, guides)
+          </sl-tree-node>
+        </div>
 
         <sl-tree-node multiple selectable>Level 0 (multiple)</sl-tree-node>
         <sl-tree-node multiple selectable indeterminate


### PR DESCRIPTION
## Summary

Fixes the `Navigation/Tree/Node > All` story so selected and multiple-selection node examples render their expected visual states.

The `sl-tree-node` component only applies selected styling and renders checkboxes when the node is `selectable`. The story was setting `selected` and `multiple` without `selectable`, so the examples looked broken even though the production `sl-tree` path passes `selectable` from the data source.


### BEFORE 
<img width="1407" height="860" alt="Screenshot 2026-07-31 at 12 57 37" src="https://github.com/user-attachments/assets/e88e0493-f2b3-4cf4-87c9-5f8366a52cab" />


### AFTER
<img width="1417" height="937" alt="Screenshot 2026-07-31 at 12 56 55" src="https://github.com/user-attachments/assets/1f99ea60-7006-42c1-aa21-26a015cd56a0" />
