### PR TITLE
fix(ellipsize-text): show tooltip for overflowing grid cells

### DIFF
--- a/.changeset/tiny-cells-smile.md
+++ b/.changeset/tiny-cells-smile.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/ellipsize-text': patch
+---
+
+Allow ellipsized text to shrink inside flex containers so its tooltip is shown when the text overflows.

--- a/packages/components/ellipsize-text/src/ellipsize-text.css
+++ b/packages/components/ellipsize-text/src/ellipsize-text.css
@@ -1,5 +1,6 @@
 :host {
   display: block;
+  min-inline-size: 0;
 }
 
 slot {

--- a/packages/components/ellipsize-text/src/ellipsize-text.spec.ts
+++ b/packages/components/ellipsize-text/src/ellipsize-text.spec.ts
@@ -42,4 +42,24 @@ describe('sl-ellipsize-text', () => {
     expect(tooltip).to.have.trimmed.text('This is a long text that should be truncated');
     expect(slot?.ariaDescribedByElements).to.include(tooltip);
   });
+
+  it('should have a tooltip when it shrinks as a flex item', async () => {
+    const container = await fixture(html`
+        <div style="display: flex; inline-size: 100px">
+          <sl-ellipsize-text> This is a long text that should be truncated </sl-ellipsize-text>
+        </div>
+      `),
+      ellipsizeText = container.querySelector<EllipsizeText>('sl-ellipsize-text')!;
+
+    // Wait for the resize observer to trigger
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const slot = ellipsizeText.renderRoot.querySelector('slot'),
+      tooltip = ellipsizeText.renderRoot.querySelector('sl-tooltip');
+
+    expect(ellipsizeText.offsetWidth).to.equal(100);
+    expect(slot!.offsetWidth).to.be.lessThan(slot!.scrollWidth);
+    expect(tooltip).to.exist;
+    expect(tooltip).to.have.trimmed.text('This is a long text that should be truncated');
+  });
 });

--- a/packages/components/ellipsize-text/src/ellipsize-text.spec.ts
+++ b/packages/components/ellipsize-text/src/ellipsize-text.spec.ts
@@ -51,7 +51,6 @@ describe('sl-ellipsize-text', () => {
       `),
       ellipsizeText = container.querySelector<EllipsizeText>('sl-ellipsize-text')!;
 
-    // Wait for the resize observer to trigger
     await new Promise(resolve => setTimeout(resolve, 50));
 
     const slot = ellipsizeText.renderRoot.querySelector('slot'),

--- a/packages/components/grid/src/stories/basics.stories.ts
+++ b/packages/components/grid/src/stories/basics.stories.ts
@@ -97,12 +97,12 @@ export const EllipsizeText: Story = {
       ellipsize-text
       column-divider
       no-skip-links>
-      <sl-grid-column path="firstName"></sl-grid-column>
-      <sl-grid-column path="lastName"></sl-grid-column>
-      <sl-grid-column path="school.name"></sl-grid-column>
-      <sl-grid-column path="school.address"></sl-grid-column>
-      <sl-grid-column path="school.city"></sl-grid-column>
-      <sl-grid-column path="school.country"></sl-grid-column>
+      <sl-grid-column path="firstName" width="80"></sl-grid-column>
+      <sl-grid-column path="lastName" width="80"></sl-grid-column>
+      <sl-grid-column path="school.name" width="100"></sl-grid-column>
+      <sl-grid-column path="school.address" width="100"></sl-grid-column>
+      <sl-grid-column path="school.city" width="65"></sl-grid-column>
+      <sl-grid-column path="school.country" width="75"></sl-grid-column>
     </sl-grid>
   `
 };


### PR DESCRIPTION
## Summary

Fix tooltips not appearing for ellipsized text inside grid cells.

`sl-ellipsize-text` retained its intrinsic width when used as a flex item, so the grid cell clipped the content before the component could detect an overflow. Adding `min-inline-size: 0` allows the component to shrink to the available cell width and correctly compare its visible and scroll widths.

### BEFORE
https://github.com/user-attachments/assets/96cd0ee6-8067-4725-9eab-784204b7ce95

### AFTER

https://github.com/user-attachments/assets/e0715aa3-4b81-435d-b5d9-b26c7379b42e

