### PR TITLE
fix(progress-bar): forward ARIA attributes to progressbar element

### DIFF
--- a/.changeset/calm-bars-progress.md
+++ b/.changeset/calm-bars-progress.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/progress-bar': patch
+---
+
+Forward ARIA attributes from the `sl-progress-bar` host to the internal element with the `progressbar` role.

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -42,7 +42,8 @@
     "test": "echo \"Error: run tests from monorepo root.\" && exit 1"
   },
   "dependencies": {
-    "@sl-design-system/icon": "^1.4.1"
+    "@sl-design-system/icon": "^1.4.1",
+    "@sl-design-system/shared": "^0.12.3"
   },
   "devDependencies": {
     "@lit/localize": "^0.12.2",

--- a/packages/components/progress-bar/src/progress-bar.spec.ts
+++ b/packages/components/progress-bar/src/progress-bar.spec.ts
@@ -49,6 +49,34 @@ describe('sl-progress-bar', () => {
     expect(progressBar).to.have.attribute('role', 'progressbar');
   });
 
+  it('should forward an aria-label to the element with the progressbar role', async () => {
+    const labelled = await fixture<ProgressBar>(
+      html`<sl-progress-bar aria-label="File upload"></sl-progress-bar>`
+    );
+    const labelledProgressBar = labelled.renderRoot.querySelector('[role="progressbar"]');
+
+    expect(labelled).not.to.have.attribute('aria-label');
+    expect(labelledProgressBar).to.have.attribute('aria-label', 'File upload');
+  });
+
+  it('should update and remove a forwarded aria-label', async () => {
+    el.setAttribute('aria-label', 'File upload');
+    await new Promise(resolve => setTimeout(resolve));
+
+    expect(el).not.to.have.attribute('aria-label');
+    expect(progressBar).to.have.attribute('aria-label', 'File upload');
+
+    el.setAttribute('aria-label', 'Preparing download');
+    await new Promise(resolve => setTimeout(resolve));
+
+    expect(el).not.to.have.attribute('aria-label');
+    expect(progressBar).to.have.attribute('aria-label', 'Preparing download');
+
+    el.removeAttribute('aria-label');
+
+    expect(progressBar).not.to.have.attribute('aria-label');
+  });
+
   it('should have the correct attributes', () => {
     expect(progressBar).to.have.attribute('aria-describedby', 'helper');
     expect(progressBar).to.have.attribute('aria-valuemin', '0');

--- a/packages/components/progress-bar/src/progress-bar.ts
+++ b/packages/components/progress-bar/src/progress-bar.ts
@@ -5,6 +5,7 @@ import {
 } from '@open-wc/scoped-elements/lit-element.js';
 import { announce } from '@sl-design-system/announcer';
 import { Icon } from '@sl-design-system/icon';
+import { ForwardAriaMixin } from '@sl-design-system/shared/mixins/forward-aria.js';
 import {
   type CSSResultGroup,
   LitElement,
@@ -13,7 +14,7 @@ import {
   html,
   nothing
 } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import styles from './progress-bar.css' with { type: 'css' };
@@ -39,7 +40,7 @@ export type ProgressColor = 'blue' | 'green' | 'orange' | 'purple' | 'red' | 'te
  * @slot default - A place for helper text like e.g. `20% of 100%`.
  */
 @localized()
-export class ProgressBar extends ScopedElementsMixin(LitElement) {
+export class ProgressBar extends ForwardAriaMixin(ScopedElementsMixin(LitElement)) {
   /** @internal */
   static override get scopedElements(): ScopedElementsMap {
     return {
@@ -65,6 +66,9 @@ export class ProgressBar extends ScopedElementsMixin(LitElement) {
   /** Progress value (from 0...100). */
   @property({ type: Number }) value = 0;
 
+  /** The element that exposes the progress bar semantics to assistive technologies. */
+  @query('.container') private container!: HTMLDivElement;
+
   private shouldAnnounce = true;
 
   /** @internal The name of the icon, depending on the variant. */
@@ -79,6 +83,12 @@ export class ProgressBar extends ScopedElementsMixin(LitElement) {
       default:
         return 'circle-check-solid';
     }
+  }
+
+  override firstUpdated(changes: PropertyValues<this>): void {
+    super.firstUpdated(changes);
+
+    this.setProxyTarget(this.container);
   }
 
   override updated(changes: PropertyValues<this>): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7941,6 +7941,7 @@ __metadata:
     "@lit/localize": "npm:^0.12.2"
     "@open-wc/scoped-elements": "npm:^3.0.10"
     "@sl-design-system/icon": "npm:^1.4.1"
+    "@sl-design-system/shared": "npm:^0.12.3"
     lit: "npm:^3.3.3"
   peerDependencies:
     "@lit/localize": ^0.12.1


### PR DESCRIPTION
## Summary

Fixes the accessible name of progress bars without a visible label

Previously, attributes such as `aria-label` were applied to the `<sl-progress-bar>` host, while the `progressbar` role was exposed by an internal element in the shadow DOM. As a result, the actual progress bar had no accessible name and Storybook reported an `aria-progressbar-name` violation.

This PR uses `ForwardAriaMixin` to forward ARIA attributes from the component host to the internal element with `role="progressbar"`

### BEFORE
<img width="1728" height="694" alt="Screenshot 2026-08-27 at 16 19 55" src="https://github.com/user-attachments/assets/b50caedf-6e26-4d9f-86ab-d84ac99b1305" />

### AFTER
<img width="1727" height="768" alt="Screenshot 2026-08-27 at 16 20 22" src="https://github.com/user-attachments/assets/821f7a8b-6da7-453e-8a82-5f1b67b5da10" />

