### PR TITLE
fix(grid): prevent rows shrinking on ellipsized text hover

### DIFF
--- a/.changeset/wacky-peaches-fetch.md
+++ b/.changeset/wacky-peaches-fetch.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Fix grid rows shrinking when hovering ellipsized cell content.

--- a/packages/components/grid/src/column.spec.ts
+++ b/packages/components/grid/src/column.spec.ts
@@ -100,6 +100,21 @@ describe('sl-column', () => {
         )
       ).to.deep.equal([true, false, false]);
     });
+
+    it('should keep cell padding when ellipsized text adds a tooltip', async () => {
+      el.querySelector('sl-grid-column')!.ellipsizeText = true;
+      el.requestUpdate();
+      await el.updateComplete;
+
+      const cell = el.renderRoot.querySelector<HTMLTableCellElement>(
+        'tbody tr:first-of-type td:first-of-type'
+      )!;
+
+      cell.append(document.createElement('sl-tooltip'));
+
+      expect(getComputedStyle(cell).paddingBlockStart).not.to.equal('0px');
+      expect(getComputedStyle(cell).paddingBlockEnd).not.to.equal('0px');
+    });
   });
 
   describe('path', () => {

--- a/packages/components/grid/src/column.spec.ts
+++ b/packages/components/grid/src/column.spec.ts
@@ -110,10 +110,14 @@ describe('sl-column', () => {
         'tbody tr:first-of-type td:first-of-type'
       )!;
 
+      const { paddingBlockStart: beforeStart, paddingBlockEnd: beforeEnd } = getComputedStyle(cell);
+
       cell.append(document.createElement('sl-tooltip'));
 
-      expect(getComputedStyle(cell).paddingBlockStart).not.to.equal('0px');
-      expect(getComputedStyle(cell).paddingBlockEnd).not.to.equal('0px');
+      const { paddingBlockStart: afterStart, paddingBlockEnd: afterEnd } = getComputedStyle(cell);
+
+      expect(afterStart).to.equal(beforeStart);
+      expect(afterEnd).to.equal(beforeEnd);
     });
   });
 

--- a/packages/components/grid/src/grid.scss
+++ b/packages/components/grid/src/grid.scss
@@ -431,7 +431,7 @@ td {
       --_body-cell-background-interactive-opacity 0.2s ease-in-out;
   }
 
-  &:has(> :not(sl-ellipsize-text)) {
+  &:has(> :not(sl-ellipsize-text, sl-tooltip)) {
     padding-block: 0;
   }
 }

--- a/packages/components/grid/src/stories/basics.stories.ts
+++ b/packages/components/grid/src/stories/basics.stories.ts
@@ -112,7 +112,7 @@ export const EllipsizeTextWithCustomContent: Story = {
     const files: ResourceFile[] = [
       {
         empty: null,
-        name: 'Leerdolenoverzicht Of Course havo-vwo bovenbouw very very long filename.pdf',
+        name: 'Some name which has extremely long and very very long filename.pdf',
         type: 'pdf'
       },
       {

--- a/packages/components/grid/src/stories/basics.stories.ts
+++ b/packages/components/grid/src/stories/basics.stories.ts
@@ -10,7 +10,7 @@ import { Icon } from '@sl-design-system/icon';
 import { MenuButton as MenuButtonComponent, MenuItem } from '@sl-design-system/menu';
 import { Tooltip } from '@sl-design-system/tooltip';
 import { type Meta, type StoryObj } from '@storybook/web-components-vite';
-import { LitElement, type TemplateResult, html } from 'lit';
+import { LitElement, type TemplateResult, css, html } from 'lit';
 import { state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import '../../register.js';
@@ -18,6 +18,12 @@ import { type GridColumnDataRenderer } from '../column.js';
 import { avatarRenderer } from './story-utils.js';
 
 type Story = StoryObj;
+
+interface ResourceFile {
+  empty: null;
+  name: string;
+  type: 'pdf' | 'xls' | 'zip';
+}
 
 export default {
   title: 'Grid/Basics',
@@ -99,6 +105,136 @@ export const EllipsizeText: Story = {
       <sl-grid-column path="school.country"></sl-grid-column>
     </sl-grid>
   `
+};
+
+export const EllipsizeTextWithCustomContent: Story = {
+  render: () => {
+    const files: ResourceFile[] = [
+      {
+        empty: null,
+        name: 'Leerdolenoverzicht Of Course havo-vwo bovenbouw very very long filename.pdf',
+        type: 'pdf'
+      },
+      {
+        empty: null,
+        name: 'OC_6VG_U1-5_woordenlijsten.zip',
+        type: 'zip'
+      },
+      {
+        empty: null,
+        name: 'Examendioom',
+        type: 'xls'
+      }
+    ];
+
+    const fileTypeStyles = css`
+      & .file-type {
+        align-items: center;
+        block-size: var(--sl-size-300);
+        display: inline-flex;
+        inline-size: var(--sl-size-300);
+        justify-content: center;
+      }
+
+      & .file-type svg {
+        block-size: var(--sl-size-300);
+        fill: none;
+        inline-size: var(--sl-size-300);
+        stroke: currentColor;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 1.8;
+      }
+
+      & .file-type.pdf {
+        color: var(--sl-color-foreground-negative-bold);
+      }
+
+      & .file-type.xls {
+        color: var(--sl-color-foreground-positive-bold);
+      }
+
+      & .file-type.zip {
+        color: var(--sl-color-foreground-accent-orange-bold);
+      }
+    `;
+
+    const downloadStyles = css`
+      & .download {
+        align-items: center;
+        appearance: none;
+        background: transparent;
+        block-size: var(--sl-size-300);
+        border: 0;
+        color: var(--sl-color-foreground-neutral-bold);
+        cursor: pointer;
+        display: inline-flex;
+        inline-size: var(--sl-size-300);
+        justify-content: center;
+        padding: 0;
+      }
+
+      & .download svg {
+        block-size: var(--sl-size-300);
+        fill: none;
+        inline-size: var(--sl-size-300);
+        stroke: currentColor;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 1.8;
+      }
+    `;
+
+    const fileTypeRenderer: GridColumnDataRenderer<ResourceFile> = ({ type }) => {
+      return html`
+        <span aria-label="${type.toUpperCase()} file" class="file-type ${type}" role="img">
+          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+            <path d="M6 2h8l4 4v16H6z"></path>
+            <path d="M14 2v5h4"></path>
+            <path d="M9 13h6"></path>
+            <path d="M9 17h6"></path>
+          </svg>
+        </span>
+      `;
+    };
+
+    const downloadRenderer: GridColumnDataRenderer<ResourceFile> = ({ name }) => {
+      return html`
+        <button aria-label="Download ${name}" class="download" type="button">
+          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+            <path d="M12 3v11"></path>
+            <path d="m7 10 5 5 5-5"></path>
+            <path d="M5 19h14"></path>
+          </svg>
+        </button>
+      `;
+    };
+
+    return html`
+      <p>
+        This example reproduces the layout where an ellipsized text cell is combined with custom
+        rendered icon and action cells. Hover the truncated file name to show its tooltip.
+      </p>
+      <sl-grid .items=${files} style="max-inline-size: 420px" ellipsize-text no-skip-links>
+        <sl-grid-column
+          grow="0"
+          header="Type"
+          hide-header-text
+          width="48"
+          .renderer=${fileTypeRenderer}
+          .renderStyles=${() => fileTypeStyles}></sl-grid-column>
+        <sl-grid-column grow="0" header="Name" path="name" width="260"></sl-grid-column>
+        <sl-grid-column grow="0" header="Info" path="empty" width="80"></sl-grid-column>
+        <sl-grid-column
+          grow="0"
+          header="Download"
+          hide-header-text
+          width="48"
+          .renderer=${downloadRenderer}
+          .renderStyles=${() => downloadStyles}></sl-grid-column>
+      </sl-grid>
+    `;
+  }
 };
 
 export const Header: Story = {


### PR DESCRIPTION
## Summary

Fix grid rows shrinking when hovering ellipsized cell content.

`sl-ellipsize-text` lazily adds an `sl-tooltip` when truncated text is hovered or focused. The grid cell selector treated that tooltip as custom cell content and removed the cell's block padding, which could reduce the entire row height.

## Changes

- Exclude `sl-tooltip` from the grid cell selector that removes block padding for custom content.
- Add a regression test to ensure ellipsized grid cells keep their padding when a tooltip is added


### BEFORE

https://github.com/user-attachments/assets/783462a2-68c8-425d-b67d-1755496cabd2



### AFTER

https://github.com/user-attachments/assets/7c788fef-7855-43d9-aaee-9fd2a9d43ff8

