### PR TITLE
fix(website): prevent deployment without JavaScript bundles

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,3 +1,30 @@
+## Verify the production website before release
+
+Use a fresh checkout with dependencies installed (`yarn install --immutable`) and the same
+environment variables as the Website workflow. From the repository root, run:
+
+```sh
+NODE_ENV=production WIREIT_CACHE=none yarn website
+node website/scripts/check-build.js
+```
+
+The website build waits for JavaScript generation before Eleventy copies it into `dist/js`.
+It also runs the artifact check automatically, so both preview and production deployment
+stop if a local script referenced by the generated HTML, or one of its imports, is missing.
+The explicit check command above validates existing output without rebuilding it.
+
+Serve the generated files without starting a development build:
+
+```sh
+python3 -m http.server 8080 --directory website/dist
+```
+
+Open the home page and a component page, exercise navigation and search, and check the browser
+console and Network panel with cache disabled. Verify that both `/js/components/main.js` and
+`/js/scripts/main.js`, and their chunks, return JavaScript successfully. Repeat this smoke test
+on the PR preview and the production URL after deployment. Artifact validation catches missing
+files; the deployed smoke test also checks hosting paths, caching and browser runtime behavior.
+
 # How to add component documentation
 
 ## Create a new branch
@@ -463,4 +490,3 @@ eleventyNavigation:
   order: 28
   status: planned
 ```
-

--- a/website/esbuild.config.js
+++ b/website/esbuild.config.js
@@ -4,7 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve as resolvePath } from 'node:path';
 import tinyGlob from 'tiny-glob';
 
-const DEV = process.env.NODE_ENV !== 'PROD';
+const DEV = process.env.NODE_ENV !== 'production';
 const jsFolder = 'build';
 
 /**

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "build": "wireit",
     "lint": "wireit",
-    "start": "wireit"
+    "start": "wireit",
+    "check-build": "wireit"
   },
   "wireit": {
     "analyze": {
@@ -34,7 +35,8 @@
       "dependencies": [
         "build:eleventy",
         "build:styles",
-        "build:ts"
+        "build:ts",
+        "check-build"
       ]
     },
     "build:eleventy": {
@@ -48,7 +50,8 @@
       "dependencies": [
         "analyze",
         "copy-tokens",
-        "..:build:themes:styles"
+        "..:build:themes:styles",
+        "build:ts"
       ],
       "files": [
         ".eleventy.cjs",
@@ -76,14 +79,18 @@
         "..:build:components"
       ],
       "files": [
-        "esbuild.config.mjs",
+        "esbuild.config.js",
         "tsconfig.json",
         "src/ts/**/*.ts"
       ],
       "output": [
-        "build/**/*.js",
-        "build/**/*.js.map"
-      ]
+        "build/**/*"
+      ],
+      "env": {
+        "NODE_ENV": {
+          "external": true
+        }
+      }
     },
     "build:type-check": {
       "command": "tsc --build tsconfig.json --pretty",
@@ -165,6 +172,12 @@
           "script": "build:type-check",
           "cascade": false
         }
+      ]
+    },
+    "check-build": {
+      "command": "node scripts/check-build.js",
+      "dependencies": [
+        "build:eleventy"
       ]
     }
   },

--- a/website/scripts/check-build.js
+++ b/website/scripts/check-build.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { globSync, readFileSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const root = fileURLToPath(new URL('../dist/', import.meta.url));
+const pages = globSync('**/*.html', { cwd: root });
+assert.ok(pages.includes('index.html'), 'Website build is missing index.html');
+
+// Validate the files we actually deploy, including shared chunks imported by the bundles.
+const scripts = new Set([
+  resolve(root, 'js/components/main.js'),
+  resolve(root, 'js/scripts/main.js')
+]);
+for (const page of pages) {
+  const html = readFileSync(resolve(root, page), 'utf8');
+  for (const match of html.matchAll(/<script\b[^>]*\bsrc\s*=\s*["']([^"']+)["']/gi)) {
+    const src = match[1];
+    if (/^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(src)) continue;
+    const pathname = decodeURIComponent(src.split(/[?#]/)[0]);
+    scripts.add(
+      resolve(
+        pathname.startsWith('/') ? root : dirname(resolve(root, page)),
+        pathname.replace(/^\//, '')
+      )
+    );
+  }
+}
+for (const script of scripts) {
+  assert.ok(statSync(script).size > 0, `Missing or empty website script: ${script}`);
+}
+await build({
+  entryPoints: [...scripts],
+  bundle: true,
+  write: false,
+  outdir: resolve(root, '__validation__'),
+  platform: 'browser',
+  format: 'esm',
+  logLevel: 'silent'
+});
+console.log(
+  `Website build verified: ${pages.length} HTML pages, ${scripts.size} script entry points and their imports.`
+);


### PR DESCRIPTION
## Summary

Fix the website build pipeline to prevent incomplete deployments where generated HTML references JavaScript bundles that are missing from the published artifact

## Root cause

The Eleventy and JavaScript builds were executed in parallel. Eleventy copies the generated `website/build` directory into `website/dist/js`, but it did not explicitly depend on the JavaScript build.

On a clean CI runner, Eleventy could finish before esbuild generated the bundles. The workflow still succeeded and deployed valid HTML, but without files such as:

- `/js/components/main.js`
- `/js/scripts/main.js`
- shared JavaScript chunks

Local development usually did not reproduce the issue because previously generated files remained in `website/build`, and the development watcher could rebuild the site after JavaScript generation completed

The issue was exposed by a change in build timing during the release workflow