### PR TITLE
fix(combobox): apply invalid styling to inner text field

### DIFF
--- a/.changeset/proud-dogs-show.md
+++ b/.changeset/proud-dogs-show.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/combobox': patch
+---
+
+Fix invalid combobox styling by applying `show-validity` to the internal text field.

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -2094,6 +2094,17 @@ describe('sl-combobox', () => {
         expect(el.valid).to.be.false;
       });
 
+      it('should pass invalid show-validity to the text field when reported', async () => {
+        el.reportValidity();
+        await el.updateComplete;
+
+        expect(el).to.have.attribute('show-validity', 'invalid');
+        expect(el.renderRoot.querySelector('sl-text-field')).to.have.attribute(
+          'show-validity',
+          'invalid'
+        );
+      });
+
       it('should be invalid when it has a placeholder', async () => {
         el.placeholder = 'Placeholder';
         await el.updateComplete;

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -524,6 +524,7 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
         placeholder=${ifDefined(
           this.multiple && this.selectedItems.length ? undefined : this.placeholder
         )}
+        show-validity=${ifDefined(this.showValidity)}
         size=${ifDefined(this.size)}>
         ${this.multiple && this.selectedItems.length
           ? html`


### PR DESCRIPTION
## Summary

Fix invalid styling for `sl-combobox` by forwarding the combobox `show-validity` state to its internal `sl-text-field`.

This makes invalid comboboxes use the same red border and invalid hover background as other form controls.


### BEFORE
<img width="992" height="382" alt="Screenshot 2026-08-12 at 15 09 19" src="https://github.com/user-attachments/assets/8fc078f1-a651-49dd-947a-d0783050383d" />


### AFTER
<img width="987" height="388" alt="Screenshot 2026-08-12 at 15 06 46" src="https://github.com/user-attachments/assets/0c1f6561-401b-49b5-bc42-fbe707ed33f4" />
