### PR TITLE
fix no-icon when type is not internal

### DIFF
--- a/.changeset/sad-cooks-stop.md
+++ b/.changeset/sad-cooks-stop.md
@@ -2,4 +2,4 @@
 '@sl-design-system/link': patch
 ---
 
-Fixed and issue where no-icon also removed padding for types other than internal but still showed the icon, causing it to overlap the text.
+Fixed an issue where no-icon also removed padding for types other than internal but still showed the icon, causing it to overlap the text.

--- a/.changeset/sad-cooks-stop.md
+++ b/.changeset/sad-cooks-stop.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/link': patch
+---
+
+Fixed and issue where no-icon also removed padding for types other than internal but still showed the icon, causing it to overlap the text.

--- a/packages/components/link/src/link.css
+++ b/packages/components/link/src/link.css
@@ -69,7 +69,7 @@ sl-icon {
   }
 }
 
-:host(:where([no-icon])) ::slotted(a[href]) {
+:host(:where([no-icon][type='internal'], [no-icon]:not([type]))) ::slotted(a[href]) {
   padding-inline: var(--_inline-padding) var(--_inline-padding);
 }
 

--- a/packages/components/link/src/link.css
+++ b/packages/components/link/src/link.css
@@ -69,7 +69,7 @@ sl-icon {
   }
 }
 
-:host(:where([no-icon][type='internal'], [no-icon]:not([type]))) ::slotted(a[href]) {
+:host(:state(hide-icon)) ::slotted(a[href]) {
   padding-inline: var(--_inline-padding) var(--_inline-padding);
 }
 

--- a/packages/components/link/src/link.spec.ts
+++ b/packages/components/link/src/link.spec.ts
@@ -765,4 +765,101 @@ describe('sl-link', () => {
       expect(icon).to.exist;
     });
   });
+
+  describe('hideIcon state', () => {
+    it('should not have hideIcon state by default', async () => {
+      el = await fixture(html`<sl-link><a href="/dashboard">Dashboard</a></sl-link>`);
+
+      expect(el.hideIcon).to.be.false;
+      expect(el).not.to.match(':state(hide-icon)');
+    });
+
+    it('should have hideIcon state when noIcon is true for internal links', async () => {
+      el = await fixture(html`<sl-link no-icon><a href="/dashboard">Dashboard</a></sl-link>`);
+
+      expect(el.hideIcon).to.be.true;
+      expect(el).to.match(':state(hide-icon)');
+    });
+
+    it('should not have hideIcon state when noIcon is true for external links', async () => {
+      el = await fixture(html`
+        <sl-link no-icon><a href="https://example.com">External</a></sl-link>
+      `);
+
+      expect(el.hideIcon).to.be.false;
+      expect(el).not.to.match(':state(hide-icon)');
+    });
+
+    it('should not have hideIcon state when noIcon is true for internal-new-tab links', async () => {
+      el = await fixture(html`
+        <sl-link no-icon><a href="/page" target="_blank">New tab</a></sl-link>
+      `);
+
+      expect(el.hideIcon).to.be.false;
+      expect(el).not.to.match(':state(hide-icon)');
+    });
+
+    it('should not have hideIcon state when noIcon is true for email links', async () => {
+      el = await fixture(html`
+        <sl-link no-icon><a href="mailto:test@example.com">Email</a></sl-link>
+      `);
+
+      expect(el.hideIcon).to.be.false;
+      expect(el).not.to.match(':state(hide-icon)');
+    });
+
+    it('should not have hideIcon state when noIcon is true for tel links', async () => {
+      el = await fixture(html` <sl-link no-icon><a href="tel:+1234567890">Phone</a></sl-link> `);
+
+      expect(el.hideIcon).to.be.false;
+      expect(el).not.to.match(':state(hide-icon)');
+    });
+
+    it('should update state when noIcon changes', async () => {
+      el = await fixture(html`<sl-link><a href="/dashboard">Dashboard</a></sl-link>`);
+
+      expect(el).not.to.match(':state(hide-icon)');
+
+      el.noIcon = true;
+      await el.updateComplete;
+
+      expect(el).to.match(':state(hide-icon)');
+
+      el.noIcon = false;
+      await el.updateComplete;
+
+      expect(el).not.to.match(':state(hide-icon)');
+    });
+
+    it('should update state when type changes from internal to external', async () => {
+      el = await fixture(html`<sl-link no-icon><a href="/page">Internal</a></sl-link>`);
+
+      expect(el).to.match(':state(hide-icon)');
+
+      el.type = 'external';
+      await el.updateComplete;
+
+      expect(el).not.to.match(':state(hide-icon)');
+    });
+
+    it('should update state when type changes from external to internal', async () => {
+      el = await fixture(html`
+        <sl-link no-icon type="external"><a href="/page">Override</a></sl-link>
+      `);
+
+      expect(el).not.to.match(':state(hide-icon)');
+
+      el.type = 'internal';
+      await el.updateComplete;
+
+      expect(el).to.match(':state(hide-icon)');
+    });
+
+    it('should not have hideIcon state when noIcon is false even for internal links', async () => {
+      el = await fixture(html`<sl-link><a href="/dashboard">Dashboard</a></sl-link>`);
+
+      expect(el.hideIcon).to.be.false;
+      expect(el).not.to.match(':state(hide-icon)');
+    });
+  });
 });

--- a/packages/components/link/src/link.ts
+++ b/packages/components/link/src/link.ts
@@ -50,6 +50,7 @@ export type LinkVariant =
  * @slot default - Place a single <code>&lt;a&gt;</code> element inside the component.
  * @csspart icon - The new-tab indicator icon.
  * @cssstate reversed - The link has an internal indicator icon on the left side.
+ * @cssstate hide-icon - The link has no icon and is an internal link.
  */
 @localized()
 export class Link extends ScopedElementsMixin(ElementInternalsMixin(LitElement)) {
@@ -124,6 +125,12 @@ export class Link extends ScopedElementsMixin(ElementInternalsMixin(LitElement))
   @cssState()
   get reversed(): boolean {
     return !this.noIcon && this.#indicatorIcon === 'arrow-left';
+  }
+
+  /** @internal Helper state whether to show the padding or not (to make place for the icon). */
+  @cssState()
+  get hideIcon(): boolean {
+    return !!(this.noIcon && this.linkType === 'internal');
   }
 
   get #indicatorIcon(): string {


### PR DESCRIPTION
This pull request addresses a bug with the `@sl-design-system/link` component where using the `no-icon` attribute incorrectly removed padding for all link types except "internal", and still displayed the icon, causing it to overlap the text. The fix ensures that padding is only affected for internal links with `no-icon`, preventing layout issues for other link types.

Bug fix for icon and padding behavior:

* Updated the CSS selector in `link.css` so that the padding adjustment for `no-icon` only applies to internal links, preventing icon overlap and incorrect padding for other link types.
* Documented the bug fix in the changeset file `.changeset/sad-cooks-stop.md`.