### PR TITLE
fix(toolbar): fix toolbar overflow after stale width measurements

### DIFF
--- a/.changeset/easy-waves-love.md
+++ b/.changeset/easy-waves-love.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/tool-bar': patch
+---
+
+Fix toolbar overflow behavior when cached item widths become stale after theme, font, or layout changes.

--- a/packages/components/tool-bar/src/overflow.spec.ts
+++ b/packages/components/tool-bar/src/overflow.spec.ts
@@ -528,61 +528,26 @@ describe('width measurement', () => {
     expect(toolbar.menuItems.length).to.equal(1);
   });
 
-  it('should remeasure when cached item widths still overflow the wrapper', async () => {
+  it('should remeasure when a slotted item changes size without a host resize', async () => {
     const toolbar = await fixture<ToolBar>(html`
-      <sl-tool-bar>
-        <sl-button>Button 1</sl-button>
-        <sl-button>Button 2</sl-button>
-        <sl-button>Button 3</sl-button>
+      <sl-tool-bar style="inline-size: 400px">
+        <sl-button>A</sl-button>
+        <sl-button>B</sl-button>
+        <sl-button>C</sl-button>
       </sl-tool-bar>
     `);
 
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await new Promise(resolve => setTimeout(resolve, 100));
     await toolbar.updateComplete;
 
-    const buttons = Array.from(toolbar.querySelectorAll('sl-button')),
-      wrapper = toolbar.wrapper!,
-      widths = [
-        [60, 60, 60],
-        [100, 100, 100]
-      ];
-    let measurementPass = -1;
+    expect(toolbar.menuItems.length).to.equal(0);
 
-    Object.defineProperty(toolbar, 'getBoundingClientRect', {
-      configurable: true,
-      value: () => ({ width: 230, height: 40 })
-    });
-    Object.defineProperty(wrapper, 'getBoundingClientRect', {
-      configurable: true,
-      value: () => ({ width: 230, height: 40 })
-    });
-    Object.defineProperty(wrapper, 'clientWidth', {
-      configurable: true,
-      get: () => 230
-    });
-    Object.defineProperty(wrapper, 'scrollWidth', {
-      configurable: true,
-      get: () => (measurementPass === 0 ? 240 : 230)
-    });
+    toolbar.querySelector('sl-button')!.style.inlineSize = '340px';
 
-    buttons.forEach((button, index) => {
-      Object.defineProperty(button, 'getBoundingClientRect', {
-        configurable: true,
-        value: () => {
-          if (index === 0) {
-            measurementPass++;
-          }
-
-          return { width: widths[Math.min(measurementPass, widths.length - 1)][index], height: 40 };
-        }
-      });
-    });
-
-    toolbar.refresh();
+    await new Promise(resolve => setTimeout(resolve, 100));
     await toolbar.updateComplete;
 
-    expect(measurementPass).to.equal(1);
-    expect(toolbar.menuItems.length).to.equal(2);
+    expect(toolbar.menuItems.length).to.be.greaterThan(0);
   });
 
   it('should not leave the measuring state set', async () => {

--- a/packages/components/tool-bar/src/overflow.spec.ts
+++ b/packages/components/tool-bar/src/overflow.spec.ts
@@ -550,6 +550,37 @@ describe('width measurement', () => {
     expect(toolbar.menuItems.length).to.be.greaterThan(0);
   });
 
+  it('should continue observing slotted item sizes after reconnecting', async () => {
+    const container = await fixture<HTMLDivElement>(html`
+        <div>
+          <sl-tool-bar style="inline-size: 400px">
+            <sl-button>A</sl-button>
+            <sl-button>B</sl-button>
+            <sl-button>C</sl-button>
+          </sl-tool-bar>
+        </div>
+      `),
+      toolbar = container.querySelector('sl-tool-bar') as ToolBar;
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await toolbar.updateComplete;
+
+    expect(toolbar.menuItems.length).to.equal(0);
+
+    toolbar.remove();
+    container.append(toolbar);
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await toolbar.updateComplete;
+
+    toolbar.querySelector('sl-button')!.style.inlineSize = '340px';
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await toolbar.updateComplete;
+
+    expect(toolbar.menuItems.length).to.be.greaterThan(0);
+  });
+
   it('should not leave the measuring state set', async () => {
     el.style.inlineSize = '150px';
     await new Promise(resolve => setTimeout(resolve, 100));

--- a/packages/components/tool-bar/src/overflow.spec.ts
+++ b/packages/components/tool-bar/src/overflow.spec.ts
@@ -528,6 +528,63 @@ describe('width measurement', () => {
     expect(toolbar.menuItems.length).to.equal(1);
   });
 
+  it('should remeasure when cached item widths still overflow the wrapper', async () => {
+    const toolbar = await fixture<ToolBar>(html`
+      <sl-tool-bar>
+        <sl-button>Button 1</sl-button>
+        <sl-button>Button 2</sl-button>
+        <sl-button>Button 3</sl-button>
+      </sl-tool-bar>
+    `);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    await toolbar.updateComplete;
+
+    const buttons = Array.from(toolbar.querySelectorAll('sl-button')),
+      wrapper = toolbar.wrapper!,
+      widths = [
+        [60, 60, 60],
+        [100, 100, 100]
+      ];
+    let measurementPass = -1;
+
+    Object.defineProperty(toolbar, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 230, height: 40 })
+    });
+    Object.defineProperty(wrapper, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 230, height: 40 })
+    });
+    Object.defineProperty(wrapper, 'clientWidth', {
+      configurable: true,
+      get: () => 230
+    });
+    Object.defineProperty(wrapper, 'scrollWidth', {
+      configurable: true,
+      get: () => (measurementPass === 0 ? 240 : 230)
+    });
+
+    buttons.forEach((button, index) => {
+      Object.defineProperty(button, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => {
+          if (index === 0) {
+            measurementPass++;
+          }
+
+          return { width: widths[Math.min(measurementPass, widths.length - 1)][index], height: 40 };
+        }
+      });
+    });
+
+    toolbar.refresh();
+    await toolbar.updateComplete;
+
+    expect(measurementPass).to.equal(1);
+    expect(toolbar.menuItems.length).to.equal(2);
+  });
+
   it('should not leave the measuring state set', async () => {
     el.style.inlineSize = '150px';
     await new Promise(resolve => setTimeout(resolve, 100));

--- a/packages/components/tool-bar/src/overflow.spec.ts
+++ b/packages/components/tool-bar/src/overflow.spec.ts
@@ -547,7 +547,7 @@ describe('width measurement', () => {
     await new Promise(resolve => setTimeout(resolve, 100));
     await toolbar.updateComplete;
 
-    expect(toolbar.menuItems.length).to.be.greaterThan(0);
+    expect(toolbar.menuItems.length).to.equal(2);
   });
 
   it('should continue observing slotted item sizes after reconnecting', async () => {
@@ -578,7 +578,7 @@ describe('width measurement', () => {
     await new Promise(resolve => setTimeout(resolve, 100));
     await toolbar.updateComplete;
 
-    expect(toolbar.menuItems.length).to.be.greaterThan(0);
+    expect(toolbar.menuItems.length).to.equal(2);
   });
 
   it('should not leave the measuring state set', async () => {

--- a/packages/components/tool-bar/src/tool-bar.stories.ts
+++ b/packages/components/tool-bar/src/tool-bar.stories.ts
@@ -330,13 +330,13 @@ export const InvertedContained: Story = {
       <sl-button fill="outline">Action 5</sl-button>
       <sl-button fill="outline">Action 6</sl-button>
     `,
-    width: '400px'
+    width: '414px'
   }
 };
 
 export const ClickEvents: Story = {
   args: {
-    width: '240px',
+    width: '250px',
     enableLogging: true,
     description:
       'This example shows a tool bar with buttons that log click events to the console to show how to handle click events on buttons and menu items.',

--- a/packages/components/tool-bar/src/tool-bar.ts
+++ b/packages/components/tool-bar/src/tool-bar.ts
@@ -218,6 +218,8 @@ export class ToolBar extends ScopedElementsMixin(ElementInternalsMixin(LitElemen
       attributes: true,
       attributeFilter: ['aria-disabled', 'disabled']
     });
+
+    this.#observeItems();
   }
 
   override disconnectedCallback(): void {

--- a/packages/components/tool-bar/src/tool-bar.ts
+++ b/packages/components/tool-bar/src/tool-bar.ts
@@ -81,8 +81,29 @@ export class ToolBar extends ScopedElementsMixin(ElementInternalsMixin(LitElemen
   /** Timeout for debouncing forceRecalculation calls. */
   #forceRecalculationTimeout?: ReturnType<typeof setTimeout>;
 
+  /** Animation frame for batching item resize recalculations. */
+  #itemResizeFrame?: ReturnType<typeof requestAnimationFrame>;
+
   /** Observe changes to the child elements. */
   #mutationObserver = new MutationObserver(() => this.refresh());
+
+  /** Observe size changes of slotted items, such as font or theme changes. */
+  #itemResizeObserver = new ResizeObserver(() => {
+    if (this.#itemResizeFrame) {
+      return;
+    }
+
+    this.#itemResizeFrame = requestAnimationFrame(() => {
+      this.#itemResizeFrame = undefined;
+
+      if (!this.wrapper || !this.isConnected) {
+        return;
+      }
+
+      this.#needsMeasurement = true;
+      this.#onResize();
+    });
+  });
 
   /**
    * Whether the toolbar is wider than its parent and needs CSS containment to measure available
@@ -201,11 +222,17 @@ export class ToolBar extends ScopedElementsMixin(ElementInternalsMixin(LitElemen
 
   override disconnectedCallback(): void {
     this.#mutationObserver.disconnect();
+    this.#itemResizeObserver.disconnect();
     this.#resizeObserver.disconnect();
 
     if (this.#forceRecalculationTimeout) {
       clearTimeout(this.#forceRecalculationTimeout);
       this.#forceRecalculationTimeout = undefined;
+    }
+
+    if (this.#itemResizeFrame) {
+      cancelAnimationFrame(this.#itemResizeFrame);
+      this.#itemResizeFrame = undefined;
     }
 
     // Reset measurements to ensure clean state on reconnect
@@ -340,6 +367,7 @@ export class ToolBar extends ScopedElementsMixin(ElementInternalsMixin(LitElemen
     }
 
     this.items = mapElementsToItems(elements);
+    this.#observeItems();
     this.#needsMeasurement = true;
     this.#fitContent = false;
     this.#lastHostWidth = 0;
@@ -574,5 +602,11 @@ export class ToolBar extends ScopedElementsMixin(ElementInternalsMixin(LitElemen
 
     // If measurements failed, we need to try again later when the items are visible
     this.#needsMeasurement = !widths;
+  }
+
+  #observeItems(): void {
+    this.#itemResizeObserver.disconnect();
+
+    this.items.forEach(item => this.#itemResizeObserver.observe(item.element));
   }
 }

--- a/packages/components/tool-bar/src/tool-bar.ts
+++ b/packages/components/tool-bar/src/tool-bar.ts
@@ -99,6 +99,9 @@ export class ToolBar extends ScopedElementsMixin(ElementInternalsMixin(LitElemen
   /** Flag indicating whether item width measurements are required before recalculating layout. */
   #needsMeasurement = true;
 
+  /** Whether the current resize pass is retrying with fresh item measurements. */
+  #remeasuringAfterOverflow = false;
+
   /** Observe changes to the size of the host element. */
   #resizeObserver = new ResizeObserver(entries => {
     if (!this.wrapper) {
@@ -439,6 +442,15 @@ export class ToolBar extends ScopedElementsMixin(ElementInternalsMixin(LitElemen
 
     applyVisibility(this.items);
     this.menuItems = hiddenItems;
+
+    if (hasWrapperOverflow(this.wrapper) && !this.#remeasuringAfterOverflow) {
+      this.#remeasuringAfterOverflow = true;
+      this.#needsMeasurement = true;
+      this.#onResize();
+      return;
+    }
+
+    this.#remeasuringAfterOverflow = false;
 
     if (this.menuItems.length > 0 && this.parentElement) {
       this.#resizeObserver.observe(this.parentElement);


### PR DESCRIPTION
## Summary

Fixes toolbar overflow behavior when cached item widths no longer match the rendered button widths after layout/theme/font changes.

The toolbar now checks the actual wrapper overflow after applying item visibility. If the wrapper still overflows, it performs one guarded recalculation with fresh item measurements. This handles cases where the initial cached widths are stale, such as Magister theme buttons becoming wider after final font metrics are applied

### BEFORE

https://github.com/user-attachments/assets/55960908-c571-42b7-b7d2-0dc70769ee5c


### AFTER

https://github.com/user-attachments/assets/df595431-8007-440a-8837-5b5ae671e0de


