### PR TITLE
fix(grid): prevent unintended row dragging from cell content

### DIFF
--- a/.changeset/calm-pandas-drag.md
+++ b/.changeset/calm-pandas-drag.md
@@ -1,0 +1,5 @@
+---
+'@sl-design-system/grid': patch
+---
+
+Prevent native draggable content inside grid cells from starting row drag and drop when the row has not been activated by a drag handle.

--- a/.changeset/calm-pandas-drag.md
+++ b/.changeset/calm-pandas-drag.md
@@ -2,4 +2,4 @@
 '@sl-design-system/grid': patch
 ---
 
-Prevent native draggable content inside grid cells from starting row drag and drop when the row has not been activated by a drag handle.
+Prevent native draggable content inside grid cells from starting row drag and drop unless the current pointer gesture originated from a drag handle.

--- a/packages/components/grid/src/grid.spec.ts
+++ b/packages/components/grid/src/grid.spec.ts
@@ -1,6 +1,10 @@
 import { type Button } from '@sl-design-system/button';
 import '@sl-design-system/button/register.js';
-import { ArrayListDataSource, type ListDataSourceGroupItem } from '@sl-design-system/data-source';
+import {
+  ArrayListDataSource,
+  type ListDataSourceGroupItem,
+  isListDataSourceDataItem
+} from '@sl-design-system/data-source';
 import '@sl-design-system/menu/register.js';
 import { type ToolBar } from '@sl-design-system/tool-bar';
 import '@sl-design-system/tooltip/register.js';
@@ -181,6 +185,116 @@ describe('sl-grid', () => {
       await el.updateComplete;
 
       expect(el.dataSource?.selects).to.equal('multiple');
+    });
+  });
+
+  describe('drag and drop', () => {
+    it('should ignore drag events from native draggable content when row dragging is disabled', async () => {
+      el = await fixture(html`
+        <sl-grid
+          .items=${[
+            { firstName: 'John', lastName: 'Doe' },
+            { firstName: 'Jane', lastName: 'Smith' }
+          ]}>
+          <sl-grid-column
+            header="Avatar"
+            .renderer=${({ firstName }: Person) =>
+              html`<img alt="" src="data:,${firstName}" />`}></sl-grid-column>
+          <sl-grid-column path="firstName"></sl-grid-column>
+        </sl-grid>
+      `);
+
+      await waitForGridToRenderData(el);
+
+      const dataSource = el.dataSource!,
+        reorderSpy = spy(dataSource, 'reorder'),
+        dragStartSpy = spy(),
+        firstRow = el.renderRoot.querySelector<HTMLTableRowElement>('tbody tr')!,
+        image = firstRow.querySelector<HTMLImageElement>('img')!;
+
+      el.addEventListener('sl-grid-dragstart', dragStartSpy);
+
+      image.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          dataTransfer: new DataTransfer()
+        })
+      );
+      document.body.dispatchEvent(
+        new DragEvent('dragover', {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          dataTransfer: new DataTransfer()
+        })
+      );
+      image.dispatchEvent(
+        new DragEvent('dragend', {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          dataTransfer: new DataTransfer()
+        })
+      );
+
+      expect(el.draggableRows).to.be.undefined;
+      expect(firstRow).not.to.have.attribute('draggable');
+      expect(dragStartSpy).not.to.have.been.called;
+      expect(reorderSpy).not.to.have.been.called;
+      expect(
+        dataSource.items.filter(isListDataSourceDataItem<Person>).map(item => item.data.firstName)
+      ).to.deep.equal(['John', 'Jane']);
+    });
+
+    it('should restore the first row when it is dragged outside the grid', async () => {
+      el = await fixture(html`
+        <sl-grid
+          .items=${[
+            { firstName: 'John', lastName: 'Doe' },
+            { firstName: 'Jane', lastName: 'Smith' },
+            { firstName: 'Alice', lastName: 'Johnson' }
+          ]}>
+          <sl-grid-drag-handle-column></sl-grid-drag-handle-column>
+          <sl-grid-column path="firstName"></sl-grid-column>
+        </sl-grid>
+      `);
+
+      await waitForGridToRenderData(el);
+
+      const firstRow = el.renderRoot.querySelector<HTMLTableRowElement>('tbody tr')!,
+        dragHandleCell = firstRow.querySelector<HTMLTableCellElement>('td[part*="drag-handle"]')!;
+
+      dragHandleCell.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      firstRow.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: new DataTransfer()
+        })
+      );
+      document.body.dispatchEvent(
+        new DragEvent('dragover', {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          dataTransfer: new DataTransfer()
+        })
+      );
+      firstRow.dispatchEvent(
+        new DragEvent('dragend', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: new DataTransfer()
+        })
+      );
+
+      expect(
+        el.dataSource?.items
+          .filter(isListDataSourceDataItem<Person>)
+          .map(item => item.data.firstName)
+      ).to.deep.equal(['John', 'Jane', 'Alice']);
     });
   });
 

--- a/packages/components/grid/src/grid.spec.ts
+++ b/packages/components/grid/src/grid.spec.ts
@@ -248,6 +248,90 @@ describe('sl-grid', () => {
       ).to.deep.equal(['John', 'Jane']);
     });
 
+    it('should disarm a data row when a drag handle press does not start a drag', async () => {
+      el = await fixture(html`
+        <sl-grid
+          .items=${[
+            { firstName: 'John', lastName: 'Doe' },
+            { firstName: 'Jane', lastName: 'Smith' }
+          ]}>
+          <sl-grid-drag-handle-column></sl-grid-drag-handle-column>
+          <sl-grid-column
+            header="Avatar"
+            .renderer=${({ firstName }: Person) =>
+              html`<img alt="" src="data:,${firstName}" />`}></sl-grid-column>
+        </sl-grid>
+      `);
+
+      await waitForGridToRenderData(el);
+
+      const dragStartSpy = spy(),
+        firstRow = el.renderRoot.querySelector<HTMLTableRowElement>('tbody tr')!,
+        dragHandleCell = firstRow.querySelector<HTMLTableCellElement>('td[part*="drag-handle"]')!,
+        image = firstRow.querySelector<HTMLImageElement>('img')!;
+
+      el.addEventListener('sl-grid-dragstart', dragStartSpy);
+
+      dragHandleCell.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      window.dispatchEvent(new MouseEvent('mouseup'));
+      image.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          dataTransfer: new DataTransfer()
+        })
+      );
+
+      expect(firstRow).not.to.have.attribute('draggable');
+      expect(dragStartSpy).not.to.have.been.called;
+    });
+
+    it('should only start dragging a group row from its drag handle', async () => {
+      const dataSource = new ArrayListDataSource<Person>(
+        [
+          { firstName: 'John', lastName: 'Doe', group: 'A' },
+          { firstName: 'Jane', lastName: 'Smith', group: 'B' }
+        ],
+        { groupBy: 'group' }
+      );
+
+      el = await fixture(html`
+        <sl-grid
+          .dataSource=${dataSource}
+          .groupHeaderRenderer=${() => html`<img alt="" src="data:,group" />`}>
+          <sl-grid-drag-handle-column></sl-grid-drag-handle-column>
+          <sl-grid-column path="firstName"></sl-grid-column>
+        </sl-grid>
+      `);
+
+      await waitForGridToRenderData(el);
+
+      const dragStartSpy = spy(),
+        groupRow = el.renderRoot.querySelector<HTMLTableRowElement>('tbody tr[part~="group"]')!,
+        groupHeader = groupRow.querySelector<GridGroupHeader>('sl-grid-group-header')!,
+        dragHandle = groupHeader.renderRoot.querySelector<HTMLElement>('[part="drag-handle"]')!,
+        image = groupRow.querySelector<HTMLImageElement>('img')!;
+
+      el.addEventListener('sl-grid-dragstart', dragStartSpy);
+
+      dragHandle.dispatchEvent(
+        new MouseEvent('mousedown', { bubbles: true, cancelable: true, composed: true })
+      );
+      window.dispatchEvent(new MouseEvent('mouseup'));
+      image.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          dataTransfer: new DataTransfer()
+        })
+      );
+
+      expect(groupRow).to.have.attribute('draggable', 'true');
+      expect(dragStartSpy).not.to.have.been.called;
+    });
+
     it('should restore the first row when it is dragged outside the grid', async () => {
       el = await fixture(html`
         <sl-grid
@@ -550,15 +634,22 @@ describe('sl-grid', () => {
         ),
         sourceGroupRow = groupRows[0],
         targetGroupRow = groupRows[1],
+        sourceGroupHeader = sourceGroupRow.querySelector<GridGroupHeader>('sl-grid-group-header')!,
+        dragHandle =
+          sourceGroupHeader.renderRoot.querySelector<HTMLElement>('[part="drag-handle"]')!,
         dragStartEvent = new DragEvent('dragstart', {
           bubbles: true,
           cancelable: true,
+          composed: true,
           dataTransfer: new DataTransfer()
         });
 
       expect(sourceGroupRow).to.have.attribute('draggable');
 
-      sourceGroupRow.dispatchEvent(dragStartEvent);
+      dragHandle.dispatchEvent(
+        new MouseEvent('mousedown', { bubbles: true, cancelable: true, composed: true })
+      );
+      dragHandle.dispatchEvent(dragStartEvent);
       targetGroupRow.dispatchEvent(
         new DragEvent('dragover', {
           bubbles: true,

--- a/packages/components/grid/src/grid.spec.ts
+++ b/packages/components/grid/src/grid.spec.ts
@@ -332,7 +332,7 @@ describe('sl-grid', () => {
       expect(dragStartSpy).not.to.have.been.called;
     });
 
-    it('should restore the first row when it is dragged outside the grid', async () => {
+    it('should restore the dragged row to its original position when it is dragged outside the grid', async () => {
       el = await fixture(html`
         <sl-grid
           .items=${[
@@ -347,11 +347,11 @@ describe('sl-grid', () => {
 
       await waitForGridToRenderData(el);
 
-      const firstRow = el.renderRoot.querySelector<HTMLTableRowElement>('tbody tr')!,
-        dragHandleCell = firstRow.querySelector<HTMLTableCellElement>('td[part*="drag-handle"]')!;
+      const draggedRow = el.renderRoot.querySelector<HTMLTableRowElement>('tbody tr')!,
+        dragHandleCell = draggedRow.querySelector<HTMLTableCellElement>('td[part*="drag-handle"]')!;
 
       dragHandleCell.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
-      firstRow.dispatchEvent(
+      draggedRow.dispatchEvent(
         new DragEvent('dragstart', {
           bubbles: true,
           cancelable: true,
@@ -366,7 +366,7 @@ describe('sl-grid', () => {
           dataTransfer: new DataTransfer()
         })
       );
-      firstRow.dispatchEvent(
+      draggedRow.dispatchEvent(
         new DragEvent('dragend', {
           bubbles: true,
           cancelable: true,

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -160,6 +160,9 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
   /** The clone of the row; used for the drag image. */
   #dragClone?: HTMLTableRowElement;
 
+  /** The row whose drag handle started the current pointer gesture. */
+  #dragArmedRow?: HTMLTableRowElement;
+
   /** The item being dragged. */
   #dragItem?: ListDataSourceItem<T>;
 
@@ -392,6 +395,8 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
     this.#bulkActionsObserver.disconnect();
     this.#mutationObserver?.disconnect();
     this.#resizeObserver?.disconnect();
+    this.#clearDragArm();
+    window.removeEventListener('dragover', this.#onWindowDragOver);
 
     if (this.#filterDebounceTimer) {
       clearTimeout(this.#filterDebounceTimer);
@@ -631,6 +636,8 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
     return html`
       <tr
         @click=${() => this.#onClickRow(item, index + 1)}
+        @mousedown=${this.#onDragHandleStart}
+        @touchstart=${this.#onDragHandleStart}
         @dragstart=${(event: DragEvent) => this.#onDragStart(event, item)}
         @dragenter=${(event: DragEvent) => this.#onDragEnter(event, item)}
         @dragover=${(event: DragEvent) => this.#onDragOver(event, item)}
@@ -662,6 +669,8 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
 
     return html`
       <tr
+        @mousedown=${this.#onDragHandleStart}
+        @touchstart=${this.#onDragHandleStart}
         @dragover=${(event: DragEvent) => this.#onGroupDragOver(event, item)}
         @dragstart=${(event: DragEvent) => this.#onDragStart(event, item)}
         @dragend=${(event: DragEvent) => this.#onDragEnd(event, item)}
@@ -849,14 +858,57 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
     this.requestUpdate();
   };
 
+  #onDragHandleStart = (event: MouseEvent | TouchEvent): void => {
+    const row = event.currentTarget as HTMLTableRowElement,
+      handle = event
+        .composedPath()
+        .find(
+          (element): element is HTMLElement =>
+            element instanceof HTMLElement && element.part.contains('drag-handle')
+        );
+
+    if (!row.draggable || !handle || handle.part.contains('fixed')) {
+      return;
+    }
+
+    this.#clearDragArm();
+    this.#dragArmedRow = row;
+    window.addEventListener('mouseup', this.#onDragHandleRelease, { once: true });
+    window.addEventListener('touchend', this.#onDragHandleRelease, { once: true });
+    window.addEventListener('touchcancel', this.#onDragHandleRelease, { once: true });
+    window.addEventListener('blur', this.#onDragHandleRelease, { once: true });
+  };
+
+  #onDragHandleRelease = (): void => {
+    const row = this.#dragArmedRow;
+
+    this.#clearDragArm();
+
+    // Group rows contain their own native draggable handle. Data rows need the draggable
+    // attribute removed when a handle press ends without starting a drag.
+    if (row && !row.part.contains('group')) {
+      row.removeAttribute('draggable');
+    }
+  };
+
+  #clearDragArm(): void {
+    this.#dragArmedRow = undefined;
+    window.removeEventListener('mouseup', this.#onDragHandleRelease);
+    window.removeEventListener('touchend', this.#onDragHandleRelease);
+    window.removeEventListener('touchcancel', this.#onDragHandleRelease);
+    window.removeEventListener('blur', this.#onDragHandleRelease);
+  }
+
   #onDragStart(event: DragEvent, item: ListDataSourceItem<T>): void {
     const row = event.currentTarget as HTMLTableRowElement;
 
     // Native draggable elements inside a cell, such as images, also emit drag events. Only start
-    // dragging a grid row after the drag handle has explicitly made the row draggable.
-    if (!row.draggable) {
+    // dragging a grid row when its handle armed this specific pointer gesture.
+    if (this.#dragArmedRow !== row) {
       return;
     }
+
+    this.#clearDragArm();
 
     event.stopPropagation();
 

--- a/packages/components/grid/src/grid.ts
+++ b/packages/components/grid/src/grid.ts
@@ -208,7 +208,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
     const grid = event.composedPath().find(el => el instanceof Grid);
 
     if (!grid || grid !== this) {
-      this.dataSource?.reorder(this.#dragItem!, this.#itemBeforeDragItem!, 'after');
+      this.#restoreDraggedItemPosition();
       this.requestUpdate();
     }
   };
@@ -850,12 +850,19 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
   };
 
   #onDragStart(event: DragEvent, item: ListDataSourceItem<T>): void {
+    const row = event.currentTarget as HTMLTableRowElement;
+
+    // Native draggable elements inside a cell, such as images, also emit drag events. Only start
+    // dragging a grid row after the drag handle has explicitly made the row draggable.
+    if (!row.draggable) {
+      return;
+    }
+
     event.stopPropagation();
 
     window.addEventListener('dragover', this.#onWindowDragOver);
 
-    const row = event.currentTarget as HTMLTableRowElement,
-      rowRect = row.getBoundingClientRect();
+    const rowRect = row.getBoundingClientRect();
 
     if (isSafari) {
       // Safari doesn't position drag images from transformed elements properly so we need to
@@ -882,9 +889,10 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
     );
 
     this.#dragItem = item;
-    const dragItemIndex = this.dataSource?.items.indexOf(item) ?? -1;
-    this.#itemBeforeDragItem = this.dataSource?.items.at(dragItemIndex - 1);
-    this.#itemAfterDragItem = this.dataSource?.items.at(dragItemIndex + 1);
+    const items = this.dataSource?.items ?? [],
+      dragItemIndex = items.indexOf(item);
+    this.#itemBeforeDragItem = items[dragItemIndex - 1];
+    this.#itemAfterDragItem = items[dragItemIndex + 1];
 
     // Update styles in the next frame, after the drag image has been created
     requestAnimationFrame(() => {
@@ -905,6 +913,10 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
   }
 
   #onDragOver(event: DragEvent, item: ListDataSourceDataItem<T>): void {
+    if (!this.#dragItem) {
+      return;
+    }
+
     event.preventDefault();
 
     const { draggableRows, dropFilter } = this;
@@ -932,7 +944,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
 
         // If the cursor is in the top half of the row, make this row the drop target
         this.dataSource?.reorder(
-          this.#dragItem!,
+          this.#dragItem,
           item,
           event.clientY < top + height / 2 ? 'before' : 'after'
         );
@@ -951,6 +963,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
 
   #onGroupDragOver(event: DragEvent, item: ListDataSourceGroupItem<T>): void {
     if (
+      !this.#dragItem ||
       !(
         this.draggableRows === 'between' ||
         (this.draggableRows === 'between-or-on-top' && this.dropTargetMode === 'between')
@@ -977,6 +990,10 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
   }
 
   #onDragEnd(event: DragEvent, item: ListDataSourceItem<T>): void {
+    if (!this.#dragItem) {
+      return;
+    }
+
     window.removeEventListener('dragover', this.#onWindowDragOver);
 
     event
@@ -1002,15 +1019,19 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
   }
 
   #onDrop(event: DragEvent, item: ListDataSourceDataItem<T>): void {
+    if (!this.#dragItem) {
+      return;
+    }
+
     if (this.draggableRows === 'on-grid') {
-      this.dropEvent.emit({ grid: this, item: this.#dragItem!, position: 'on-grid' });
+      this.dropEvent.emit({ grid: this, item: this.#dragItem, position: 'on-grid' });
     } else if (
       this.draggableRows === 'on-top' ||
       (this.draggableRows === 'between-or-on-top' && this.dropTargetMode === 'on-top')
     ) {
       this.dropEvent.emit({
         grid: this,
-        item: this.#dragItem!,
+        item: this.#dragItem,
         relativeItem: item.data,
         position: 'on-top'
       });
@@ -1026,7 +1047,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
 
       const proceeded = this.dropEvent.emit({
         grid: this,
-        item: this.#dragItem!,
+        item: this.#dragItem,
         relativeItem: item.data,
         position
       });
@@ -1043,6 +1064,7 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
 
   #onGroupDrop(event: DragEvent, item: ListDataSourceGroupItem<T>): void {
     if (
+      !this.#dragItem ||
       !(
         this.draggableRows === 'between' ||
         (this.draggableRows === 'between-or-on-top' && this.dropTargetMode === 'between')
@@ -1071,12 +1093,12 @@ export class Grid<T = any> extends ScopedElementsMixin(LitElement) {
     if (
       this.dropEvent.emit({
         grid: this,
-        item: this.#dragItem!,
+        item: this.#dragItem,
         relativeItem: relativeItem.data,
         position
       })
     ) {
-      this.dataSource?.reorder(this.#dragItem!, relativeItem, position);
+      this.dataSource?.reorder(this.#dragItem, relativeItem, position);
     }
     this.requestUpdate();
   }


### PR DESCRIPTION
## Summary

Prevents native draggable elements inside grid cells, such as avatar images, from unintentionally starting row drag and drop

Row dragging now starts only when the current mouse or touch gesture originates from a drag handle. The per-gesture state is cleared on release, cancellation, window blur, or when the actual drag begins

This also prevents native draggable content from bypassing the guard after an unused drag-handle press and inside permanently draggable group rows

The fix additionally corrects restoring the first row when it is dragged outside the grid. Previously, `.at(-1)` incorrectly treated the last item as the first row’s previous sibling, causing the first row to move to the end


### BEFORE

https://github.com/user-attachments/assets/64df69d0-e76a-420b-8362-013b51359bf2


### AFTER

https://github.com/user-attachments/assets/fa05bf05-6474-4914-8a60-faeca31375f9

