### PR TITLE
fix(storybook tree) fix tree story toggle controls

### DIFF
--- a/packages/components/tree/src/tree.stories-utils.spec.ts
+++ b/packages/components/tree/src/tree.stories-utils.spec.ts
@@ -1,9 +1,11 @@
-import { fixture } from '@sl-design-system/vitest-browser-lit';
 import { describe, expect, it } from 'vitest';
 import { NestedTreeDataSource } from './nested-tree-data-source.js';
 import { type TreeDataSourceNode } from './tree-data-source.js';
-import { getTopLevelSelectedNodes } from './tree.stories-utils.js';
-import meta from './tree.stories.js';
+import {
+  getTopLevelSelectedNodes,
+  toggleSelectedDescendants,
+  toggleSelectedNodes
+} from './tree.stories-utils.js';
 
 interface TestNode {
   id: number;
@@ -40,25 +42,12 @@ const createDataSource = () =>
     multiple: true
   });
 
-const renderStory = async (dataSource: NestedTreeDataSource<TestNode>) => {
-  const render = meta.render as (args: {
-    dataSource: NestedTreeDataSource<TestNode>;
-  }) => Parameters<typeof fixture>[0];
-
-  return await fixture(render({ dataSource }));
-};
-
-const getButton = (el: Element, label: string): HTMLElement =>
-  Array.from(el.querySelectorAll<HTMLElement>('sl-button')).find(
-    button => button.textContent?.trim() === label
-  )!;
-
 const getExpandableStates = (node: TreeDataSourceNode<TestNode>): boolean[] => [
   node.expanded,
   ...(node.children ?? []).flatMap(getExpandableStates)
 ];
 
-describe('tree stories', () => {
+describe('tree story utils', () => {
   it('should only return selected nodes without a selected ancestor', () => {
     const dataSource = createDataSource(),
       parent = dataSource.nodes[0],
@@ -72,32 +61,28 @@ describe('tree stories', () => {
     expect(getTopLevelSelectedNodes(dataSource.selection)).to.deep.equal([parent]);
   });
 
-  it('should toggle only the top-level selected node', async () => {
+  it('should toggle only the top-level selected node', () => {
     const dataSource = createDataSource(),
       parent = dataSource.nodes[0],
-      child = parent.children![0],
-      el = await renderStory(dataSource);
+      child = parent.children![0];
 
     dataSource.select(parent);
 
-    getButton(el, 'Toggle selected').click();
-    await new Promise(resolve => setTimeout(resolve, 50));
+    toggleSelectedNodes(dataSource);
 
     expect(parent.expanded).to.be.false;
     expect(child.expanded).to.be.true;
   });
 
-  it('should force toggle descendants to the selected node state', async () => {
+  it('should force toggle descendants to the selected node state', () => {
     const dataSource = createDataSource(),
       parent = dataSource.nodes[0],
-      child = parent.children![0],
-      el = await renderStory(dataSource);
+      child = parent.children![0];
 
     dataSource.collapse(child);
     dataSource.select(parent);
 
-    getButton(el, 'Toggle descendants').click();
-    await new Promise(resolve => setTimeout(resolve, 50));
+    toggleSelectedDescendants(dataSource);
 
     expect(getExpandableStates(parent).every(expanded => !expanded)).to.be.true;
   });

--- a/packages/components/tree/src/tree.stories-utils.ts
+++ b/packages/components/tree/src/tree.stories-utils.ts
@@ -1,4 +1,4 @@
-import { type TreeDataSourceNode } from './tree-data-source.js';
+import { type TreeDataSource, type TreeDataSourceNode } from './tree-data-source.js';
 
 export const getTopLevelSelectedNodes = <T>(
   selection: Iterable<TreeDataSourceNode<T>>
@@ -19,4 +19,14 @@ export const getTopLevelSelectedNodes = <T>(
 
     return true;
   });
+};
+
+export const toggleSelectedNodes = <T>(dataSource?: TreeDataSource<T>): void => {
+  getTopLevelSelectedNodes(dataSource?.selection ?? []).forEach(node => dataSource?.toggle(node));
+};
+
+export const toggleSelectedDescendants = <T>(dataSource?: TreeDataSource<T>): void => {
+  getTopLevelSelectedNodes(dataSource?.selection ?? []).forEach(node =>
+    dataSource?.toggleDescendants(node, !node.expanded)
+  );
 };

--- a/packages/components/tree/src/tree.stories-utils.ts
+++ b/packages/components/tree/src/tree.stories-utils.ts
@@ -1,0 +1,22 @@
+import { type TreeDataSourceNode } from './tree-data-source.js';
+
+export const getTopLevelSelectedNodes = <T>(
+  selection: Iterable<TreeDataSourceNode<T>>
+): Array<TreeDataSourceNode<T>> => {
+  const selectedNodes = Array.from(selection),
+    selectionSet = new Set(selectedNodes);
+
+  return selectedNodes.filter(node => {
+    let parent = node.parent;
+
+    while (parent) {
+      if (selectionSet.has(parent)) {
+        return false;
+      }
+
+      parent = parent.parent;
+    }
+
+    return true;
+  });
+};

--- a/packages/components/tree/src/tree.stories.spec.ts
+++ b/packages/components/tree/src/tree.stories.spec.ts
@@ -41,7 +41,9 @@ const createDataSource = () =>
   });
 
 const renderStory = async (dataSource: NestedTreeDataSource<TestNode>) => {
-  const render = meta.render as (args: { dataSource: NestedTreeDataSource<TestNode> }) => unknown;
+  const render = meta.render as (args: {
+    dataSource: NestedTreeDataSource<TestNode>;
+  }) => Parameters<typeof fixture>[0];
 
   return await fixture(render({ dataSource }));
 };

--- a/packages/components/tree/src/tree.stories.spec.ts
+++ b/packages/components/tree/src/tree.stories.spec.ts
@@ -1,0 +1,102 @@
+import { fixture } from '@sl-design-system/vitest-browser-lit';
+import { describe, expect, it } from 'vitest';
+import { NestedTreeDataSource } from './nested-tree-data-source.js';
+import { type TreeDataSourceNode } from './tree-data-source.js';
+import { getTopLevelSelectedNodes } from './tree.stories-utils.js';
+import meta from './tree.stories.js';
+
+interface TestNode {
+  id: number;
+  name: string;
+  children?: TestNode[];
+}
+
+const data: TestNode[] = [
+  {
+    id: 1,
+    name: 'Parent',
+    children: [
+      {
+        id: 2,
+        name: 'Child A',
+        children: [{ id: 3, name: 'Grandchild' }]
+      },
+      {
+        id: 4,
+        name: 'Child B',
+        children: [{ id: 5, name: 'Leaf' }]
+      }
+    ]
+  }
+];
+
+const createDataSource = () =>
+  new NestedTreeDataSource<TestNode>(data, {
+    getChildren: ({ children }) => children,
+    getId: ({ id }) => id,
+    getLabel: ({ name }) => name,
+    isExpandable: ({ children }) => !!children,
+    isExpanded: () => true,
+    multiple: true
+  });
+
+const renderStory = async (dataSource: NestedTreeDataSource<TestNode>) => {
+  const render = meta.render as (args: { dataSource: NestedTreeDataSource<TestNode> }) => unknown;
+
+  return await fixture(render({ dataSource }));
+};
+
+const getButton = (el: Element, label: string): HTMLElement =>
+  Array.from(el.querySelectorAll<HTMLElement>('sl-button')).find(
+    button => button.textContent?.trim() === label
+  )!;
+
+const getExpandableStates = (node: TreeDataSourceNode<TestNode>): boolean[] => [
+  node.expanded,
+  ...(node.children ?? []).flatMap(getExpandableStates)
+];
+
+describe('tree stories', () => {
+  it('should only return selected nodes without a selected ancestor', () => {
+    const dataSource = createDataSource(),
+      parent = dataSource.nodes[0],
+      child = parent.children![0],
+      grandchild = child.children![0];
+
+    dataSource.selection.add(parent);
+    dataSource.selection.add(child);
+    dataSource.selection.add(grandchild);
+
+    expect(getTopLevelSelectedNodes(dataSource.selection)).to.deep.equal([parent]);
+  });
+
+  it('should toggle only the top-level selected node', async () => {
+    const dataSource = createDataSource(),
+      parent = dataSource.nodes[0],
+      child = parent.children![0],
+      el = await renderStory(dataSource);
+
+    dataSource.select(parent);
+
+    getButton(el, 'Toggle selected').click();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(parent.expanded).to.be.false;
+    expect(child.expanded).to.be.true;
+  });
+
+  it('should force toggle descendants to the selected node state', async () => {
+    const dataSource = createDataSource(),
+      parent = dataSource.nodes[0],
+      child = parent.children![0],
+      el = await renderStory(dataSource);
+
+    dataSource.collapse(child);
+    dataSource.select(parent);
+
+    getButton(el, 'Toggle descendants').click();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(getExpandableStates(parent).every(expanded => !expanded)).to.be.true;
+  });
+});

--- a/packages/components/tree/src/tree.stories.ts
+++ b/packages/components/tree/src/tree.stories.ts
@@ -40,6 +40,7 @@ import { NestedTreeDataSource } from './nested-tree-data-source.js';
 import './register.js';
 import { type TreeDataSourceNode } from './tree-data-source.js';
 import { type Tree } from './tree.js';
+import { getTopLevelSelectedNodes } from './tree.stories-utils.js';
 
 type Props = Pick<Tree, 'dataSource' | 'hideGuides' | 'renderer' | 'scopedElements'> & {
   maxWidth?: string;
@@ -323,9 +324,10 @@ export default {
     styles: { table: { disable: true } }
   },
   render: ({ dataSource, hideGuides, maxWidth, renderer, scopedElements, styles }) => {
-    const onToggle = () => dataSource?.selection.forEach(node => dataSource?.toggle(node)),
+    const getSelectedNodes = () => getTopLevelSelectedNodes(dataSource?.selection ?? []),
+      onToggle = () => getSelectedNodes().forEach(node => dataSource?.toggle(node)),
       onToggleDescendants = () =>
-        dataSource?.selection.forEach(node => dataSource?.toggleDescendants(node)),
+        getSelectedNodes().forEach(node => dataSource?.toggleDescendants(node, !node.expanded)),
       onExpandAll = () => dataSource?.expandAll(),
       onCollapseAll = () => dataSource?.collapseAll();
 
@@ -341,7 +343,9 @@ export default {
       }
       <sl-button-bar style="margin-block-end: 1rem">
         <sl-button @click=${onToggle}>Toggle selected</sl-button>
-        <sl-button @click=${onToggleDescendants}>Toggle descendants</sl-button>
+        <sl-button @click=${onToggleDescendants} aria-label="Toggle descendants of selected item">
+          Toggle descendants
+        </sl-button>
         <sl-button @click=${onExpandAll}>Expand all</sl-button>
         <sl-button @click=${onCollapseAll}>Collapse all</sl-button>
       </sl-button-bar>

--- a/packages/components/tree/src/tree.stories.ts
+++ b/packages/components/tree/src/tree.stories.ts
@@ -40,7 +40,7 @@ import { NestedTreeDataSource } from './nested-tree-data-source.js';
 import './register.js';
 import { type TreeDataSourceNode } from './tree-data-source.js';
 import { type Tree } from './tree.js';
-import { getTopLevelSelectedNodes } from './tree.stories-utils.js';
+import { toggleSelectedDescendants, toggleSelectedNodes } from './tree.stories-utils.js';
 
 type Props = Pick<Tree, 'dataSource' | 'hideGuides' | 'renderer' | 'scopedElements'> & {
   maxWidth?: string;
@@ -324,10 +324,8 @@ export default {
     styles: { table: { disable: true } }
   },
   render: ({ dataSource, hideGuides, maxWidth, renderer, scopedElements, styles }) => {
-    const getSelectedNodes = () => getTopLevelSelectedNodes(dataSource?.selection ?? []),
-      onToggle = () => getSelectedNodes().forEach(node => dataSource?.toggle(node)),
-      onToggleDescendants = () =>
-        getSelectedNodes().forEach(node => dataSource?.toggleDescendants(node, !node.expanded)),
+    const onToggle = () => toggleSelectedNodes(dataSource),
+      onToggleDescendants = () => toggleSelectedDescendants(dataSource),
       onExpandAll = () => dataSource?.expandAll(),
       onCollapseAll = () => dataSource?.collapseAll();
 


### PR DESCRIPTION
## Summary

- Fix Tree Storybook controls so `Toggle descendants` applies a consistent forced expand/collapse state to the selected branch
- Ignore selected descendant nodes when an ancestor is already selected, preventing duplicate toggles in multiple-selection trees
- Add an accessible label for the `Toggle descendants` control
- Add story-level tests covering mixed expanded/collapsed branches and selected ancestor/descendant handling

### BEFORE

https://github.com/user-attachments/assets/5a1f52d2-e531-4dbe-9c5d-c9ad427ac737



### AFTER

https://github.com/user-attachments/assets/f57ddb65-6a69-49de-b4aa-55053371281a

