### PR TITLE
chore: update component statuses to stable for first stable release

### DIFF
--- a/.changeset/wet-buckets-repair.md
+++ b/.changeset/wet-buckets-repair.md
@@ -1,0 +1,10 @@
+---
+'@sl-design-system/toggle-button': major
+'@sl-design-system/progress-bar': major
+'@sl-design-system/search-field': major
+'@sl-design-system/toggle-group': major
+'@sl-design-system/callout': major
+'@sl-design-system/tag': major
+---
+
+First stable release

--- a/.changeset/wet-buckets-repair.md
+++ b/.changeset/wet-buckets-repair.md
@@ -4,6 +4,7 @@
 '@sl-design-system/search-field': major
 '@sl-design-system/toggle-group': major
 '@sl-design-system/callout': major
+'@sl-design-system/menu': major
 '@sl-design-system/tag': major
 ---
 

--- a/packages/components/callout/package.json
+++ b/packages/components/callout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sl-design-system/callout",
   "version": "0.2.1",
-  "status": "preview",
+  "status": "stable",
   "description": "Callout component for the SL Design System",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sl-design-system/menu",
   "version": "0.4.0",
-  "status": "preview",
+  "status": "stable",
   "description": "Menu components for the SL Design System",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sl-design-system/progress-bar",
   "version": "0.2.1",
-  "status": "preview",
+  "status": "stable",
   "description": "Progress-bar component for the SL Design System",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/components/search-field/package.json
+++ b/packages/components/search-field/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sl-design-system/search-field",
   "version": "0.2.6",
-  "status": "preview",
+  "status": "stable",
   "description": "Search field component for the SL Design System",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/components/tag/package.json
+++ b/packages/components/tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sl-design-system/tag",
   "version": "0.1.14",
-  "status": "preview",
+  "status": "stable",
   "description": "Tag component for the SL Design System",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/components/toggle-button/package.json
+++ b/packages/components/toggle-button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sl-design-system/toggle-button",
   "version": "0.0.17",
-  "status": "preview",
+  "status": "stable",
   "description": "Toggle button component for the SL Design System",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/components/toggle-group/package.json
+++ b/packages/components/toggle-group/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sl-design-system/toggle-group",
   "version": "0.0.17",
-  "status": "preview",
+  "status": "stable",
   "description": "Toggle group component for the SL Design System",
   "license": "Apache-2.0",
   "publishConfig": {


### PR DESCRIPTION
This pull request marks the first stable release for six SL Design System components by updating their status from "preview" to "stable". It also documents this milestone in the changeset file.

Stable release updates:

* Updated the `status` field from "preview" to "stable" in the following component `package.json` files:
  - `@sl-design-system/callout` (`packages/components/callout/package.json`)
  - `@sl-design-system/progress-bar` (`packages/components/progress-bar/package.json`)
  - `@sl-design-system/search-field` (`packages/components/search-field/package.json`)
  - `@sl-design-system/tag` (`packages/components/tag/package.json`)
  - `@sl-design-system/toggle-button` (`packages/components/toggle-button/package.json`)
  - `@sl-design-system/toggle-group` (`packages/components/toggle-group/package.json`)

Release documentation:

* Added a changeset file `.changeset/wet-buckets-repair.md` to record the first stable release of these components.