### PR TITLE
feat(storybook website): Add Piwik PRO tracking for website and Storybook

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -33,4 +33,5 @@
   }
 </style>
 
+<script src="/storybook-static/piwik-pro.js"></script>
 <script src="/storybook-static/sidebar-controls.js"></script>

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -33,5 +33,12 @@
   }
 </style>
 
-<script src="/storybook-static/piwik-pro.js"></script>
+<script>
+  if (location.hostname === 'storybook.sanomalearning.design') {
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = '/storybook-static/piwik-pro.js';
+    document.head.appendChild(script);
+  }
+</script>
 <script src="/storybook-static/sidebar-controls.js"></script>

--- a/.storybook/public/piwik-pro.js
+++ b/.storybook/public/piwik-pro.js
@@ -1,0 +1,29 @@
+(function (window, document, dataLayerName, id) {
+  ((window[dataLayerName] = window[dataLayerName] || []),
+    window[dataLayerName].push({ start: new Date().getTime(), event: 'stg.start' }));
+  var scripts = document.getElementsByTagName('script')[0],
+    tags = document.createElement('script');
+  var qP = [];
+  dataLayerName !== 'dataLayer' && qP.push('data_layer_name=' + dataLayerName);
+  var qPString = qP.length > 0 ? '?' + qP.join('&') : '';
+  ((tags.async = !0),
+    (tags.src = 'https://sanomalearning.containers.piwik.pro/' + id + '.js' + qPString),
+    scripts.parentNode.insertBefore(tags, scripts));
+  !(function (a, n, i) {
+    a[n] = a[n] || {};
+    for (var c = 0; c < i.length; c++)
+      !(function (i) {
+        ((a[n][i] = a[n][i] || {}),
+          (a[n][i].api =
+            a[n][i].api ||
+            function () {
+              var a = [].slice.call(arguments, 0);
+              'string' == typeof a[0] &&
+                window[dataLayerName].push({
+                  event: n + '.' + i + ':' + a[0],
+                  parameters: [].slice.call(arguments, 1)
+                });
+            }));
+      })(i[c]);
+  })(window, 'ppms', ['tm', 'cm']);
+})(window, document, 'dataLayer', '77a8ca24-33ff-495d-887b-5d2fa8c34f6a');

--- a/website/src/_includes/base.njk
+++ b/website/src/_includes/base.njk
@@ -28,6 +28,7 @@
     <meta property="og:site_name" content="Sanoma Learning Design System"/>
   </head>
   <body>
+    <script src="/assets/scripts/piwik-pro.js"></script>
     <header class="ds-top-navigation">
       <button class="ds-top-navigation__hamburger" aria-expanded="false" aria-haspopup="menu" aria-controls="main-menu" aria-label="Show navigation menu"></button>
       <a href="/" class="ds-top-navigation__logo" title="Go to homepage"></a>

--- a/website/src/_includes/base.njk
+++ b/website/src/_includes/base.njk
@@ -28,7 +28,14 @@
     <meta property="og:site_name" content="Sanoma Learning Design System"/>
   </head>
   <body>
-    <script src="/assets/scripts/piwik-pro.js"></script>
+    <script>
+      if (location.hostname === 'sanomalearning.design') {
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = '/assets/scripts/piwik-pro.js';
+        document.head.appendChild(script);
+      }
+    </script>
     <header class="ds-top-navigation">
       <button class="ds-top-navigation__hamburger" aria-expanded="false" aria-haspopup="menu" aria-controls="main-menu" aria-label="Show navigation menu"></button>
       <a href="/" class="ds-top-navigation__logo" title="Go to homepage"></a>

--- a/website/src/assets/scripts/piwik-pro.js
+++ b/website/src/assets/scripts/piwik-pro.js
@@ -1,0 +1,6 @@
+(function(window, document, dataLayerName, id) {
+window[dataLayerName]=window[dataLayerName]||[],window[dataLayerName].push({start:(new Date).getTime(),event:"stg.start"});var scripts=document.getElementsByTagName('script')[0],tags=document.createElement('script');
+var qP=[];dataLayerName!=="dataLayer"&&qP.push("data_layer_name="+dataLayerName);var qPString=qP.length>0?("?"+qP.join("&")):"";
+tags.async=!0,tags.src="https://sanomalearning.containers.piwik.pro/"+id+".js"+qPString,scripts.parentNode.insertBefore(tags,scripts);
+!function(a,n,i){a[n]=a[n]||{};for(var c=0;c<i.length;c++)!function(i){a[n][i]=a[n][i]||{},a[n][i].api=a[n][i].api||function(){var a=[].slice.call(arguments,0);"string"==typeof a[0]&&window[dataLayerName].push({event:n+"."+i+":"+a[0],parameters:[].slice.call(arguments,1)})}}(i[c])}(window,"ppms",["tm","cm"]);
+})(window, document, 'dataLayer', '098ec492-9f3e-4855-9d07-e85d2be79ed1');


### PR DESCRIPTION
## Summary

Adds Piwik PRO tracking for the Design System website and Storybook.

The website tracking script is loaded only on `sanomalearning.design`. The Storybook tracking script is loaded on `storybook.sanomalearning.design`

The setup uses separate Piwik PRO containers for the website and Storybook, and keeps anonymous analytics enabled by disabling cookies in the tracking setup.

## Changes

- Added Piwik PRO helper script for the website
- Added Piwik PRO helper script for Storybook
- Loaded the website script from the Eleventy base layout
- Loaded the Storybook script from `manager-head.html`
- Added Storybook route tracking so story changes are tracked as page views


### AFTER
<img width="3024" height="1736" alt="piwik" src="https://github.com/user-attachments/assets/0a5e9dde-b189-494d-b595-34ad9386c694" />




https://github.com/user-attachments/assets/b9f9f426-1f5b-4a9a-8b49-a1d530072ef0

