### PR TITLE
fix(combobox tag): keep overflowing selected tag removable

### DIFF
--- a/.changeset/open-dogs-check.md
+++ b/.changeset/open-dogs-check.md
@@ -1,0 +1,6 @@
+---
+'@sl-design-system/combobox': patch
+'@sl-design-system/tag': patch
+---
+
+Fixed stacked tag lists and multi-select comboboxes so at least one selected tag remains visible and removable when selected values overflow. Long visible tags are now constrained and truncated instead of being hidden entirely behind the stack counter, and comboboxes no longer create a large gap between the visible tags and the input caret when stacking is active.

--- a/packages/components/combobox/src/combobox.scss
+++ b/packages/components/combobox/src/combobox.scss
@@ -53,10 +53,6 @@ sl-tag-list {
   z-index: 1;
 }
 
-sl-tag-list[data-stacked-active] {
-  flex-grow: 1;
-}
-
 sl-tag {
   outline-offset: 0;
   outline-width: 0;

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -1298,6 +1298,13 @@ describe('sl-combobox', () => {
           `+${selectedTags.length - visibleSelectedTags.length}`
         );
         expect(visibleSelectedTags.length).to.be.greaterThan(0);
+
+        const inputRect = input.getBoundingClientRect(),
+          lastVisibleTagRect = visibleSelectedTags.at(-1)!.getBoundingClientRect(),
+          gap = inputRect.left - lastVisibleTagRect.right;
+
+        expect(gap).to.be.at.least(0);
+        expect(gap).to.be.lessThan(16);
       });
 
       it('should not flicker when selecting many items in a limited space', async () => {

--- a/packages/components/tag/src/tag-list.spec.ts
+++ b/packages/components/tag/src/tag-list.spec.ts
@@ -669,6 +669,61 @@ describe('sl-tag-list', () => {
       expect(el.stackSize).to.equal(2);
     });
 
+    it('should constrain the last visible tag when it does not fit next to the stack', async () => {
+      el = await fixture(html`
+        <sl-tag-list stacked style="gap: 10px; padding: 0; margin: 0; border: none;">
+          <sl-tag removable>Tag 1</sl-tag>
+          <sl-tag removable>Tag 2</sl-tag>
+          <sl-tag removable>Very long selected tag that should overflow</sl-tag>
+        </sl-tag-list>
+      `);
+
+      // Container is 140px, stack 40px, gap 10px => remaining width is 90px.
+      // The last tag is 180px, but it should remain visible and truncate inside that space.
+      el.getBoundingClientRect = () => new DOMRect(0, 0, 140, 20);
+      el.stack!.getBoundingClientRect = () => new DOMRect(0, 0, 40, 20);
+
+      Array.from(el.querySelectorAll('sl-tag')).forEach((tag, index) => {
+        tag.getBoundingClientRect = () => new DOMRect(0, 0, index === 2 ? 180 : 100, 20);
+      });
+
+      await triggerVisibilityUpdate();
+
+      const tags = Array.from(el.querySelectorAll('sl-tag'));
+
+      expect(tags.map(t => t.style.display)).to.deep.equal(['none', 'none', '']);
+      expect(tags[2].style.maxInlineSize).to.equal('90px');
+      expect(el.stackSize).to.equal(2);
+    });
+
+    it('should restore a constrained tag max-inline-size before measuring again', async () => {
+      el = await fixture(html`
+        <sl-tag-list stacked style="gap: 10px; padding: 0; margin: 0; border: none;">
+          <sl-tag removable>Tag 1</sl-tag>
+          <sl-tag removable>Very long selected tag that should overflow</sl-tag>
+        </sl-tag-list>
+      `);
+
+      el.getBoundingClientRect = () => new DOMRect(0, 0, 140, 20);
+      el.stack!.getBoundingClientRect = () => new DOMRect(0, 0, 40, 20);
+
+      Array.from(el.querySelectorAll('sl-tag')).forEach((tag, index) => {
+        tag.getBoundingClientRect = () => new DOMRect(0, 0, index === 1 ? 180 : 100, 20);
+      });
+
+      await triggerVisibilityUpdate();
+
+      const longTag = el.querySelectorAll('sl-tag')[1] as HTMLElement;
+
+      expect(longTag.style.maxInlineSize).to.equal('90px');
+
+      el.getBoundingClientRect = () => new DOMRect(0, 0, 300, 20);
+      await triggerVisibilityUpdate();
+
+      expect(longTag.style.maxInlineSize).to.equal('');
+      expect(el.stackSize).to.equal(0);
+    });
+
     it('should not overwrite cached stack width when the stack measurement is 0', async () => {
       el = await fixture(html`
         <sl-tag-list stacked style="gap: 10px; padding: 0; margin: 0; border: none;">

--- a/packages/components/tag/src/tag-list.ts
+++ b/packages/components/tag/src/tag-list.ts
@@ -78,11 +78,17 @@ export class TagList extends ScopedElementsMixin(LitElement) {
   /** Original disabled state of tags temporarily disabled through the tag list. */
   #tagDisabledState = new WeakMap<Tag, boolean | undefined>();
 
+  /** Original max-inline-size of tags temporarily constrained through stacked overflow. */
+  #tagMaxInlineSizeState = new WeakMap<Tag, string>();
+
   /** Number of completed passes before the initial visibility is considered stable. */
   #initialVisibilityPasses = 0;
 
   /** Currently observed stack element, if stacked mode is active. */
   #observedStack?: HTMLElement;
+
+  /** Currently observed parent element, if connected. */
+  #observedParent?: HTMLElement;
 
   /**
    * Stacked lists stay hidden until the first visibility calculation settles. These helpers keep
@@ -130,6 +136,25 @@ export class TagList extends ScopedElementsMixin(LitElement) {
     }
 
     this.#observedStack = nextObservedStack;
+  }
+
+  /** Recalculate tag visibility when the available space from the parent changes. */
+  #syncParentObservation(): void {
+    const nextObservedParent = this.parentElement ?? undefined;
+
+    if (this.#observedParent === nextObservedParent) {
+      return;
+    }
+
+    if (this.#observedParent) {
+      this.#resizeObserver.unobserve(this.#observedParent);
+    }
+
+    if (nextObservedParent) {
+      this.#resizeObserver.observe(nextObservedParent);
+    }
+
+    this.#observedParent = nextObservedParent;
   }
 
   /**
@@ -216,6 +241,7 @@ export class TagList extends ScopedElementsMixin(LitElement) {
     this.setAttribute('role', 'list');
     this.#resetInitialVisibilityState();
     this.#syncStackObservation();
+    this.#syncParentObservation();
 
     this.#resizeObserver.observe(this);
   }
@@ -223,6 +249,7 @@ export class TagList extends ScopedElementsMixin(LitElement) {
   override disconnectedCallback(): void {
     this.#resizeObserver.disconnect();
     this.#observedStack = undefined;
+    this.#observedParent = undefined;
 
     if (this.#breakResizeObserverLoop) {
       clearTimeout(this.#breakResizeObserverLoop);
@@ -264,7 +291,10 @@ export class TagList extends ScopedElementsMixin(LitElement) {
         this.#resetInitialVisibilityState();
         this.stackSize = 0;
         this.removeAttribute('data-stacked-active');
-        this.tags.forEach(tag => (tag.style.display = ''));
+        this.tags.forEach(tag => {
+          tag.style.display = '';
+          this.#restoreTagMaxInlineSize(tag);
+        });
       }
     }
 
@@ -384,6 +414,7 @@ export class TagList extends ScopedElementsMixin(LitElement) {
   #onSlotChange(event: Event & { target: HTMLSlotElement }): void {
     this.tags.forEach(tag => {
       tag.navigationDescription = undefined;
+      this.#restoreTagMaxInlineSize(tag);
       this.#restoreTagDisabledState(tag);
       tag.removeAttribute('role');
     });
@@ -448,6 +479,23 @@ export class TagList extends ScopedElementsMixin(LitElement) {
     this.#tagDisabledState.delete(tag);
   }
 
+  #setTagMaxInlineSize(tag: Tag, maxInlineSize: number): void {
+    if (!this.#tagMaxInlineSizeState.has(tag)) {
+      this.#tagMaxInlineSizeState.set(tag, tag.style.maxInlineSize);
+    }
+
+    tag.style.maxInlineSize = `${Math.max(0, maxInlineSize)}px`;
+  }
+
+  #restoreTagMaxInlineSize(tag: Tag): void {
+    if (!this.#tagMaxInlineSizeState.has(tag)) {
+      return;
+    }
+
+    tag.style.maxInlineSize = this.#tagMaxInlineSizeState.get(tag) ?? '';
+    this.#tagMaxInlineSizeState.delete(tag);
+  }
+
   #runVisibilityUpdate(): void {
     if (this.stack) {
       const measuredStackInlineSize = this.stack.getBoundingClientRect().width;
@@ -500,12 +548,15 @@ export class TagList extends ScopedElementsMixin(LitElement) {
 
     try {
       // Reset visibility of all tags
-      this.tags.forEach(tag => (tag.style.display = ''));
+      this.tags.forEach(tag => {
+        tag.style.display = '';
+        this.#restoreTagMaxInlineSize(tag);
+      });
 
-      // Measure available width after restoring tag visibility.
-      // This prevents the layout from getting stuck in a collapsed width that
-      // was based on a previous stacked state.
-      availableWidth = this.getBoundingClientRect().width;
+      // Measure available width after restoring tag visibility. If CSS caps the list with a
+      // max-inline-size (for example in comboboxes), use that cap so a previously collapsed list can
+      // reveal more tags after its container grows again without visually stretching the list.
+      availableWidth = Math.max(this.getBoundingClientRect().width, this.#getMaxInlineSize(styles));
       this.style.inlineSize = `${availableWidth}px`;
 
       sizes = this.tags.map(t => t.getBoundingClientRect().width);
@@ -542,6 +593,8 @@ export class TagList extends ScopedElementsMixin(LitElement) {
       }
     }
 
+    this.#constrainLastVisibleTag(availableWidth, sizes, gap);
+
     // Excluded tags are not taken into account for rovingTabindex, so there is a tabindex 0 left,
     // when we exclude them, we need to set tabindex -1 explicitly.
     this.tags.forEach(tag => {
@@ -568,6 +621,32 @@ export class TagList extends ScopedElementsMixin(LitElement) {
 
     // Now that we updated the visibility of the tags, we need to clear the element cache
     this.#clearRovingTabindexCache();
+  }
+
+  #getMaxInlineSize(styles: CSSStyleDeclaration): number {
+    const maxInlineSize = Number.parseFloat(styles.maxInlineSize);
+
+    return Number.isFinite(maxInlineSize) ? maxInlineSize : 0;
+  }
+
+  #constrainLastVisibleTag(availableWidth: number, sizes: number[], gap: number): void {
+    const visibleTagIndexes = this.tags
+      .map((tag, index) => (tag.style.display === 'none' ? undefined : index))
+      .filter((index): index is number => index !== undefined);
+
+    if (!visibleTagIndexes.length) {
+      return;
+    }
+
+    const lastVisibleTagIndex = visibleTagIndexes.at(-1)!,
+      usedWidth = visibleTagIndexes
+        .slice(0, -1)
+        .reduce((total, index) => total + sizes[index] + gap, 0),
+      maxInlineSize = availableWidth - usedWidth;
+
+    if (sizes[lastVisibleTagIndex] > maxInlineSize + SUBPIXEL_BUFFER_PX) {
+      this.#setTagMaxInlineSize(this.tags[lastVisibleTagIndex], maxInlineSize);
+    }
   }
 
   #clearRovingTabindexCache(): void {


### PR DESCRIPTION
## Summary

- Keep the stacked combobox/tag-list layout from creating a large gap before the input caret.
- Keep at least one real selected tag visible next to the stack counter.
- Constrain an overflowing visible tag with `max-inline-size` so its label truncates while the remove button remains available.
- Recalculate stacked tag visibility when the parent grows again.

**BEFORE:**

https://github.com/user-attachments/assets/ab4bc76e-49d0-4be5-8462-16cb18066e5f


### AFTER

https://github.com/user-attachments/assets/dac6e66e-2b46-4e5d-87c2-867afc0be8fa


