### PR TITLE
Fix/3466 date field contrast

### DIFF
--- a/.changeset/wicked-roses-fail.md
+++ b/.changeset/wicked-roses-fail.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/date-field': patch
+---
+
+Fixes incorrect text color in year select dialog

--- a/packages/components/date-field/src/date-field.scss
+++ b/packages/components/date-field/src/date-field.scss
@@ -124,6 +124,7 @@ dialog {
   border-radius: var(--sl-size-borderRadius-default);
   box-shadow: var(--sl-elevation-shadow-overlay);
   box-sizing: border-box;
+  color: var(--sl-color-foreground-plain);
   display: none;
   margin: var(--sl-size-100) 0 var(--sl-size-100) calc(-1 * var(--sl-size-borderWidth-default));
   opacity: 0;


### PR DESCRIPTION
This pull request addresses a UI bug in the `@sl-design-system/date-field` package by ensuring the correct text color is applied in the year select dialog. The main change sets the text color to use `var(--sl-color-foreground-plain)` in the dialog, fixing the previously incorrect color.

UI Bug Fixes:

* Set the text color of the year select dialog to `var(--sl-color-foreground-plain)` in `date-field.scss`, ensuring consistent and correct text appearance.
* Documented the patch and fix in `.changeset/wicked-roses-fail.md`.