### PR TITLE
fix(combobox): keep options open when focus moves inside

### DIFF
--- a/.changeset/ten-dingos-type.md
+++ b/.changeset/ten-dingos-type.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/combobox': patch
+---
+
+Keep the options list open when screen reader focus moves from the combobox input to an option.

--- a/packages/components/combobox/src/combobox.spec.ts
+++ b/packages/components/combobox/src/combobox.spec.ts
@@ -392,6 +392,17 @@ describe('sl-combobox', () => {
       expect(onBlur).to.have.been.calledOnce;
     });
 
+    it('should keep the popover open when focus moves to an option', () => {
+      const option = el.querySelector('sl-option')!;
+
+      input.click();
+      input.dispatchEvent(
+        new FocusEvent('focusout', { bubbles: true, composed: true, relatedTarget: option })
+      );
+
+      expect(el.wrapper).to.match(':popover-open');
+    });
+
     it('should emit an sl-change event when selecting an option', async () => {
       const onChange = spy();
 

--- a/packages/components/combobox/src/combobox.ts
+++ b/packages/components/combobox/src/combobox.ts
@@ -670,8 +670,10 @@ export class Combobox<T = any, U = T> extends ObserveAttributesMixin(
   }
 
   #onFocusout(event: FocusEvent): void {
-    const leavingComponent =
-      !event.relatedTarget || (event.relatedTarget !== this && event.relatedTarget !== this.input);
+    const relatedTarget = event.relatedTarget,
+      leavingComponent =
+        !(relatedTarget instanceof Node) ||
+        (!this.contains(relatedTarget) && !this.renderRoot.contains(relatedTarget));
 
     if (leavingComponent) {
       this.wrapper?.hidePopover();


### PR DESCRIPTION
## Summary

Fix the combobox options list collapsing when screen reader focus moves from the input to an option.

Previously, the `focusout` handler treated every target other than the combobox host or input as being outside the component. As a result, moving focus to an option immediately closed the popover.

The handler now checks whether the new focus target is contained within either the combobox light DOM or shadow DOM