### PR TITLE
Fix/linting rules for new tooltip

### DIFF
--- a/.changeset/sharp-gifts-raise.md
+++ b/.changeset/sharp-gifts-raise.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/eslint-plugin-slds': patch
+---
+
+Fix linting for new tooltip implementation

--- a/tools/eslint-plugin-slds/lib/rules/checkbox-has-label.js
+++ b/tools/eslint-plugin-slds/lib/rules/checkbox-has-label.js
@@ -1,4 +1,3 @@
-import { TemplateAnalyzer } from 'eslint-plugin-lit/lib/template-analyzer.js';
 import {
   checkTemplateForLabel,
   hasAttribute,
@@ -49,13 +48,26 @@ export const checkboxHasLabel = {
     }
   },
   create(context) {
+    const tooltipLabelledIdsByAnalyzer = new WeakMap();
+
+    const getTooltipLabelledIds = analyzer => {
+      const cachedIds = tooltipLabelledIdsByAnalyzer.get(analyzer);
+
+      if (cachedIds) {
+        return cachedIds;
+      }
+
+      const tooltipLabelledIds = collectTooltipLabelledIds(analyzer);
+      tooltipLabelledIdsByAnalyzer.set(analyzer, tooltipLabelledIds);
+
+      return tooltipLabelledIds;
+    };
+
     return {
       TaggedTemplateExpression(node) {
         if (isNestedHtmlTemplate(node, context)) {
           return;
         }
-
-        const tooltipLabelledIds = collectTooltipLabelledIds(TemplateAnalyzer.create(node));
 
         checkTemplateForLabel({
           context,
@@ -63,6 +75,7 @@ export const checkboxHasLabel = {
           elementName: 'sl-checkbox',
           hasLabel(element, analyzer, sourceCode) {
             const elementId = (analyzer.getAttributeValue(element, 'id', sourceCode) ?? '').trim();
+            const tooltipLabelledIds = getTooltipLabelledIds(analyzer);
 
             return (
               hasCheckboxLabel(element, analyzer, sourceCode) ||

--- a/tools/eslint-plugin-slds/lib/rules/checkbox-has-label.js
+++ b/tools/eslint-plugin-slds/lib/rules/checkbox-has-label.js
@@ -74,13 +74,14 @@ export const checkboxHasLabel = {
           node,
           elementName: 'sl-checkbox',
           hasLabel(element, analyzer, sourceCode) {
-            const elementId = (analyzer.getAttributeValue(element, 'id', sourceCode) ?? '').trim();
-            const tooltipLabelledIds = getTooltipLabelledIds(analyzer);
+            const rawId = analyzer.getAttributeValue(element, 'id', sourceCode);
+            const elementId = typeof rawId === 'string' ? rawId.trim() : '';
+            const tooltipLabelledIds = elementId !== '' ? getTooltipLabelledIds(analyzer) : null;
 
             return (
               hasCheckboxLabel(element, analyzer, sourceCode) ||
               hasAttribute(element, analyzer, sourceCode, 'aria-label', 'aria-labelledby') ||
-              (elementId !== '' && tooltipLabelledIds.has(elementId))
+              (elementId !== '' && tooltipLabelledIds !== null && tooltipLabelledIds.has(elementId))
             );
           }
         });

--- a/tools/eslint-plugin-slds/lib/rules/checkbox-has-label.js
+++ b/tools/eslint-plugin-slds/lib/rules/checkbox-has-label.js
@@ -1,3 +1,4 @@
+import { TemplateAnalyzer } from 'eslint-plugin-lit/lib/template-analyzer.js';
 import {
   checkTemplateForLabel,
   hasAttribute,
@@ -7,6 +8,27 @@ import {
 
 const hasCheckboxLabel = (element, analyzer, sourceCode) => {
   return element.childNodes.some(child => hasMeaningfulContent(child, analyzer, sourceCode));
+};
+
+const collectTooltipLabelledIds = analyzer => {
+  const tooltipLabelledIds = new Set();
+
+  analyzer.traverse({
+    enterElement(element) {
+      if (element.name !== 'sl-tooltip') {
+        return;
+      }
+
+      const attribs = element.attribs ?? {},
+        forIds = (attribs['for'] ?? '').trim().split(/\s+/).filter(Boolean);
+
+      if ((attribs['type'] ?? 'label').trim() !== 'description') {
+        forIds.forEach(id => tooltipLabelledIds.add(id));
+      }
+    }
+  });
+
+  return tooltipLabelledIds;
 };
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -33,14 +55,19 @@ export const checkboxHasLabel = {
           return;
         }
 
+        const tooltipLabelledIds = collectTooltipLabelledIds(TemplateAnalyzer.create(node));
+
         checkTemplateForLabel({
           context,
           node,
           elementName: 'sl-checkbox',
           hasLabel(element, analyzer, sourceCode) {
+            const elementId = (analyzer.getAttributeValue(element, 'id', sourceCode) ?? '').trim();
+
             return (
               hasCheckboxLabel(element, analyzer, sourceCode) ||
-              hasAttribute(element, analyzer, sourceCode, 'aria-label', 'aria-labelledby')
+              hasAttribute(element, analyzer, sourceCode, 'aria-label', 'aria-labelledby') ||
+              (elementId !== '' && tooltipLabelledIds.has(elementId))
             );
           }
         });

--- a/tools/eslint-plugin-slds/tests/lib/rules/checkbox-has-label.test.js
+++ b/tools/eslint-plugin-slds/tests/lib/rules/checkbox-has-label.test.js
@@ -16,6 +16,12 @@ ruleTester.run('checkbox-has-label', checkboxHasLabel, {
     { code: 'html`<sl-checkbox aria-label="Accept terms"></sl-checkbox>`;' },
     { code: 'html`<sl-checkbox aria-labelledby="checkbox-label"></sl-checkbox>`;' },
     {
+      code: 'html`<sl-checkbox id="checkbox"></sl-checkbox><sl-tooltip for="checkbox">Toggle me</sl-tooltip>`;'
+    },
+    {
+      code: 'html`<sl-checkbox id="checkbox"></sl-checkbox><sl-tooltip for="checkbox another">Toggle me</sl-tooltip>`;'
+    },
+    {
       code: 'html`<sl-form-field label="Accept terms"><sl-checkbox></sl-checkbox></sl-form-field>`;'
     },
     {
@@ -41,6 +47,10 @@ ruleTester.run('checkbox-has-label', checkboxHasLabel, {
     },
     {
       code: 'html`<sl-checkbox><sl-infotip slot="infotip">Info</sl-infotip></sl-checkbox>`;',
+      errors: [{ messageId: 'missingLabel' }]
+    },
+    {
+      code: 'html`<sl-checkbox id="checkbox"></sl-checkbox><sl-tooltip type="description" for="checkbox">Toggle me</sl-tooltip>`;',
       errors: [{ messageId: 'missingLabel' }]
     },
     {

--- a/tools/eslint-plugin-slds/tests/lib/rules/checkbox-has-label.test.js
+++ b/tools/eslint-plugin-slds/tests/lib/rules/checkbox-has-label.test.js
@@ -22,6 +22,9 @@ ruleTester.run('checkbox-has-label', checkboxHasLabel, {
       code: 'html`<sl-checkbox id="checkbox"></sl-checkbox><sl-tooltip for="checkbox another">Toggle me</sl-tooltip>`;'
     },
     {
+      code: 'html`${html`<sl-checkbox id="nested"></sl-checkbox><sl-tooltip for="nested">Toggle me</sl-tooltip>`}`;'
+    },
+    {
       code: 'html`<sl-form-field label="Accept terms"><sl-checkbox></sl-checkbox></sl-form-field>`;'
     },
     {
@@ -51,6 +54,10 @@ ruleTester.run('checkbox-has-label', checkboxHasLabel, {
     },
     {
       code: 'html`<sl-checkbox id="checkbox"></sl-checkbox><sl-tooltip type="description" for="checkbox">Toggle me</sl-tooltip>`;',
+      errors: [{ messageId: 'missingLabel' }]
+    },
+    {
+      code: 'html`<sl-tooltip for="nested">Toggle me</sl-tooltip>${html`<sl-checkbox id="nested"></sl-checkbox>`}`;',
       errors: [{ messageId: 'missingLabel' }]
     },
     {

--- a/tools/eslint-plugin-slds/tests/lib/rules/checkbox-has-label.test.js
+++ b/tools/eslint-plugin-slds/tests/lib/rules/checkbox-has-label.test.js
@@ -41,6 +41,11 @@ ruleTester.run('checkbox-has-label', checkboxHasLabel, {
       errors: [{ messageId: 'missingLabel' }]
     },
     {
+      // bound id must not throw — non-string getAttributeValue result
+      code: 'html`<sl-checkbox id=${foo}></sl-checkbox>`;',
+      errors: [{ messageId: 'missingLabel' }]
+    },
+    {
       code: 'html`<sl-checkbox>   </sl-checkbox>`;',
       errors: [{ messageId: 'missingLabel' }]
     },


### PR DESCRIPTION
This pull request updates the `checkbox-has-label` ESLint rule to support the new tooltip implementation, ensuring that checkboxes labeled via an `sl-tooltip` (with `for` attribute) are recognized as having a label. It also adds and updates tests to cover these scenarios.

**ESLint rule enhancements:**

* Updated `checkbox-has-label.js` to recognize `<sl-tooltip for="...">` as a valid label for `<sl-checkbox>`, unless the tooltip's `type` is `"description"`. [[1]](diffhunk://#diff-d153ddcc479880b3d5a3ad9fff931923987055f6129de1a6a683e536a29f6f2bR13-R33) [[2]](diffhunk://#diff-d153ddcc479880b3d5a3ad9fff931923987055f6129de1a6a683e536a29f6f2bR58-R70)
* Added logic to collect all checkbox IDs labeled by tooltips and check them during linting.

**Testing improvements:**

* Added test cases to confirm that checkboxes labeled by tooltips pass the rule, and that tooltips with `type="description"` do not count as labels. [[1]](diffhunk://#diff-0ff084775cc4fe282d3e3e51ff63a0cb7ffae9692a7c0eafe0837238f39bc040R18-R23) [[2]](diffhunk://#diff-0ff084775cc4fe282d3e3e51ff63a0cb7ffae9692a7c0eafe0837238f39bc040R52-R55)

**Documentation/metadata:**

* Updated the changeset to document the patch and the improved linting for the new tooltip implementation.