### PR TITLE
fix(toggle-group): use group aria role by default

### DIFF
--- a/.changeset/bumpy-teeth-begin.md
+++ b/.changeset/bumpy-teeth-begin.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/toggle-group': patch
+---
+
+Use `role="group"` as the default semantic role for toggle groups instead of `role="region"`, and preserve explicitly provided roles.

--- a/packages/components/toggle-group/src/toggle-group.spec.ts
+++ b/packages/components/toggle-group/src/toggle-group.spec.ts
@@ -52,13 +52,25 @@ describe('sl-toggle-group', () => {
     });
 
     it('should have group semantics', () => {
-      expect(el).to.have.attribute('role', 'group');
+      expect(el).not.to.have.attribute('role');
+      expect(el.internals.role).to.equal('group');
     });
 
     it('should not override an explicit role', async () => {
       el = await fixture(html`<sl-toggle-group role="toolbar"></sl-toggle-group>`);
 
       expect(el).to.have.attribute('role', 'toolbar');
+      expect(el.internals.role).to.equal('group');
+    });
+
+    it('should restore the default semantics when an explicit role is removed', async () => {
+      el = await fixture(html`<sl-toggle-group role="toolbar"></sl-toggle-group>`);
+
+      el.removeAttribute('role');
+      await el.updateComplete;
+
+      expect(el).not.to.have.attribute('role');
+      expect(el.internals.role).to.equal('group');
     });
 
     it('should propagate disabled to the buttons', async () => {

--- a/packages/components/toggle-group/src/toggle-group.spec.ts
+++ b/packages/components/toggle-group/src/toggle-group.spec.ts
@@ -51,6 +51,16 @@ describe('sl-toggle-group', () => {
       expect(el.size).to.be.undefined;
     });
 
+    it('should have group semantics', () => {
+      expect(el).to.have.attribute('role', 'group');
+    });
+
+    it('should not override an explicit role', async () => {
+      el = await fixture(html`<sl-toggle-group role="toolbar"></sl-toggle-group>`);
+
+      expect(el).to.have.attribute('role', 'toolbar');
+    });
+
     it('should propagate disabled to the buttons', async () => {
       const buttons = Array.from(el.querySelectorAll('sl-toggle-button'));
 

--- a/packages/components/toggle-group/src/toggle-group.ts
+++ b/packages/components/toggle-group/src/toggle-group.ts
@@ -93,8 +93,9 @@ export class ToggleGroup extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
 
-    // https://twitter.com/LeonieWatson/status/1545788775644667904
-    this.setAttribute('role', 'region');
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'group');
+    }
   }
 
   override updated(changes: PropertyValues<this>): void {

--- a/packages/components/toggle-group/src/toggle-group.ts
+++ b/packages/components/toggle-group/src/toggle-group.ts
@@ -50,6 +50,9 @@ export class ToggleGroup extends LitElement {
     isFocusableElement: (el: ToggleButton) => !el.disabled
   });
 
+  /** @internal */
+  readonly internals = this.attachInternals();
+
   /**
    * If set, will disable all buttons in the group.
    *
@@ -93,9 +96,7 @@ export class ToggleGroup extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
 
-    if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'group');
-    }
+    this.internals.role = 'group';
   }
 
   override updated(changes: PropertyValues<this>): void {


### PR DESCRIPTION
## Summary

- Change the default semantic role of `sl-toggle-group` from `region` to `group`
- Preserve explicitly provided roles, such as `role="toolbar"`
- Add regression tests for the default role and explicit role handling

## Why

`role="region"` exposes the toggle group as a landmark, which is intended for important page sections. A toggle group is a set of related controls, so `role="group"` better communicates its purpose to assistive technologies

### BEFORE
<img width="1203" height="803" alt="Screenshot 2026-08-13 at 14 43 00" src="https://github.com/user-attachments/assets/8481344b-3348-4641-9725-0cbc17bddce2" />

### AFTER
<img width="1203" height="800" alt="Screenshot 2026-08-13 at 14 43 44" src="https://github.com/user-attachments/assets/24326dcd-3391-47cb-8dd9-5f987df61372" />
